### PR TITLE
added the else statement if there is no sitelogo for the pre-header

### DIFF
--- a/src/components/header/css/component.scss
+++ b/src/components/header/css/component.scss
@@ -108,6 +108,20 @@
                 display: inline-block;
                 @include QLD-fontgrid(sm);
             }
+
+            &--mobile {
+                display: inline-block;
+                @include QLD-space(height, 1.75unit);
+                color: var(--QLD-color-light-link);
+
+                @include QLD-media(md) {
+                    @include QLD-space(height, 2.5unit);
+                }
+
+                @include QLD-media(lg) {
+                    display: none;
+                }
+            }
         }
 
         .qld__header__cta-wrapper{
@@ -237,6 +251,10 @@
                 color: var(--QLD-color-dark-link);
             }
 
+            .qld__header__pre-header-url--mobile {
+                color: var(--QLD-color-dark-link);
+            }
+
             a{
                 @include QLD-underline('dark','noUnderline','default','noVisited');
             }
@@ -280,6 +298,10 @@
             color: var(--QLD-color-dark-text);
 
             .qld__header__pre-header-url {
+                color: var(--QLD-color-dark-link);
+            }
+
+            .qld__header__pre-header-url--mobile {
                 color: var(--QLD-color-dark-link);
             }
 

--- a/src/components/header/html/component.hbs
+++ b/src/components/header/html/component.hbs
@@ -13,7 +13,10 @@
                     alt="Queensland Government"
                     src="./?a={{site.metadata.sitePreHeaderLogo.value}}"
                 />
+                {{else}}
+                     <span class="qld__header__pre-header-url--mobile">{{site.metadata.sitePreHeaderText.value}}</span>
                 {{/if}}
+                
             </a>
 
             <div class="qld__header__cta-wrapper">


### PR DESCRIPTION
Added improvement to the header component preheader. The improvement if there is no preheader logo set the pre logo text will display.

Ticket: https://squizgroup.atlassian.net/browse/QHWT-953
Repo Branch:  https://github.com/Qld-Health-Online-Team/design-system/tree/improvement/QHWT-953