### PR TITLE
Fix date field width

### DIFF
--- a/src/components/_global/css/forms/select/component.scss
+++ b/src/components/_global/css/forms/select/component.scss
@@ -303,6 +303,7 @@ select{
 	select{
 		@include QLD-space(margin-left, .25unit );
 		@include QLD-space(margin-right, .75unit );
+		width: 50%;
 	}
 }
 


### PR DESCRIPTION
This pull request includes a small change to the `src/components/_global/css/forms/select/component.scss` file. The change sets the width of the `select` element to 50%.

* [`src/components/_global/css/forms/select/component.scss`](diffhunk://#diff-fe25765d4ff9232e8cf13c87080720478fa244d6314444a21c2d6b556af6f9b6R306): Added `width: 50%` to the `select` element.