### PR TITLE
Add Letter heading

### DIFF
--- a/src/components/a-z_listing/css/component.scss
+++ b/src/components/a-z_listing/css/component.scss
@@ -74,6 +74,7 @@
             @include QLD-space(margin, 24px 0 24px);
             text-transform: uppercase;
             // line-height: 1.5;
+            display: block;
 
             @include QLD-media(md) {
                 @include QLD-space(margin, 48px 0 24px);

--- a/src/components/a-z_listing/html/component.hbs
+++ b/src/components/a-z_listing/html/component.hbs
@@ -6,7 +6,7 @@
                     {{#listAZOptions children}}{{/listAZOptions}}
                 </ul>
                 <ul class="qld__a-z_listing__list">
-                    {{#listAZ children}}{{/listAZ}}
+                    {{#listAZ children data.metadata.letter_heading.value}}{{/listAZ}}
                 </ul>
             </div>
         </div>

--- a/src/components/a-z_listing/js/manifest.json
+++ b/src/components/a-z_listing/js/manifest.json
@@ -13,7 +13,20 @@
 					"value": "",
 					"required": false,
 					"editable": true
-				}
+				},
+				"letter_heading": {
+                    "type": "metadata_field_select",
+                    "description": "",
+                    "friendly_name": "Letter heading",
+                    "value": "span",
+                    "options": {
+                        "h2": "h2",
+                        "h3": "h3",
+                        "h4": "h4",
+						"h5": "h5",
+                        "span": "span"
+                    }
+                }
 			}
 		},
 		"children": [{

--- a/src/helpers/Handlebars/listAZ.js
+++ b/src/helpers/Handlebars/listAZ.js
@@ -1,4 +1,4 @@
-module.exports = function(items, url, options) {
+module.exports = function(items, letterHeading, url, options) {
     var html = '<li class="qld__a-z_listing__options__item">';
     var services = [];
     var letters = [];
@@ -49,7 +49,8 @@ module.exports = function(items, url, options) {
 
             return 0;
         })
-        html += '<h3 class="qld__a-z_listing__list__item__header"><span id="'+letters[i]+'">'+letters[i]+'</span></h3>';
+
+        html += '<'+letterHeading+' class="qld__a-z_listing__list__item__header"><span id="'+letters[i]+'">'+letters[i]+'</span></'+letterHeading+'>';
         html += '<ul class="qld__a-z_listing__list__item__services">';
         for(var k = 0; k < services[letters[i]].length; k++) {
             html += '<li class="qld__a-z_listing__list__item__services__item"><a class="qld__a-z_listing__list__item__services__item__link" href="./?a='+services[letters[i]][k].id+'"><span>'+services[letters[i]][k].name+'</span></a></li>';


### PR DESCRIPTION
Add Letter heading - QHWT-1106
This pull request introduces several enhancements to the A-Z listing component, including adding a new metadata field, updating the Handlebars helper, and making minor CSS adjustments. The most important changes are detailed below.

### Enhancements to A-Z Listing Component:

* **Addition of Metadata Field:**
  - [`src/components/a-z_listing/js/manifest.json`](diffhunk://#diff-d2712a841b2729da56280a3fd1df12d155b426d0577c644440644eafb67b872cR16-R28): Added a new `letter_heading` metadata field with options for different heading levels (`h2`, `h3`, `h4`, `h5`, `span`).

* **Updates to Handlebars Helper:**
  - [`src/helpers/Handlebars/listAZ.js`](diffhunk://#diff-b32c20a89216afef5d0c1180cf1d7911801e690b16d9af3946aae889782cdf8aL1-R1): Modified the `listAZ` helper function to accept a `letterHeading` parameter and use it for rendering the heading tags dynamically. [[1]](diffhunk://#diff-b32c20a89216afef5d0c1180cf1d7911801e690b16d9af3946aae889782cdf8aL1-R1) [[2]](diffhunk://#diff-b32c20a89216afef5d0c1180cf1d7911801e690b16d9af3946aae889782cdf8aL52-R53)

* **Template Adjustments:**
  - [`src/components/a-z_listing/html/component.hbs`](diffhunk://#diff-e8ee9b708ed11b52aa9b5f756ad76a35c3af23d997d5865270a5c688b5dfc96fL9-R9): Updated the template to pass the new `letter_heading` metadata value to the `listAZ` helper.

* **CSS Modifications:**
  - [`src/components/a-z_listing/css/component.scss`](diffhunk://#diff-5a67db30510bd9ee01bcd24b60be3ffc575ba5e2a1908df5c1e49e9642a43944R77): Added a `display: block;` rule to ensure proper layout of the A-Z listing items.