### PR TITLE
Rework Accordion structure

### DIFF
--- a/src/components/accordion/css/component.scss
+++ b/src/components/accordion/css/component.scss
@@ -299,23 +299,23 @@ li + li .qld__accordion {
 	border-top: none;
 }
 
-.main {
-    * {
-        + .qld__accordion,
-        + .qld__accordion-group {
-            @include QLD-space(margin-top, 1.5unit);
-			@include QLD-space(margin-bottom, 1.5unit);
+// .main {
+//     * {
+//         + .qld__accordion,
+//         + .qld__accordion-group {
+//             @include QLD-space(margin-top, 1.5unit);
+// 			@include QLD-space(margin-bottom, 1.5unit);
 
-			@include QLD-media(lg) {
-				@include QLD-space(margin-top, 2unit);
-			}
+// 			@include QLD-media(lg) {
+// 				@include QLD-space(margin-top, 2unit);
+// 			}
 			
-			&:last-child{
-				@include QLD-space(margin-bottom, 0unit);
-			}
-        }
-    }
-}
+// 			&:last-child{
+// 				@include QLD-space(margin-bottom, 0unit);
+// 			}
+//         }
+//     }
+// }
 
 
 @media print {

--- a/src/components/accordion/html/component.hbs
+++ b/src/components/accordion/html/component.hbs
@@ -15,25 +15,25 @@
             <button class="qld__accordion__toggle-btn qld__accordion__toggle-btn--closed" type="button">Open all</button>
         </div>
         {{/ifCond}}
-        <ul class="qld__accordion-list">
+        
             {{#printAccordion metadata}}
                 {{#ifCond this.content '!=' ''}}
-                <li>
-                    <section class="qld__accordion">
-                        <button class="qld__accordion__title js-qld__accordion qld__accordion--closed" aria-controls="accordion-group-{{../assetid}}-{{this.fieldid}}" aria-expanded="false" type="button">
-                            {{this.title}}
-                        </button>
+                    <div class="qld__accordion">
+                        <h2>
+                            <button class="qld__accordion__title js-qld__accordion qld__accordion--closed" aria-controls="accordion-group-{{../assetid}}-{{this.fieldid}}" aria-expanded="false" type="button">
+                                {{this.title}}
+                            </button>
+                        </h2>
             
                         <div class="qld__accordion__body qld__accordion--closed" id="accordion-group-{{../assetid}}-{{this.fieldid}}">
                             <div class="qld__accordion__body-wrapper">
                                 {{{this.content}}}
                             </div>
                         </div>
-                    </section>
-                </li>
+                    </div>
                 {{/ifCond}}
             {{/printAccordion}}
-        </ul>
+        
     </div>
 {{/with}}
 


### PR DESCRIPTION
Rework Accordion structure QHWT-1082

This pull request includes changes to the accordion component, focusing on updating the HTML structure and commenting out unused SCSS styles.

### HTML Structure Updates:
* [`src/components/accordion/html/component.hbs`](diffhunk://#diff-9dcbe47d05f6572c97e44505fc60eeb7ffe1e7121ac8fe47246305c3f32753f5L18-R36): Updated the accordion structure by replacing `<ul>` and `<li>` elements with `<div>` and `<h2>` elements for better semantic HTML.

### SCSS Style Updates:
* [`src/components/accordion/css/component.scss`](diffhunk://#diff-4375bae5cd43ee1e28a29a37998a6d8116c8fc4d48b8e385f1d348a988b958d2L302-R318): Commented out the `.main` class and its nested styles, which include margin adjustments for `.qld__accordion` and `.qld__accordion-group` elements.
