### PR TITLE
Rework heading

### DIFF
--- a/src/components/page_alert/css/component.scss
+++ b/src/components/page_alert/css/component.scss
@@ -33,6 +33,7 @@
 	& &--heading.qld__display-lg {
 		color: var(--QLD-color-light__heading);
 		@include QLD-space(margin-bottom, 1unit);
+		line-height: 2.25rem;
 	}
 
 	& a{

--- a/src/components/page_alert/html/component.hbs
+++ b/src/components/page_alert/html/component.hbs
@@ -15,7 +15,7 @@
                 <svg aria-hidden="true" focusable="false" xmlns="http://www.w3.org/2000/svg" class="qld__icon qld__icon--md"><use href="{{@root.site.metadata.siteDefaultIcons.value}}#qld__icon__error"></use></svg>
             {{/ifCond}} --}}
             {{#if metadata.heading.value}}
-                <div class="qld__page-alerts--heading qld__display-lg">{{metadata.heading.value}}</div>
+                <{{metadata.heading_level.value}} class="qld__page-alerts--heading qld__display-lg">{{metadata.heading.value}}</{{metadata.heading_level.value}}>
             {{/if}}
             {{#if metadata.body.value}}
                 <div>{{{metadata.body.value}}}</div>

--- a/src/components/page_alert/js/manifest.json
+++ b/src/components/page_alert/js/manifest.json
@@ -21,6 +21,21 @@
 					"required": false,
 					"editable": true
 				},
+				"heading_level": {
+					"type": "metadata_field_select",
+					"description": "",
+					"friendly_name": "Heading level",
+					"value": "h2",
+					"options": {
+						"h2": "h2",
+						"h3": "h3",
+						"h4": "h4",
+						"h5": "h5",
+						"h6": "h6"
+					},
+					"required": false,
+					"editable": true
+				},
 				"heading": {
 					"type": "metadata_field_text",
 					"description": "",


### PR DESCRIPTION
Rework heading - QHWT-1093

This pull request includes several changes to the `page_alert` component, focusing on improving the flexibility and styling of headings. The most important changes include adding a new `heading_level` metadata field, updating the HTML template to use this new field, and adjusting the CSS for better visual consistency.

### Enhancements to Heading Flexibility:

* [`src/components/page_alert/js/manifest.json`](diffhunk://#diff-317b8955316abafe4b1af03faa02c1cd43842277855e243e28746b2b311a82c9R24-R38): Added a new `heading_level` metadata field to allow selection of heading levels (`h2` to `h6`).
* [`src/components/page_alert/html/component.hbs`](diffhunk://#diff-d317abb40b0469d96af218c59357c4d68d07527196e35c9f7605276c39c0a3e7L18-R18): Updated the template to dynamically use the selected heading level from the `heading_level` metadata field.

### Styling Improvements:

* [`src/components/page_alert/css/component.scss`](diffhunk://#diff-1c6405078f7489eb7ce12d53c09df1393de66f227f488e4f7f8bfb5c37edf561R36): Added `line-height` to the heading style for better visual consistency.