### PR TITLE
Exclude Alert headings

### DIFF
--- a/src/components/in_page_navigation/js/global.js
+++ b/src/components/in_page_navigation/js/global.js
@@ -20,7 +20,7 @@
             
             var headingSelector = nav.getAttribute('data-headingType') ? nav.getAttribute('data-headingType') : 'h2';
             var pageContent = isLandingPage ? mainEl : document.getElementById('content');
-            var headings = pageContent.querySelectorAll(headingSelector + ':not(.qld__inpage-nav-links__heading):not(.banner__heading)');
+            var headings = pageContent.querySelectorAll(headingSelector + ':not(.qld__inpage-nav-links__heading):not(.banner__heading):not(.qld__page-alerts--heading)');
             var list = nav.querySelector('.qld__link-list');
             list.innerHTML = '';
 

--- a/src/components/in_page_navigation/js/global.js
+++ b/src/components/in_page_navigation/js/global.js
@@ -20,7 +20,7 @@
             
             var headingSelector = nav.getAttribute('data-headingType') ? nav.getAttribute('data-headingType') : 'h2';
             var pageContent = isLandingPage ? mainEl : document.getElementById('content');
-            var headings = pageContent.querySelectorAll(headingSelector + ':not(.qld__inpage-nav-links__heading):not(.banner__heading):not(.qld__page-alerts--heading)');
+            var headings = pageContent.querySelectorAll(headingSelector + ':not(.qld__inpage-nav-links__heading):not(.qld__code ' + headingSelector + '):not(.banner__heading)not(.qld__accordion :not(h2) ' + headingSelector + ')');
             var list = nav.querySelector('.qld__link-list');
             list.innerHTML = '';
 

--- a/src/components/in_page_navigation/js/global.js
+++ b/src/components/in_page_navigation/js/global.js
@@ -20,26 +20,12 @@
             
             var headingSelector = nav.getAttribute('data-headingType') ? nav.getAttribute('data-headingType') : 'h2';
             var pageContent = isLandingPage ? mainEl : document.getElementById('content');
-            
-            // Determine whether we should exclude .qld__accordion based on headingSelector
-            const excludeAccordion = /h[3-6]/.test(headingSelector);
-            
-            // Define the base selector to exclude .qld__code and additional classes
-            const baseSelector = `${headingSelector}:not(.qld__inpage-nav-links__heading):not(.banner__heading):not(.qld__code *)`;
-            
-            // Adjust the selector if excluding .qld__accordion headings
-            const finalSelector = excludeAccordion
-              ? `${baseSelector}:not(.qld__accordion)`
-              : baseSelector;
-            
-            // Collect unique headings using a Set to avoid duplicates
-            const headings = new Set(
-              Array.from(pageContent.querySelectorAll(finalSelector)).map(heading => heading.textContent.trim())
-            );
-            
-            // Log the unique text content of each heading in the console
-            headings.forEach(heading => console.log(heading));
-            
+            // var headings = pageContent.querySelectorAll(headingSelector + ':not(.qld__inpage-nav-links__heading):not(.qld__code *' + headingSelector + '):not(.banner__heading):not(.qld__accordion ' + headingSelector + '):not(h2)');
+            var headings = pageContent.querySelectorAll(
+                headingSelector +
+                ':not(.qld__inpage-nav-links__heading):not(.banner__heading):not(.qld__code *):not(.qld__accordion h3):not(.qld__accordion h4):not(.qld__accordion h5):not(.qld__accordion h6)'
+              );
+              
 
             var list = nav.querySelector('.qld__link-list');
             list.innerHTML = '';

--- a/src/components/in_page_navigation/js/global.js
+++ b/src/components/in_page_navigation/js/global.js
@@ -20,7 +20,7 @@
             
             var headingSelector = nav.getAttribute('data-headingType') ? nav.getAttribute('data-headingType') : 'h2';
             var pageContent = isLandingPage ? mainEl : document.getElementById('content');
-            var headings = pageContent.querySelectorAll(headingSelector + ':not(.qld__inpage-nav-links__heading):not(.qld__code ' + headingSelector + '):not(.banner__heading):not(.qld__accordion :not(h2) ' + headingSelector + ')');
+            var headings = pageContent.querySelectorAll(headingSelector + ':not(.qld__inpage-nav-links__heading):not(.qld__code ' + headingSelector + '):not(.banner__heading):not(.qld__accordion ' + headingSelector + '):not(h2)');
             var list = nav.querySelector('.qld__link-list');
             list.innerHTML = '';
 

--- a/src/components/in_page_navigation/js/global.js
+++ b/src/components/in_page_navigation/js/global.js
@@ -20,7 +20,7 @@
             
             var headingSelector = nav.getAttribute('data-headingType') ? nav.getAttribute('data-headingType') : 'h2';
             var pageContent = isLandingPage ? mainEl : document.getElementById('content');
-            // var headings = pageContent.querySelectorAll(headingSelector + ':not(.qld__inpage-nav-links__heading):not(.qld__code *' + headingSelector + '):not(.banner__heading):not(.qld__accordion ' + headingSelector + '):not(h2)');
+            // Exclude Code CT, and accordion h3, h4, h5, h6
             var headings = pageContent.querySelectorAll(
                 headingSelector +
                 ':not(.qld__inpage-nav-links__heading):not(.banner__heading):not(.qld__code *):not(.qld__accordion h3):not(.qld__accordion h4):not(.qld__accordion h5):not(.qld__accordion h6)'

--- a/src/components/in_page_navigation/js/global.js
+++ b/src/components/in_page_navigation/js/global.js
@@ -20,7 +20,7 @@
             
             var headingSelector = nav.getAttribute('data-headingType') ? nav.getAttribute('data-headingType') : 'h2';
             var pageContent = isLandingPage ? mainEl : document.getElementById('content');
-            var headings = pageContent.querySelectorAll(headingSelector + ':not(.qld__inpage-nav-links__heading):not(.qld__code ' + headingSelector + '):not(.banner__heading)not(.qld__accordion :not(h2) ' + headingSelector + ')');
+            var headings = pageContent.querySelectorAll(headingSelector + ':not(.qld__inpage-nav-links__heading):not(.qld__code ' + headingSelector + '):not(.banner__heading):not(.qld__accordion :not(h2) ' + headingSelector + ')');
             var list = nav.querySelector('.qld__link-list');
             list.innerHTML = '';
 

--- a/src/components/in_page_navigation/js/global.js
+++ b/src/components/in_page_navigation/js/global.js
@@ -20,7 +20,27 @@
             
             var headingSelector = nav.getAttribute('data-headingType') ? nav.getAttribute('data-headingType') : 'h2';
             var pageContent = isLandingPage ? mainEl : document.getElementById('content');
-            var headings = pageContent.querySelectorAll(headingSelector + ':not(.qld__inpage-nav-links__heading):not(.qld__code ' + headingSelector + '):not(.banner__heading):not(.qld__accordion ' + headingSelector + '):not(h2)');
+            
+            // Determine whether we should exclude .qld__accordion based on headingSelector
+            const excludeAccordion = /h[3-6]/.test(headingSelector);
+            
+            // Define the base selector to exclude .qld__code and additional classes
+            const baseSelector = `${headingSelector}:not(.qld__inpage-nav-links__heading):not(.banner__heading):not(.qld__code *)`;
+            
+            // Adjust the selector if excluding .qld__accordion headings
+            const finalSelector = excludeAccordion
+              ? `${baseSelector}:not(.qld__accordion)`
+              : baseSelector;
+            
+            // Collect unique headings using a Set to avoid duplicates
+            const headings = new Set(
+              Array.from(pageContent.querySelectorAll(finalSelector)).map(heading => heading.textContent.trim())
+            );
+            
+            // Log the unique text content of each heading in the console
+            headings.forEach(heading => console.log(heading));
+            
+
             var list = nav.querySelector('.qld__link-list');
             list.innerHTML = '';
 


### PR DESCRIPTION
Exclude Alert headings QHWT-1196

This pull request includes a change to the `src/components/in_page_navigation/js/global.js` file. The main update is to refine the selection of headings for in-page navigation by excluding specific elements.

Improvements to heading selection:

* [`src/components/in_page_navigation/js/global.js`](diffhunk://#diff-f02743a64fe8275e8a6bfa32e13070fde4d867e84d056ca3fa6cd4aebe679c8aL23-R29): Updated the `headings` variable to exclude Code CT and accordion elements (`h3`, `h4`, `h5`, `h6`) from the in-page navigation.