### PR TITLE
Change ul li to div for feature card

### DIFF
--- a/src/components/card_feature/html/component.hbs
+++ b/src/components/card_feature/html/component.hbs
@@ -35,8 +35,8 @@
         {{/if}}
 
         <div class="row"> 
-            <ul class="qld__card-list qld__card-list--matchheight">
-                <li class="col-xs-12 col-md-12 {{@root.component.data.metadata.col_width.value}}">
+            <div class="qld__card-list qld__card-list--matchheight">
+                <div class="col-xs-12 col-md-12 {{@root.component.data.metadata.col_width.value}}">
 
                     <div class="qld__card qld__card__multi-action {{#ifCond metadata.show_arrow.value '==' 'true'}}qld__card--arrow{{/ifCond}} {{#ifCond metadata.show_icon_image.value '==' 'icon'}}qld__card--icon{{/ifCond}} {{#ifCond metadata.show_icon_image.value '==' 'image'}}qld__card--image{{/ifCond}} {{metadata.background.value}} {{#ifCond metadata.card_image_right.value '==' 'left'}}qld__card__multi-action--feature{{/ifCond}} {{#ifCond metadata.card_image_right.value '==' 'right'}}qld__card__multi-action--feature qld__card__multi-action--image-right{{/ifCond}}" >
                         {{#ifCond metadata.show_icon_image.value '==' 'icon'}}
@@ -108,14 +108,8 @@
                         </div>
 
                     </div>
-
-
-
-
-
-
-                </li>
-            </ul>
+                </div>
+            </div>
         </div>
 
             {{#if metadata.all_link.value}}


### PR DESCRIPTION
Change ul li to div for feature card QHWT-1089

This pull request includes changes to the `src/components/card_feature/html/component.hbs` file to improve the structure and semantics of the HTML code and improve accessibility. The most important changes include replacing the `ul` and `li` elements with `div` elements to better align with the intended layout and usage.

HTML structure improvements:

* Replaced `ul` and `li` elements with `div` elements to enhance the semantic structure and layout of the card feature component. (`src/components/card_feature/html/component.hbs`) [[1]](diffhunk://#diff-14068a92e2ce0a38779b3cbbad93af25aff2038593fb976649fb7974045fafacL38-R39) [[2]](diffhunk://#diff-14068a92e2ce0a38779b3cbbad93af25aff2038593fb976649fb7974045fafacL111-R112)