### PR TITLE
Update Back to top href

### DIFF
--- a/src/components/widgets/html/component.hbs
+++ b/src/components/widgets/html/component.hbs
@@ -1,6 +1,6 @@
 {{#if site.metadata.siteBackToTopShow.value}}
 <div class="qld__widgets">
-    <a href="#" class="qld__btn qld__btn--floating
+    <a href="#content" class="qld__btn qld__btn--floating
     qld__btn--back-to-top show" aria-label="Back to top">
         <span>Back to top</span>
     </a>


### PR DESCRIPTION
Update Back to top href QHWT-1076
This pull request includes a small but important change to the `src/components/widgets/html/component.hbs` file. The change modifies the `href` attribute of the "Back to top" button to improve accessibility.

* [`src/components/widgets/html/component.hbs`](diffhunk://#diff-9c4e43a70c1b4ae9b35a3f900d9dcea5bd33e5f0951384cea90068cd84a61f36L3-R3): Changed the `href` attribute of the "Back to top" button from `"#"` to `"#content"` to ensure it directs users to the main content section, enhancing accessibility.