### PR TITLE
Add accessible name

### DIFF
--- a/src/components/banner_advanced/html/component.hbs
+++ b/src/components/banner_advanced/html/component.hbs
@@ -197,7 +197,7 @@
             {{#ifCond metadata.cta_type.value '==' 'icon-tiles'}}
                 {{#if metadata.root_node.value}}
                 <div class="qld__banner__nav {{#ifCond metadata.hero_image_alignment.value '==' 'page'}}qld__banner__nav--fix-right{{/ifCond}}">
-                    <nav {{#if cta_icon_tiles_label}}aria-label="{{cta_icon_tiles_label}}"{{/if}} class="
+                    <nav {{#if metadata.cta_icon_tiles_label.value}}aria-label="{{metadata.cta_icon_tiles_label.value}}" {{/if}} class="
                         qld__tile-nav 
                         {{#ifCond metadata.cta_icon_tile_background.value '==' 'alternate'}}qld__tile-nav--alt{{/ifCond}} 
                         {{#ifCond metadata.cta_icon_tile_background.value '==' 'dark'}}qld__tile-nav--dark{{/ifCond}} 

--- a/src/components/banner_advanced/html/component.hbs
+++ b/src/components/banner_advanced/html/component.hbs
@@ -197,7 +197,7 @@
             {{#ifCond metadata.cta_type.value '==' 'icon-tiles'}}
                 {{#if metadata.root_node.value}}
                 <div class="qld__banner__nav {{#ifCond metadata.hero_image_alignment.value '==' 'page'}}qld__banner__nav--fix-right{{/ifCond}}">
-                    <nav aria-label="Contact details" class="
+                    <nav {{#if cta_icon_tiles_label}}aria-label="{{cta_icon_tiles_label}}"{{/if}} class="
                         qld__tile-nav 
                         {{#ifCond metadata.cta_icon_tile_background.value '==' 'alternate'}}qld__tile-nav--alt{{/ifCond}} 
                         {{#ifCond metadata.cta_icon_tile_background.value '==' 'dark'}}qld__tile-nav--dark{{/ifCond}} 

--- a/src/components/banner_advanced/html/component.hbs
+++ b/src/components/banner_advanced/html/component.hbs
@@ -197,7 +197,7 @@
             {{#ifCond metadata.cta_type.value '==' 'icon-tiles'}}
                 {{#if metadata.root_node.value}}
                 <div class="qld__banner__nav {{#ifCond metadata.hero_image_alignment.value '==' 'page'}}qld__banner__nav--fix-right{{/ifCond}}">
-                    <nav class="
+                    <nav aria-label="Contact details" class="
                         qld__tile-nav 
                         {{#ifCond metadata.cta_icon_tile_background.value '==' 'alternate'}}qld__tile-nav--alt{{/ifCond}} 
                         {{#ifCond metadata.cta_icon_tile_background.value '==' 'dark'}}qld__tile-nav--dark{{/ifCond}} 

--- a/src/components/banner_advanced/js/manifest.json
+++ b/src/components/banner_advanced/js/manifest.json
@@ -364,6 +364,23 @@
                         }]
                     }
 				},
+                "cta_icon_tiles_label": {
+					"type": "metadata_field_text",
+					"description": "",
+					"friendly_name": "Icon Tiles Label",
+					"value": "Contact details",
+					"required": false,
+					"editable": true,
+                    "display_if": {
+                        "show": true,
+                        "operator": "AND",
+                        "rules": [{
+                            "field": "cta_type",
+                            "operator": "equals",
+                            "value": "icon-tiles"
+                        }]
+                    }
+				},
 				"root_node": {
 					"type": "metadata_field_related_asset",
 					"description": "",


### PR DESCRIPTION
Add accessible name - QHWT-1080

This pull request includes changes to the `banner_advanced` component to enhance accessibility by adding an ARIA label and a new metadata field. The most important changes include adding the ARIA label for icon tiles and updating the manifest to include the new metadata field.

Enhancements to accessibility:

* [`src/components/banner_advanced/html/component.hbs`](diffhunk://#diff-227eac69d05393fd7f193a70f44ec0918c3e063e3dc7227264d0965b59202e49L200-R200): Added an ARIA label to the `nav` element when `cta_icon_tiles_label` metadata is present.

Updates to metadata:

* [`src/components/banner_advanced/js/manifest.json`](diffhunk://#diff-a9887da3c6b2d89e32c4b615c1b33440b5ca8632152829fc7e1a735a6ed333bcR365-R381): Added a new metadata field `cta_icon_tiles_label` with properties such as type, description, friendly name, value, required status, and display conditions.
