### PR TITLE
Fix/header nav qhwt 1090

### DIFF
--- a/src/components/main_navigation/html/component.hbs
+++ b/src/components/main_navigation/html/component.hbs
@@ -19,7 +19,7 @@
                         {{#if site.metadata.mainNavHomeIconShow.value}}
                         <li class="{{#if current.home}}active{{/if}} qld__main-nav__item">
                             <div class="qld__main-nav__item-title">
-                                <a class="qld__main-nav__item-link" {{#if current.home}}aria-current="page"{{/if}} href="./?a={{site.data.assetid}}">
+                                <a class="qld__main-nav__item-link" {{#if current.home}}aria-current="page" aria-label="Home"{{/if}} href="./?a={{site.data.assetid}}">
                                     <svg aria-hidden="true" focusable="false" xmlns="http://www.w3.org/2000/svg" class="qld__icon qld__icon--md "><use href="{{@root.site.metadata.siteDefaultIcons.value}}#qld__icon__home"></use></svg>
                                     <span class="qld__main-nav__item-text" data-name="{{{asset_short_name}}}">Home</span>
                                 </a>

--- a/src/components/main_navigation/html/component.hbs
+++ b/src/components/main_navigation/html/component.hbs
@@ -19,7 +19,7 @@
                         {{#if site.metadata.mainNavHomeIconShow.value}}
                         <li class="{{#if current.home}}active{{/if}} qld__main-nav__item">
                             <div class="qld__main-nav__item-title">
-                                <a class="qld__main-nav__item-link" {{#if current.home}}aria-current="page" aria-label="Home"{{/if}} href="./?a={{site.data.assetid}}">
+                                <a class="qld__main-nav__item-link" aria-label="Home" {{#if current.home}}aria-current="page" {{/if}} href="./?a={{site.data.assetid}}">
                                     <svg aria-hidden="true" focusable="false" xmlns="http://www.w3.org/2000/svg" class="qld__icon qld__icon--md "><use href="{{@root.site.metadata.siteDefaultIcons.value}}#qld__icon__home"></use></svg>
                                     <span class="qld__main-nav__item-text" data-name="{{{asset_short_name}}}">Home</span>
                                 </a>

--- a/src/components/mega_main_navigation/html/component.hbs
+++ b/src/components/mega_main_navigation/html/component.hbs
@@ -22,7 +22,7 @@
                         {{#if site.metadata.mainNavHomeIconShow.value}}
                         <li class="qld__main-nav__item {{#if current.home}}active{{/if}}">
                             <div class="qld__main-nav__item-title">
-                                <a class="qld__main-nav__item-home qld__main-nav__item-link" {{#if current.home}}aria-current="page"{{/if}} href="./?a={{site.data.assetid}}">
+                                <a class="qld__main-nav__item-home qld__main-nav__item-link" aria-label="Home" {{#if current.home}}aria-current="page"{{/if}} href="./?a={{site.data.assetid}}">
                                     <svg aria-hidden="true" focusable="false" xmlns="http://www.w3.org/2000/svg" class="qld__icon qld__icon--sm"><use href="{{@root.site.metadata.siteDefaultIcons.value}}#qld__icon__home"></use></svg>
                                     <span class="qld__main-nav__item-text" data-name="{{{asset_short_name}}}">Home</span>
                                 </a>


### PR DESCRIPTION
Fix/header nav qhwt 1090

This pull request includes changes to improve accessibility by adding `aria-label` attributes to navigation links in two components.

Accessibility improvements:

* [`src/components/main_navigation/html/component.hbs`](diffhunk://#diff-ec361c1d23dcfb742e0b2dcafb4ad93ba2b3d94515057d7948390bdf77fdd8efL22-R22): Added `aria-label="Home"` to the main navigation home link.
* [`src/components/mega_main_navigation/html/component.hbs`](diffhunk://#diff-93a19205079102c840a007a56ba083bcbb84a966ab44629d8edbf45924b427c1L25-R25): Added `aria-label="Home"` to the mega main navigation home link.