### PR TITLE
Update pagination colours

### DIFF
--- a/src/components/pagination/css/component.scss
+++ b/src/components/pagination/css/component.scss
@@ -129,7 +129,6 @@
             background-color: $QLD-color-neutral--white;
             display: inline-flex;
             justify-content: center;
-            box-shadow: inset 0 0 0 $QLD-border-width-thin $QLD-color-light__border--alt;
             @include QLD-space(line-height, 1.25unit);
             box-shadow: inset 0 0 0 $QLD-border-width-thin $QLD-color-light__border--alt;
             border: none;

--- a/src/components/pagination/css/component.scss
+++ b/src/components/pagination/css/component.scss
@@ -131,7 +131,7 @@
             justify-content: center;
             box-shadow: inset 0 0 0 $QLD-border-width-thin $QLD-color-light__border--alt;
             @include QLD-space(line-height, 1.25unit);
-            box-shadow: inset 0 0 0 $QLD-border-width-thin $QLD-color-neutral--lighter;
+            box-shadow: inset 0 0 0 $QLD-border-width-thin $QLD-color-light__border--alt;
             border: none;
             cursor: pointer;
 

--- a/src/components/pagination/css/component.scss
+++ b/src/components/pagination/css/component.scss
@@ -40,6 +40,7 @@
                 &:active,
                 &:focus {
                     background-color: var(--QLD-color-light__action--primary-hover);
+                    color: var(--QLD-color-light__link--on-action);
                     // border-color: var(--QLD-color-light__action--primary-hover);
                     box-shadow: inset 0 0 0 $QLD-border-width-thin var(--QLD-color-light__action--primary-hover);
                 }
@@ -100,8 +101,8 @@
             a {
                 &:active,
                 &:focus {
-                    color: var(--QLD-color-dark__link);
-                    background-color: var(--QLD-color-light__action--secondary);
+                    color: var(--QLD-color-light__link);
+                    background-color: transparent;
                     // border: $QLD-border-width-default solid var(--QLD-color-light__action--secondary);
                     box-shadow: inset 0 0 0 $QLD-border-width-default var(--QLD-color-light__action--secondary);
                 }
@@ -121,7 +122,7 @@
             display: inline-flex;
             justify-content: center;
             @include QLD-space(line-height, 1.25unit);
-            box-shadow: inset 0 0 0 $QLD-border-width-thin $QLD-color-neutral--lighter;
+            box-shadow: inset 0 0 0 $QLD-border-width-thin $QLD-color-light__border--alt;
 
             &:hover{
                 color: var(--QLD-color-light__link);

--- a/src/components/pagination/css/component.scss
+++ b/src/components/pagination/css/component.scss
@@ -141,6 +141,9 @@
                 text-decoration: none;
                 box-shadow: inset 0 0 0 $QLD-border-width-default var(--QLD-color-light__action--secondary);
             }
+            &:visited{
+                color: var(--QLD-color-light__link);
+            }
 
             &[rel] {
                 color: var(--QLD-color-light__action--primary);

--- a/src/components/pagination/css/component.scss
+++ b/src/components/pagination/css/component.scss
@@ -121,8 +121,8 @@
             background-color: $QLD-color-neutral--white;
             display: inline-flex;
             justify-content: center;
-            @include QLD-space(line-height, 1.25unit);
             box-shadow: inset 0 0 0 $QLD-border-width-thin $QLD-color-light__border--alt;
+            @include QLD-space(line-height, 1.25unit);
 
             &:hover{
                 color: var(--QLD-color-light__link);
@@ -134,7 +134,6 @@
             &[rel] {
                 color: var(--QLD-color-light__action--primary);
             }
-
         }
 
         span {

--- a/src/components/pagination/css/component.scss
+++ b/src/components/pagination/css/component.scss
@@ -38,6 +38,7 @@
 
                 &:hover{
                     background-color: var(--QLD-color-light__action--primary-hover);
+                    color: var(--QLD-color-light__link--on-action);
                     // border-color: var(--QLD-color-light__action--primary-hover);
                     box-shadow: inset 0 0 0 $QLD-border-width-default var(--QLD-color-light__action--primary-hover);
                     @include QLD-box-shadow(1);


### PR DESCRIPTION
Update pagination colours QHWT-1213

This pull request includes several updates to the styles in the `src/components/pagination/css/component.scss` file. These changes primarily focus on improving the visual consistency and accessibility of the pagination component by updating color variables and adding new styles for different states.

Styling updates:

* Added a new color for the `:hover` and `:focus` states to improve visibility and consistency. [[1]](diffhunk://#diff-b091c9a36ecdd4e4c68fad962267094ef1a0ed7b11ab48be2738e80607f6f64cR41) [[2]](diffhunk://#diff-b091c9a36ecdd4e4c68fad962267094ef1a0ed7b11ab48be2738e80607f6f64cR50)
* Updated the color and background for `a` and `button` elements in their `:active` and `:focus` states to enhance accessibility.
* Changed the box-shadow color for better contrast and alignment with the design system.
* Added a new style for the `:visited` state to ensure consistent link color after visiting.