### PR TITLE
Fix/qhwt 1206 qhwt 1086

### DIFF
--- a/src/components/main_navigation/html/component.hbs
+++ b/src/components/main_navigation/html/component.hbs
@@ -9,7 +9,7 @@
                 <div class="qld__main-nav__menu-inner">
                     <div class="qld__main-nav__focus-trap-top"></div>
                     <div class="qld__main-nav__header">
-                        <h6 class="qld__main-nav__menu-heading">Menu</h6>
+                        <h2 class="qld__main-nav__menu-heading" tabindex="-1">Menu</h2>
                         <button aria-controls="main-nav" class="qld__main-nav__toggle qld__main-nav__toggle--close">
                             <svg aria-hidden="true" focusable="false" xmlns="http://www.w3.org/2000/svg" class="qld__icon qld__icon--md"><use href="{{@root.site.metadata.siteDefaultIcons.value}}#qld__icon__close"></use></svg>
                             <span class="qld__main-nav__toggle-text">Close</span>

--- a/src/components/main_navigation/js/global.js
+++ b/src/components/main_navigation/js/global.js
@@ -204,6 +204,7 @@
         var openButton = document.querySelector('.qld__main-nav__toggle--open');
         var focustrapTop = menu.querySelector('.qld__main-nav__focus-trap-top');
         var focustrapBottom = menu.querySelector('.qld__main-nav__focus-trap-bottom');
+        var menuHeading = document.querySelector(".qld__main-nav__menu-heading");
         var focusContent = menu.querySelectorAll('a, .qld__main-nav__toggle');
         var closed = target.className.indexOf('qld__main-nav__content--open') === -1;
         var header = document.querySelector('.qld__header');
@@ -247,7 +248,7 @@
                     if (state === 'opening' ) {
 
                         // Move the focus to the close button
-                        openButton.focus();
+                        menuHeading.focus();
                         openButton.setAttribute('aria-expanded', true);
                         closeButton.setAttribute('aria-expanded', true);
 

--- a/src/components/main_navigation/js/global.js
+++ b/src/components/main_navigation/js/global.js
@@ -247,7 +247,7 @@
                     if (state === 'opening' ) {
 
                         // Move the focus to the close button
-                        closeButton.focus();
+                        openButton.focus();
                         openButton.setAttribute('aria-expanded', true);
                         closeButton.setAttribute('aria-expanded', true);
 
@@ -255,7 +255,7 @@
                         focustrapTop.setAttribute('tabindex', 0);
                         focustrapBottom.setAttribute('tabindex', 0);
 
-                        header.setAttribute('aria-hidden', true);
+                        // header.setAttribute('aria-hidden', true);
                         body.setAttribute('aria-hidden', true);
                         footer.setAttribute('aria-hidden', true);
 
@@ -285,7 +285,7 @@
                         }
                     } else {
                         // Move the focus back to the menu button
-                        openButton.focus();
+                        closeButton.focus();
                         openButton.setAttribute('aria-expanded', false);
                         closeButton.setAttribute('aria-expanded', false);
 

--- a/src/components/mega_main_navigation/html/component.hbs
+++ b/src/components/mega_main_navigation/html/component.hbs
@@ -9,7 +9,7 @@
                 <div class="qld__main-nav__menu-inner">
                     <div class="qld__main-nav__focus-trap-top"></div>
                     <div class="qld__main-nav__header">
-                        <h6 class="qld__main-nav__menu-heading">Menu</h6>
+                        <h2 class="qld__main-nav__menu-heading" tabindex="-1">Menu</h2>
                         <button
                             aria-controls="main-nav"
                             class="qld__main-nav__toggle qld__main-nav__toggle--close"


### PR DESCRIPTION
https://squizgroup.atlassian.net/browse/QHWT-1086

This pull request includes changes to improve the accessibility and user experience of the main navigation component. The most important changes include updating the heading level and focusing behavior when the menu is opened or closed.

### Accessibility Improvements:

* [`src/components/main_navigation/html/component.hbs`](diffhunk://#diff-ec361c1d23dcfb742e0b2dcafb4ad93ba2b3d94515057d7948390bdf77fdd8efL12-R12): Changed the heading level from `<h6>` to `<h2>` and added a `tabindex="-1"` attribute to the menu heading for better screen reader support.
* [`src/components/mega_main_navigation/html/component.hbs`](diffhunk://#diff-93a19205079102c840a007a56ba083bcbb84a966ab44629d8edbf45924b427c1L12-R12): Made the same heading level change as above to ensure consistency across different navigation components.

### Focus Management:

* [`src/components/main_navigation/js/global.js`](diffhunk://#diff-343a55df9db3667863da1174298e62db2d115023e9ec48e4d03ceca6ccdcccd2R207): Added a reference to the menu heading element and updated the focus behavior to move focus to the menu heading when the menu is opened. [[1]](diffhunk://#diff-343a55df9db3667863da1174298e62db2d115023e9ec48e4d03ceca6ccdcccd2R207) [[2]](diffhunk://#diff-343a55df9db3667863da1174298e62db2d115023e9ec48e4d03ceca6ccdcccd2L250-R259)
* [`src/components/main_navigation/js/global.js`](diffhunk://#diff-343a55df9db3667863da1174298e62db2d115023e9ec48e4d03ceca6ccdcccd2L288-R289): Changed the focus behavior to move focus back to the close button when the menu is closed.