### PR TITLE
Add accessibility tags for background images

### DIFF
--- a/src/components/card_feature/html/component.hbs
+++ b/src/components/card_feature/html/component.hbs
@@ -1,7 +1,7 @@
 {{#with component.data}}
 <section class="qld__card--wrapper qld__body {{metadata.body_background.value}} {{metadata.body_background_type.value}}" 
-    {{#ifCond metadata.body_background_type.value '==' 'qld__card--wrapper-bg-image'}} style="background-image:url(./?a={{metadata.body_background_image.value}})"{{/ifCond}}
-    {{#ifCond metadata.body_background_type.value '==' 'qld__card--wrapper-bg-pattern'}} style="background-image:url(./?a={{metadata.body_background_pattern.value}})"{{/ifCond}} >
+    {{#ifCond metadata.body_background_type.value '==' 'qld__card--wrapper-bg-image'}} style="background-image:url(./?a={{metadata.body_background_image.value}})" {{#if ../component.background_image_alt}} role="img" aria-label="{{../component.background_image_alt}}"{{/if}}{{/ifCond}}
+    {{#ifCond metadata.body_background_type.value '==' 'qld__card--wrapper-bg-pattern'}} style="background-image:url(./?a={{metadata.body_background_pattern.value}})" {{#if ../component.background_pattern_alt}} role="img" aria-label="{{../component.background_pattern_alt}}"{{/if}}{{/ifCond}}>
     <div class="container-fluid">
     
         {{#if metadata.intro_heading.value}}
@@ -45,7 +45,7 @@
                         {{#ifCond metadata.show_icon_image.value '==' 'image'}}
                             <a aria-label="{{metadata.card_title.value}}" {{#if metadata.shortDescription.value}}aria-describedby="card-{{assetid}}"{{/if}} class="qld__card__image-link" href="./?a={{metadata.card_title_url.value}}">
 
-                                <div class="qld__responsive-media-img--bg" style="background-image: url('./?a={{metadata.card_image.value}}');" {{#if ../component.image_alt}}aria-label="Image for {{../component.image_alt}}"{{else}}aria-label="Image for {{metadata.card_title.value}}"{{/if}}></div>
+                                <div class="qld__responsive-media-img--bg" style="background-image: url('./?a={{metadata.card_image.value}}');" {{#if ../component.image_alt}}role="img" aria-label="{{../component.image_alt}}"{{/if}}></div>
 
                             </a>
                         {{/ifCond}}

--- a/src/components/card_feature/html/component.hbs
+++ b/src/components/card_feature/html/component.hbs
@@ -45,7 +45,7 @@
                         {{#ifCond metadata.show_icon_image.value '==' 'image'}}
                             <a aria-label="{{metadata.card_title.value}}" {{#if metadata.shortDescription.value}}aria-describedby="card-{{assetid}}"{{/if}} class="qld__card__image-link" href="./?a={{metadata.card_title_url.value}}">
 
-                                <div class="qld__responsive-media-img--bg" style="background-image: url('./?a={{metadata.card_image.value}}');" {{#if image_alt}}role="img" aria-label="{{image_alt}}"{{/if}}></div>
+                                <div class="qld__responsive-media-img--bg" style="background-image: url('./?a={{metadata.card_image.value}}');" {{#if ../component.image_alt}}role="img" aria-label="{{../component.image_alt}}"{{/if}}></div>
 
                             </a>
                         {{/ifCond}}

--- a/src/components/card_feature/html/component.hbs
+++ b/src/components/card_feature/html/component.hbs
@@ -45,7 +45,7 @@
                         {{#ifCond metadata.show_icon_image.value '==' 'image'}}
                             <a aria-label="{{metadata.card_title.value}}" {{#if metadata.shortDescription.value}}aria-describedby="card-{{assetid}}"{{/if}} class="qld__card__image-link" href="./?a={{metadata.card_title_url.value}}">
 
-                                <div class="qld__responsive-media-img--bg" style="background-image: url('./?a={{metadata.card_image.value}}');" {{#if ../component.image_alt}}role="img" aria-label="{{../component.image_alt}}"{{/if}}></div>
+                                <div class="qld__responsive-media-img--bg" style="background-image: url('./?a={{metadata.card_image.value}}');" {{#if image_alt}}role="img" aria-label="{{image_alt}}"{{/if}}></div>
 
                             </a>
                         {{/ifCond}}

--- a/src/components/card_feature/js/manifest.json
+++ b/src/components/card_feature/js/manifest.json
@@ -391,6 +391,8 @@
             }
         },
         "image_alt": "Image of mario themed ginger bread house",
+        "background_image_alt": "Mario image",
+        "background_pattern_alt": "Gatton HHS",
         "children": [{
             "assetid": "22724",
             "type_code": "page_redirect",

--- a/src/components/card_multi_action/html/component.hbs
+++ b/src/components/card_multi_action/html/component.hbs
@@ -1,8 +1,7 @@
 {{#with component.data}}
 <section class="qld__card--wrapper qld__body {{metadata.body_background.value}} {{metadata.body_background_type.value}}" id="{{#if metadata.id_field.value}}{{metadata.id_field.value}}{{else}}cards-multi-{{assetid}}{{/if}}"
-    {{#ifCond metadata.body_background_type.value '==' 'qld__card--wrapper-bg-image'}} style="background-image:url(./?a={{metadata.body_background_image.value}})"{{/ifCond}}
-    {{#ifCond metadata.body_background_type.value '==' 'qld__card--wrapper-bg-pattern'}} style="background-image:url(./?a={{metadata.body_background_pattern.value}})"{{/ifCond}} >
-    <div class="container-fluid">
+    {{#ifCond metadata.body_background_type.value '==' 'qld__card--wrapper-bg-image'}} style="background-image:url(./?a={{metadata.body_background_image.value}})" {{#if ../component.background_image_alt}} role="img" aria-label="{{../component.background_image_alt}}"{{/if}}{{/ifCond}}
+    {{#ifCond metadata.body_background_type.value '==' 'qld__card--wrapper-bg-pattern'}} style="background-image:url(./?a={{metadata.body_background_pattern.value}})" {{#if ../component.background_pattern_alt}} role="img" aria-label="{{../component.background_pattern_alt}}"{{/if}}{{/ifCond}} >
 {{/with}}  
     {{#with component.data}}
         {{#if metadata.intro_heading.value}}

--- a/src/components/card_multi_action/js/manifest.json
+++ b/src/components/card_multi_action/js/manifest.json
@@ -229,6 +229,8 @@
 				}
             }
         },
+        "background_image_alt":	"Mario image",
+        "background_pattern_alt": "Gatton HHS",
         "children": [{
             "assetid": "22724",
             "type_code": "page_redirect",

--- a/src/components/card_no_action/html/component.hbs
+++ b/src/components/card_no_action/html/component.hbs
@@ -1,6 +1,6 @@
 <section class="qld__card--wrapper qld__body {{component.data.metadata.body_background.value}} {{component.data.metadata.body_background_type.value}}" id="{{#if component.data.metadata.id_field.value}}{{component.data.metadata.id_field.value}}{{else}}cards-{{component.data.assetid}}{{/if}}"
-    {{#ifCond component.data.metadata.body_background_type.value '==' 'qld__card--wrapper-bg-image'}} style="background-image:url(./?a={{component.data.metadata.body_background_image.value}})"{{/ifCond}}
-    {{#ifCond component.data.metadata.body_background_type.value '==' 'qld__card--wrapper-bg-pattern'}} style="background-image:url(./?a={{component.data.metadata.body_background_pattern.value}})"{{/ifCond}} >
+    {{#ifCond component.data.metadata.body_background_type.value '==' 'qld__card--wrapper-bg-image'}} style="background-image:url(./?a={{component.data.metadata.body_background_image.value}})"{{#if ../component.background_image_alt}} role="img" aria-label="{{../component.background_image_alt}}"{{/if}}{{/ifCond}}
+    {{#ifCond component.data.metadata.body_background_type.value '==' 'qld__card--wrapper-bg-pattern'}} style="background-image:url(./?a={{component.data.metadata.body_background_pattern.value}})"{{#if ../component.background_pattern_alt}} role="img" aria-label="{{../component.background_pattern_alt}}"{{/if}}{{/ifCond}} >
 
     <div class="container-fluid">
         

--- a/src/components/card_no_action/html/component.hbs
+++ b/src/components/card_no_action/html/component.hbs
@@ -1,6 +1,6 @@
 <section class="qld__card--wrapper qld__body {{component.data.metadata.body_background.value}} {{component.data.metadata.body_background_type.value}}" id="{{#if component.data.metadata.id_field.value}}{{component.data.metadata.id_field.value}}{{else}}cards-{{component.data.assetid}}{{/if}}"
-    {{#ifCond component.data.metadata.body_background_type.value '==' 'qld__card--wrapper-bg-image'}} style="background-image:url(./?a={{component.data.metadata.body_background_image.value}})"{{#if ../component.background_image_alt}} role="img" aria-label="{{../component.background_image_alt}}"{{/if}}{{/ifCond}}
-    {{#ifCond component.data.metadata.body_background_type.value '==' 'qld__card--wrapper-bg-pattern'}} style="background-image:url(./?a={{component.data.metadata.body_background_pattern.value}})"{{#if ../component.background_pattern_alt}} role="img" aria-label="{{../component.background_pattern_alt}}"{{/if}}{{/ifCond}} >
+    {{#ifCond component.data.metadata.body_background_type.value '==' 'qld__card--wrapper-bg-image'}} style="background-image:url(./?a={{component.data.metadata.body_background_image.value}})"{{#if component.background_image_alt}} role="img" aria-label="{{component.background_image_alt}}"{{/if}}{{/ifCond}}
+    {{#ifCond component.data.metadata.body_background_type.value '==' 'qld__card--wrapper-bg-pattern'}} style="background-image:url(./?a={{component.data.metadata.body_background_pattern.value}})"{{#if component.background_pattern_alt}} role="img" aria-label="{{component.background_pattern_alt}}"{{/if}}{{/ifCond}} >
 
     <div class="container-fluid">
         

--- a/src/components/card_no_action/js/manifest.json
+++ b/src/components/card_no_action/js/manifest.json
@@ -217,6 +217,8 @@
 				}
 			}
 		},
+        "background_image_alt": "Mario image",
+        "background_pattern_alt": "Gatton HHS",
 		"children": [
             {
             "assetid": "22724",

--- a/src/components/card_single_action/html/component.hbs
+++ b/src/components/card_single_action/html/component.hbs
@@ -1,6 +1,6 @@
 <section class="qld__card--wrapper qld__body {{component.data.metadata.body_background.value}} {{component.data.metadata.body_background_type.value}}" id="{{#if component.data.metadata.id_field.value}}{{component.data.metadata.id_field.value}}{{else}}cards-single-{{component.data.assetid}}{{/if}}"
-    {{#ifCond component.data.metadata.body_background_type.value '==' 'qld__card--wrapper-bg-image'}} style="background-image:url(./?a={{component.data.metadata.body_background_image.value}})"{{#if ../component.background_image_alt}} role="img" aria-label="{{../component.background_image_alt}}"{{/if}}{{/ifCond}}
-    {{#ifCond component.data.metadata.body_background_type.value '==' 'qld__card--wrapper-bg-pattern'}} style="background-image:url(./?a={{component.data.metadata.body_background_pattern.value}})"{{#if ../component.background_pattern_alt}} role="img" aria-label="{{../component.background_pattern_alt}}"{{/if}}{{/ifCond}} >
+    {{#ifCond component.data.metadata.body_background_type.value '==' 'qld__card--wrapper-bg-image'}} style="background-image:url(./?a={{component.data.metadata.body_background_image.value}})"{{#if component.background_image_alt}} role="img" aria-label="{{component.background_image_alt}}"{{/if}}{{/ifCond}}
+    {{#ifCond component.data.metadata.body_background_type.value '==' 'qld__card--wrapper-bg-pattern'}} style="background-image:url(./?a={{component.data.metadata.body_background_pattern.value}})"{{#if component.background_pattern_alt}} role="img" aria-label="{{component.background_pattern_alt}}"{{/if}}{{/ifCond}} >
 
     <div class="container-fluid">
         

--- a/src/components/card_single_action/html/component.hbs
+++ b/src/components/card_single_action/html/component.hbs
@@ -1,6 +1,6 @@
 <section class="qld__card--wrapper qld__body {{component.data.metadata.body_background.value}} {{component.data.metadata.body_background_type.value}}" id="{{#if component.data.metadata.id_field.value}}{{component.data.metadata.id_field.value}}{{else}}cards-single-{{component.data.assetid}}{{/if}}"
-    {{#ifCond component.data.metadata.body_background_type.value '==' 'qld__card--wrapper-bg-image'}} style="background-image:url(./?a={{component.data.metadata.body_background_image.value}})"{{/ifCond}}
-    {{#ifCond component.data.metadata.body_background_type.value '==' 'qld__card--wrapper-bg-pattern'}} style="background-image:url(./?a={{component.data.metadata.body_background_pattern.value}})"{{/ifCond}} >
+    {{#ifCond component.data.metadata.body_background_type.value '==' 'qld__card--wrapper-bg-image'}} style="background-image:url(./?a={{component.data.metadata.body_background_image.value}})"{{#if ../component.background_image_alt}} role="img" aria-label="{{../component.background_image_alt}}"{{/if}}{{/ifCond}}
+    {{#ifCond component.data.metadata.body_background_type.value '==' 'qld__card--wrapper-bg-pattern'}} style="background-image:url(./?a={{component.data.metadata.body_background_pattern.value}})"{{#if ../component.background_pattern_alt}} role="img" aria-label="{{../component.background_pattern_alt}}"{{/if}}{{/ifCond}} >
 
     <div class="container-fluid">
         

--- a/src/components/card_single_action/js/manifest.json
+++ b/src/components/card_single_action/js/manifest.json
@@ -229,6 +229,8 @@
 				}
 			}
 		},
+        "background_image_alt":	"Mario image",
+        "background_pattern_alt": "Gatton HHS",
 		"children": [
             {
             "assetid": "22724",

--- a/src/helpers/Handlebars/getThumbnailAlt.js
+++ b/src/helpers/Handlebars/getThumbnailAlt.js
@@ -1,12 +1,5 @@
 module.exports = function(thumbnails, index, shortName) {
-    var ariaLabel = 'aria-label="Image for '
+    if (!thumbnails[index].asset_thumbnail_alt.length) return '';
 
-    if(thumbnails[index].asset_thumbnail_alt.length){
-        
-        ariaLabel += thumbnails[index].asset_thumbnail_alt + '"';
-    } else {
-        ariaLabel += shortName + '"';
-    }
-
-    return ariaLabel
+    return 'aria-label="' + thumbnails[index].asset_thumbnail_alt + '" role="img"';
 }


### PR DESCRIPTION
Add accessibility tags for background images QHWT-1088

This pull request includes several changes to improve accessibility by adding `aria-label` and `role="img"` attributes to various components. The most important changes include updates to the `component.hbs` files for different card types and the addition of new fields in the corresponding `manifest.json` files.

Accessibility improvements:

* [`src/components/card_feature/html/component.hbs`](diffhunk://#diff-14068a92e2ce0a38779b3cbbad93af25aff2038593fb976649fb7974045fafacL3-R4): Added `role="img"` and `aria-label` attributes for background images and patterns, as well as for card images. [[1]](diffhunk://#diff-14068a92e2ce0a38779b3cbbad93af25aff2038593fb976649fb7974045fafacL3-R4) [[2]](diffhunk://#diff-14068a92e2ce0a38779b3cbbad93af25aff2038593fb976649fb7974045fafacL48-R48)
* [`src/components/card_multi_action/html/component.hbs`](diffhunk://#diff-80118341916a7b9c6cf5f39bca9d9045a37ec2cd63a12352866b6f8d1d042af9L3-R4): Added `role="img"` and `aria-label` attributes for background images and patterns.
* [`src/components/card_no_action/html/component.hbs`](diffhunk://#diff-57fdb03ee8cc7d1ce8376a5675e0ef0802a027f44c9341e983693ad65b8567e6L2-R3): Added `role="img"` and `aria-label` attributes for background images and patterns.
* [`src/components/card_single_action/html/component.hbs`](diffhunk://#diff-9d694cc0ccf4a549f5c949bb6e982abf5eefa52a6c34f050e8b4710cbbf1089aL2-R3): Added `role="img"` and `aria-label` attributes for background images and patterns.
* [`src/helpers/Handlebars/getThumbnailAlt.js`](diffhunk://#diff-f1234f59be7895aaed9316282daebd33ac287e253684b4d4f03ee8fc7bf10a9bL2-R4): Simplified the function to return the `aria-label` and `role="img"` attributes directly if the `asset_thumbnail_alt` is present.
