### PR TITLE
Fix/qhwt 1206 qhwt 1210

### DIFF
--- a/src/components/basic_search/html/component.hbs
+++ b/src/components/basic_search/html/component.hbs
@@ -331,7 +331,7 @@
                                 
                                 {{#if label}}
                                 <li class="{{linkType}}{{#if isCurrent}} active{{/if}}">
-                                    <a href="{{{url}}}">{{label}}</a></li>
+                                    <a href="{{{url}}}" aria-current="page">{{label}}</a></li>
                                 {{/if}}
 
                                 {{#ifCond linkType '===' 'next'}}

--- a/src/components/pagination/html/component.hbs
+++ b/src/components/pagination/html/component.hbs
@@ -19,12 +19,7 @@
                 
                 {{#if label}}
                 <li class="{{linkType}}{{#if isCurrent}} active{{/if}}">
-                    <a 
-                        class="qld__search-pagination_link" 
-                        href="{{url}}" 
-                        aria-current="page"
-                    >{{label}}
-                    </a>
+                    <a class="qld__search-pagination_link" href="{{url}}" aria-current="page">{{label}}</a>
                 </li>
                 {{/if}}
 

--- a/src/components/pagination/html/component.hbs
+++ b/src/components/pagination/html/component.hbs
@@ -19,7 +19,13 @@
                 
                 {{#if label}}
                 <li class="{{linkType}}{{#if isCurrent}} active{{/if}}">
-                    <a class="qld__search-pagination_link" href="{{url}}">{{label}}</a></li>
+                    <a 
+                        class="qld__search-pagination_link" 
+                        href="{{url}}" 
+                        aria-current="page"
+                    >{{label}}
+                    </a>
+                </li>
                 {{/if}}
 
                 {{#ifCond linkType '===' 'next'}}


### PR DESCRIPTION
https://squizgroup.atlassian.net/browse/QHWT-1210

This pull request includes accessibility improvements to the `basic_search` and `pagination` components. The changes ensure that the current page is properly indicated to screen readers by adding the `aria-current="page"` attribute to the relevant links.

Accessibility improvements:

* [`src/components/basic_search/html/component.hbs`](diffhunk://#diff-cee01265c95869dbc33a81676569ee6e097921f60fcf4c86a05bf100ef277c91L334-R334): Added `aria-current="page"` attribute to the link for the current page.
* [`src/components/pagination/html/component.hbs`](diffhunk://#diff-d224824148499ce9c2a4e79727d314a649520cd680f8ed4ff352cd0d6cdf6542L22-R23): Added `aria-current="page"` attribute to the link for the current page.