### PR TITLE
Update structure and styles for tags

### DIFF
--- a/src/components/_global/css/tags/component.scss
+++ b/src/components/_global/css/tags/component.scss
@@ -73,7 +73,6 @@ a.qld__tag,
 			background-color: var(--QLD-color-light__action--primary-hover);
 			color: var(--QLD-color-light__link--on-action);
 			border-color: var(--QLD-color-light__action--primary-hover);
-			
 		}
 	}
 
@@ -198,6 +197,8 @@ a.qld__tag,
 	border-radius: $QLD-border-radius-lg;
 	text-decoration: none;
 	@include QLD-underline('light','noUnderline','default');
+	display: flex;
+	align-items: center;
 
 	&:hover {
 		color: var(--QLD-color-light__text);
@@ -206,33 +207,40 @@ a.qld__tag,
 		text-decoration: none;
 	}
 
-	.qld__tag--filter-close{
-
-		// background-image: QLD-svg-with-fill($QLD-icon-close, var(--QLD-color-light__action--secondary));
-		// background-color: transparent;
-		// background-repeat: no-repeat;
-		// background-position: center;
-		mask-image: QLD-svguri($QLD-icon-close);
+	.qld__tag--filter-close {
+		@include QLD-space(margin-left, .5unit); 
+		background-color: transparent;
+		border: none;
+		height: 1.25rem;
+		width: 1.25rem;
+		display: flex;
+		align-items: center;
+		padding: 0;
+		border-radius: 50%;
+		&:focus{
+			outline: 3px solid var(--QLD-color-light__focus);
+			outline-offset: 2px;
+		}
+	}
+	.qld__tag--filter-close-icon {
+        mask-image: QLD-svguri($QLD-icon-close);
 		mask-repeat: no-repeat;
 		mask-position: center;
 		background-color: var(--QLD-color-light__action--secondary);
 		@include QLD-space(height, 1.25unit);
 		@include QLD-space(width, 1.25unit);
 		display: inline-block;
-		@include QLD-space(margin-left, .5unit);
+		margin-left: 0;
 		@include QLD-space(line-height, 1.5unit);
 		vertical-align: middle;
 		white-space: nowrap;
 		border: none;
 		cursor: pointer;
-
-
-		&:hover{
-			// background-image: QLD-svg-with-fill($QLD-icon-close-hover, var(--QLD-color-light__action--secondary));
+		&:hover {
 			mask-image: QLD-svguri($QLD-icon-close-hover);
 			background-color: var(--QLD-color-light__action--secondary-hover);
 		}
-	}
+    }
 
 	.qld__body--light &,
 	.qld__card--light .qld__card__footer &{
@@ -271,7 +279,11 @@ a.qld__tag,
 			text-decoration: none;
 		}
 
-		.qld__tag--filter-close{
+		.qld__tag--filter-close:focus{
+			outline-color: var(--QLD-color-dark__focus);
+		}
+
+		.qld__tag--filter-close-icon {
 			// background-image: QLD-svg-with-fill($QLD-icon-close, var(--QLD-color-dark__action--secondary));
 			background-color: var(--QLD-color-dark__action--secondary-hover);
 
@@ -295,7 +307,12 @@ a.qld__tag,
 			text-decoration: none;
 		}
 
-		.qld__tag--filter-close{
+
+		.qld__tag--filter-close:focus{
+			outline-color: var(--QLD-color-dark__focus);
+		}
+		
+		.qld__tag--filter-close-icon{
 			// background-image: QLD-svg-with-fill($QLD-icon-close, var(--QLD-color-dark__action--secondary));
 			background-color: var(--QLD-color-dark__action--secondary-hover);
 

--- a/src/components/_global/css/tags/component.scss
+++ b/src/components/_global/css/tags/component.scss
@@ -16,6 +16,39 @@
 	// white-space: nowrap;
 	text-align: center;
 	text-decoration: none;
+	&-list--wrapper {
+		display: flex;
+		align-items: flex-start;
+		flex-direction: column;
+		padding-top: 20px;
+    	padding-top: 1.25rem;
+		@include QLD-media(md) {
+			flex-direction: row;
+			align-items: center;
+		}
+		@include QLD-media(lg) {
+			padding-top: 24px;
+        	padding-top: 1.5rem;
+		}
+	}
+	&-list--title {
+		font-weight: bold;
+		display: block;
+		white-space: nowrap;
+		padding-right: 16px;
+		padding-right: 1rem;
+		padding-bottom: 8px;
+		padding-bottom: 0.5rem;
+		@include QLD-media(md) {
+            padding-top: 4px;
+			padding-top: 0.25rem;
+			padding-bottom: 0px;
+			padding-bottom: 0rem;
+			-ms-flex-item-align: center;
+			align-self: center;
+        }
+	}
+
 
 	.qld__card .qld__card__footer &{ 
 		color: var(--QLD-color-light__text--lighter);

--- a/src/html/component-tag_list.html
+++ b/src/html/component-tag_list.html
@@ -109,13 +109,13 @@
                                     <h3>Tags - Applied filter</h3>
                                     <ul class="qld__tag-list">
                                         <li>
-                                            <a href="https://www.sunshinecoast.health.qld.gov.au/about-us/news?tag=dental_health" class="qld__tag qld__tag--filter" tabindex="0">Filter<button class="qld__tag--filter-close" data-toggleUrl="{{toggleUrl}}"><span class="sr-only">close</span></button></a>
+                                            <div class="qld__tag qld__tag--filter" tabindex="0">Filter<button class="qld__tag--filter-close" data-toggleUrl="{{toggleUrl}}"><span class="qld__tag--filter-close-icon"></span><span class="sr-only">close</span></button></div>
                                         </li>
                                         <li>
-                                            <a href="https://www.sunshinecoast.health.qld.gov.au/about-us/news?tag=staff" class="qld__tag qld__tag--filter" tabindex="0">Filter<button class="qld__tag--filter-close" data-toggleUrl="{{toggleUrl}}"><span class="sr-only">close</span></button></a>
+                                            <div class="qld__tag qld__tag--filter" tabindex="0">Filter<button class="qld__tag--filter-close" data-toggleUrl="{{toggleUrl}}"><span class="qld__tag--filter-close-icon"></span><span class="sr-only">close</span></button></div>
                                         </li>
                                         <li>
-                                            <a href="https://www.sunshinecoast.health.qld.gov.au/about-us/news?tag=dental_health" class="qld__tag qld__tag--filter" tabindex="0">Filter<button class="qld__tag--filter-close" data-toggleUrl="{{toggleUrl}}"><span class="sr-only">close</span></button></a>
+                                            <div class="qld__tag qld__tag--filter" tabindex="0">Filter<button class="qld__tag--filter-close" data-toggleUrl="{{toggleUrl}}"><span class="qld__tag--filter-close-icon"></span><span class="sr-only">close</span></button></div>
                                         </li>
                                     </ul>
                                 </div>
@@ -174,13 +174,13 @@
                                     <h3>Tags - Applied filter</h3>
                                     <ul class="qld__tag-list">
                                         <li>
-                                            <a href="https://www.sunshinecoast.health.qld.gov.au/about-us/news?tag=dental_health" class="qld__tag qld__tag--filter" tabindex="0">Filter<button class="qld__tag--filter-close" data-toggleUrl="{{toggleUrl}}"><span class="sr-only">close</span></button></a>
+                                            <div class="qld__tag qld__tag--filter" tabindex="0">Filter<button class="qld__tag--filter-close" data-toggleUrl="{{toggleUrl}}"><span class="qld__tag--filter-close-icon"></span><span class="sr-only">close</span></button></div>
                                         </li>
                                         <li>
-                                            <a href="https://www.sunshinecoast.health.qld.gov.au/about-us/news?tag=staff" class="qld__tag qld__tag--filter" tabindex="0">Filter<button class="qld__tag--filter-close" data-toggleUrl="{{toggleUrl}}"><span class="sr-only">close</span></button></a>
+                                            <div class="qld__tag qld__tag--filter" tabindex="0">Filter<button class="qld__tag--filter-close" data-toggleUrl="{{toggleUrl}}"><span class="qld__tag--filter-close-icon"></span><span class="sr-only">close</span></button></div>
                                         </li>
                                         <li>
-                                            <a href="https://www.sunshinecoast.health.qld.gov.au/about-us/news?tag=dental_health" class="qld__tag qld__tag--filter" tabindex="0">Filter<button class="qld__tag--filter-close" data-toggleUrl="{{toggleUrl}}"><span class="sr-only">close</span></button></a>
+                                            <div class="qld__tag qld__tag--filter" tabindex="0">Filter<button class="qld__tag--filter-close" data-toggleUrl="{{toggleUrl}}"><span class="qld__tag--filter-close-icon"></span><span class="sr-only">close</span></button></div>
                                         </li>
                                     </ul>
                                 </div>
@@ -239,13 +239,13 @@
                                     <h3>Tags - Applied filter</h3>
                                     <ul class="qld__tag-list">
                                         <li>
-                                            <a href="https://www.sunshinecoast.health.qld.gov.au/about-us/news?tag=dental_health" class="qld__tag qld__tag--filter" tabindex="0">Filter<button class="qld__tag--filter-close" data-toggleUrl="{{toggleUrl}}"><span class="sr-only">close</span></button></a>
+                                            <div class="qld__tag qld__tag--filter" tabindex="0">Filter<button class="qld__tag--filter-close" data-toggleUrl="{{toggleUrl}}"><span class="qld__tag--filter-close-icon"></span><span class="sr-only">close</span></button></div>
                                         </li>
                                         <li>
-                                            <a href="https://www.sunshinecoast.health.qld.gov.au/about-us/news?tag=staff" class="qld__tag qld__tag--filter" tabindex="0">Filter<button class="qld__tag--filter-close" data-toggleUrl="{{toggleUrl}}"><span class="sr-only">close</span></button></a>
+                                            <div class="qld__tag qld__tag--filter" tabindex="0">Filter<button class="qld__tag--filter-close" data-toggleUrl="{{toggleUrl}}"><span class="qld__tag--filter-close-icon"></span><span class="sr-only">close</span></button></div>
                                         </li>
                                         <li>
-                                            <a href="https://www.sunshinecoast.health.qld.gov.au/about-us/news?tag=dental_health" class="qld__tag qld__tag--filter" tabindex="0">Filter<button class="qld__tag--filter-close" data-toggleUrl="{{toggleUrl}}"><span class="sr-only">close</span></button></a>
+                                            <div class="qld__tag qld__tag--filter" tabindex="0">Filter<button class="qld__tag--filter-close" data-toggleUrl="{{toggleUrl}}"><span class="qld__tag--filter-close-icon"></span><span class="sr-only">close</span></button></div>
                                         </li>
                                     </ul>
                                 </div>
@@ -304,13 +304,13 @@
                                     <h3>Tags - Applied filter</h3>
                                     <ul class="qld__tag-list">
                                         <li>
-                                            <a href="https://www.sunshinecoast.health.qld.gov.au/about-us/news?tag=dental_health" class="qld__tag qld__tag--filter" tabindex="0">Filter<button class="qld__tag--filter-close" data-toggleUrl="{{toggleUrl}}"><span class="sr-only">close</span></button></a>
+                                            <div class="qld__tag qld__tag--filter" tabindex="0">Filter<button class="qld__tag--filter-close" data-toggleUrl="{{toggleUrl}}"><span class="qld__tag--filter-close-icon"></span><span class="sr-only">close</span></button></div>
                                         </li>
                                         <li>
-                                            <a href="https://www.sunshinecoast.health.qld.gov.au/about-us/news?tag=staff" class="qld__tag qld__tag--filter" tabindex="0">Filter<button class="qld__tag--filter-close" data-toggleUrl="{{toggleUrl}}"><span class="sr-only">close</span></button></a>
+                                            <div href="https://www.sunshinecoast.health.qld.gov.au/about-us/news?tag=staff" class="qld__tag qld__tag--filter" tabindex="0">Filter<button class="qld__tag--filter-close" data-toggleUrl="{{toggleUrl}}"><span class="qld__tag--filter-close-icon"></span><span class="sr-only">close</span></button></div>
                                         </li>
                                         <li>
-                                            <a href="https://www.sunshinecoast.health.qld.gov.au/about-us/news?tag=dental_health" class="qld__tag qld__tag--filter" tabindex="0">Filter<button class="qld__tag--filter-close" data-toggleUrl="{{toggleUrl}}"><span class="sr-only">close</span></button></a>
+                                            <div class="qld__tag qld__tag--filter" tabindex="0">Filter<button class="qld__tag--filter-close" data-toggleUrl="{{toggleUrl}}"><span class="qld__tag--filter-close-icon"></span><span class="sr-only">close</span></button></div>
                                         </li>
                                     </ul>
                                 </div>

--- a/src/html/component-tag_list.html
+++ b/src/html/component-tag_list.html
@@ -107,17 +107,21 @@
                                         </li>
                                     </ul>
                                     <h3>Tags - Applied filter</h3>
-                                    <ul class="qld__tag-list">
-                                        <li>
-                                            <div class="qld__tag qld__tag--filter" tabindex="0">Filter<button class="qld__tag--filter-close" data-toggleUrl="{{toggleUrl}}"><span class="qld__tag--filter-close-icon"></span><span class="sr-only">close</span></button></div>
-                                        </li>
-                                        <li>
-                                            <div class="qld__tag qld__tag--filter" tabindex="0">Filter<button class="qld__tag--filter-close" data-toggleUrl="{{toggleUrl}}"><span class="qld__tag--filter-close-icon"></span><span class="sr-only">close</span></button></div>
-                                        </li>
-                                        <li>
-                                            <div class="qld__tag qld__tag--filter" tabindex="0">Filter<button class="qld__tag--filter-close" data-toggleUrl="{{toggleUrl}}"><span class="qld__tag--filter-close-icon"></span><span class="sr-only">close</span></button></div>
-                                        </li>
-                                    </ul>
+                                    <div class="qld__tag-list--wrapper">
+                                        <span class="qld__tag-list--title">Filter by:</span>
+                                        <ul class="qld__tag-list">
+                                            <li>
+                                                <div class="qld__tag qld__tag--filter" tabindex="0">Filter<button class="qld__tag--filter-close" data-toggleUrl="{{toggleUrl}}"><span class="qld__tag--filter-close-icon"></span><span class="sr-only">close</span></button></div>
+                                            </li>
+                                            <li>
+                                                <div class="qld__tag qld__tag--filter" tabindex="0">Filter<button class="qld__tag--filter-close" data-toggleUrl="{{toggleUrl}}"><span class="qld__tag--filter-close-icon"></span><span class="sr-only">close</span></button></div>
+                                            </li>
+                                            <li>
+                                                <div class="qld__tag qld__tag--filter" tabindex="0">Filter<button class="qld__tag--filter-close" data-toggleUrl="{{toggleUrl}}"><span class="qld__tag--filter-close-icon"></span><span class="sr-only">close</span></button></div>
+                                            </li>
+                                        </ul>
+                                    </div>
+
                                 </div>
                             </div>
                             <div class="qld__body qld__body--alt">
@@ -172,17 +176,20 @@
                                         </li>
                                     </ul>
                                     <h3>Tags - Applied filter</h3>
-                                    <ul class="qld__tag-list">
-                                        <li>
-                                            <div class="qld__tag qld__tag--filter" tabindex="0">Filter<button class="qld__tag--filter-close" data-toggleUrl="{{toggleUrl}}"><span class="qld__tag--filter-close-icon"></span><span class="sr-only">close</span></button></div>
-                                        </li>
-                                        <li>
-                                            <div class="qld__tag qld__tag--filter" tabindex="0">Filter<button class="qld__tag--filter-close" data-toggleUrl="{{toggleUrl}}"><span class="qld__tag--filter-close-icon"></span><span class="sr-only">close</span></button></div>
-                                        </li>
-                                        <li>
-                                            <div class="qld__tag qld__tag--filter" tabindex="0">Filter<button class="qld__tag--filter-close" data-toggleUrl="{{toggleUrl}}"><span class="qld__tag--filter-close-icon"></span><span class="sr-only">close</span></button></div>
-                                        </li>
-                                    </ul>
+                                    <div class="qld__tag-list--wrapper">
+                                        <span class="qld__tag-list--title">Filter by:</span>
+                                        <ul class="qld__tag-list">
+                                            <li>
+                                                <div class="qld__tag qld__tag--filter" tabindex="0">Filter<button class="qld__tag--filter-close" data-toggleUrl="{{toggleUrl}}"><span class="qld__tag--filter-close-icon"></span><span class="sr-only">close</span></button></div>
+                                            </li>
+                                            <li>
+                                                <div class="qld__tag qld__tag--filter" tabindex="0">Filter<button class="qld__tag--filter-close" data-toggleUrl="{{toggleUrl}}"><span class="qld__tag--filter-close-icon"></span><span class="sr-only">close</span></button></div>
+                                            </li>
+                                            <li>
+                                                <div class="qld__tag qld__tag--filter" tabindex="0">Filter<button class="qld__tag--filter-close" data-toggleUrl="{{toggleUrl}}"><span class="qld__tag--filter-close-icon"></span><span class="sr-only">close</span></button></div>
+                                            </li>
+                                        </ul>
+                                    </div>
                                 </div>
                             </div>
                             <div class="qld__body qld__body--dark">
@@ -237,17 +244,20 @@
                                         </li>
                                     </ul>
                                     <h3>Tags - Applied filter</h3>
-                                    <ul class="qld__tag-list">
-                                        <li>
-                                            <div class="qld__tag qld__tag--filter" tabindex="0">Filter<button class="qld__tag--filter-close" data-toggleUrl="{{toggleUrl}}"><span class="qld__tag--filter-close-icon"></span><span class="sr-only">close</span></button></div>
-                                        </li>
-                                        <li>
-                                            <div class="qld__tag qld__tag--filter" tabindex="0">Filter<button class="qld__tag--filter-close" data-toggleUrl="{{toggleUrl}}"><span class="qld__tag--filter-close-icon"></span><span class="sr-only">close</span></button></div>
-                                        </li>
-                                        <li>
-                                            <div class="qld__tag qld__tag--filter" tabindex="0">Filter<button class="qld__tag--filter-close" data-toggleUrl="{{toggleUrl}}"><span class="qld__tag--filter-close-icon"></span><span class="sr-only">close</span></button></div>
-                                        </li>
-                                    </ul>
+                                    <div class="qld__tag-list--wrapper">
+                                        <span class="qld__tag-list--title">Filter by:</span>
+                                        <ul class="qld__tag-list">
+                                            <li>
+                                                <div class="qld__tag qld__tag--filter" tabindex="0">Filter<button class="qld__tag--filter-close" data-toggleUrl="{{toggleUrl}}"><span class="qld__tag--filter-close-icon"></span><span class="sr-only">close</span></button></div>
+                                            </li>
+                                            <li>
+                                                <div class="qld__tag qld__tag--filter" tabindex="0">Filter<button class="qld__tag--filter-close" data-toggleUrl="{{toggleUrl}}"><span class="qld__tag--filter-close-icon"></span><span class="sr-only">close</span></button></div>
+                                            </li>
+                                            <li>
+                                                <div class="qld__tag qld__tag--filter" tabindex="0">Filter<button class="qld__tag--filter-close" data-toggleUrl="{{toggleUrl}}"><span class="qld__tag--filter-close-icon"></span><span class="sr-only">close</span></button></div>
+                                            </li>
+                                        </ul>
+                                    </div>
                                 </div>
                             </div>
                             <div class="qld__body qld__body--dark-alt">
@@ -302,17 +312,20 @@
                                         </li>
                                     </ul>
                                     <h3>Tags - Applied filter</h3>
-                                    <ul class="qld__tag-list">
-                                        <li>
-                                            <div class="qld__tag qld__tag--filter" tabindex="0">Filter<button class="qld__tag--filter-close" data-toggleUrl="{{toggleUrl}}"><span class="qld__tag--filter-close-icon"></span><span class="sr-only">close</span></button></div>
-                                        </li>
-                                        <li>
-                                            <div href="https://www.sunshinecoast.health.qld.gov.au/about-us/news?tag=staff" class="qld__tag qld__tag--filter" tabindex="0">Filter<button class="qld__tag--filter-close" data-toggleUrl="{{toggleUrl}}"><span class="qld__tag--filter-close-icon"></span><span class="sr-only">close</span></button></div>
-                                        </li>
-                                        <li>
-                                            <div class="qld__tag qld__tag--filter" tabindex="0">Filter<button class="qld__tag--filter-close" data-toggleUrl="{{toggleUrl}}"><span class="qld__tag--filter-close-icon"></span><span class="sr-only">close</span></button></div>
-                                        </li>
-                                    </ul>
+                                    <div class="qld__tag-list--wrapper">
+                                        <span class="qld__tag-list--title">Filter by:</span>
+                                        <ul class="qld__tag-list">
+                                            <li>
+                                                <div class="qld__tag qld__tag--filter" tabindex="0">Filter<button class="qld__tag--filter-close" data-toggleUrl="{{toggleUrl}}"><span class="qld__tag--filter-close-icon"></span><span class="sr-only">close</span></button></div>
+                                            </li>
+                                            <li>
+                                                <div href="https://www.sunshinecoast.health.qld.gov.au/about-us/news?tag=staff" class="qld__tag qld__tag--filter" tabindex="0">Filter<button class="qld__tag--filter-close" data-toggleUrl="{{toggleUrl}}"><span class="qld__tag--filter-close-icon"></span><span class="sr-only">close</span></button></div>
+                                            </li>
+                                            <li>
+                                                <div class="qld__tag qld__tag--filter" tabindex="0">Filter<button class="qld__tag--filter-close" data-toggleUrl="{{toggleUrl}}"><span class="qld__tag--filter-close-icon"></span><span class="sr-only">close</span></button></div>
+                                            </li>
+                                        </ul>
+                                    </div>
                                 </div>
                             </div>
                         </div>


### PR DESCRIPTION
Update structure and styles for tags

This pull request includes changes to the styling and structure of the tag components in the SCSS and HTML files to improve the layout and accessibility.

### SCSS Changes:

* Added new styles for the `qld__tag-list--wrapper` and `qld__tag-list--title` classes to improve the layout and alignment of tag lists.
* Updated the `qld__tag--filter-close` class to include new styles for focus state and improved accessibility.
* Modified the `qld__tag--filter-close-icon` class to adjust the margin and background color. [[1]](diffhunk://#diff-1afa2de127670e3587fb10b831556ef10b72352e6927a9cc9ac5883de70db696L210-L231) [[2]](diffhunk://#diff-1afa2de127670e3587fb10b831556ef10b72352e6927a9cc9ac5883de70db696L274-R319)

### HTML Changes:

* Wrapped the applied filter tags in a new `qld__tag-list--wrapper` div and added a `qld__tag-list--title` span to provide a clearer structure. [[1]](diffhunk://#diff-ff59af05347f1abfcf5b39402e6664b345ef618e57971132764e9d5d6296ea23R110-R125) [[2]](diffhunk://#diff-ff59af05347f1abfcf5b39402e6664b345ef618e57971132764e9d5d6296ea23R179-R194) [[3]](diffhunk://#diff-ff59af05347f1abfcf5b39402e6664b345ef618e57971132764e9d5d6296ea23R247-R262) [[4]](diffhunk://#diff-ff59af05347f1abfcf5b39402e6664b345ef618e57971132764e9d5d6296ea23R315-R325)
* Replaced the `<a>` tags with `<div>` tags for the filter tags to enhance accessibility and structure. [[1]](diffhunk://#diff-ff59af05347f1abfcf5b39402e6664b345ef618e57971132764e9d5d6296ea23R110-R125) [[2]](diffhunk://#diff-ff59af05347f1abfcf5b39402e6664b345ef618e57971132764e9d5d6296ea23R179-R194) [[3]](diffhunk://#diff-ff59af05347f1abfcf5b39402e6664b345ef618e57971132764e9d5d6296ea23R247-R262) [[4]](diffhunk://#diff-ff59af05347f1abfcf5b39402e6664b345ef618e57971132764e9d5d6296ea23R315-R325)

These changes collectively improve the layout, alignment, and accessibility of the tag components.

