### PR TITLE
Remove describedby from a tag

### DIFF
--- a/src/components/card_feature/html/component.hbs
+++ b/src/components/card_feature/html/component.hbs
@@ -43,7 +43,7 @@
                             <div class="qld__card__icon"><i class="{{metadata.card_icon.value}}"></i></div>
                         {{/ifCond}} 
                         {{#ifCond metadata.show_icon_image.value '==' 'image'}}
-                            <a aria-label="{{metadata.card_title.value}}" {{#if metadata.shortDescription.value}}aria-describedby="card-{{assetid}}"{{/if}} class="qld__card__image-link" href="./?a={{metadata.card_title_url.value}}">
+                            <a aria-label="{{metadata.card_title.value}}" class="qld__card__image-link" href="./?a={{metadata.card_title_url.value}}">
 
                                 <div class="qld__responsive-media-img--bg" style="background-image: url('./?a={{metadata.card_image.value}}');" {{#if ../component.image_alt}}role="img" aria-label="{{../component.image_alt}}"{{/if}}></div>
 
@@ -55,7 +55,7 @@
                                 <div class="qld__card__content-inner">
                                     {{#if metadata.card_title_url.value}}
                                     <h3 class="qld__card__title">
-                                        <a aria-label="{{metadata.card_title.value}}" {{#if metadata.shortDescription.value}}aria-describedby="card-{{assetid}}"{{/if}} class="qld__card--clickable__link" href="./?a={{metadata.card_title_url.value}}">{{metadata.card_title.value}}</a>   
+                                        <a aria-label="{{metadata.card_title.value}}" class="qld__card--clickable__link" href="./?a={{metadata.card_title_url.value}}">{{metadata.card_title.value}}</a>   
                                     </h3>
                                     {{/if}}
                                     {{#if metadata.body_text.value}}


### PR DESCRIPTION
Remove describedby from a tag
This pull request includes changes to the `src/components/card_feature/html/component.hbs` file to improve accessibility and simplify the code. The most important changes are:

Accessibility improvements:

* Removed unnecessary `aria-describedby` attributes from the anchor tags to streamline the HTML and ensure better accessibility. [[1]](diffhunk://#diff-14068a92e2ce0a38779b3cbbad93af25aff2038593fb976649fb7974045fafacL46-R46) [[2]](diffhunk://#diff-14068a92e2ce0a38779b3cbbad93af25aff2038593fb976649fb7974045fafacL58-R58)