### PR TITLE
Fix/breadcrumbs chevron qhwt 1239

### DIFF
--- a/src/components/breadcrumbs/css/component.scss
+++ b/src/components/breadcrumbs/css/component.scss
@@ -133,7 +133,8 @@
         color: var(--QLD-color-dark__text--lighter);
         
         > .qld__link-list {
-            > .qld__breadcrumbs__item:not(:last-child){
+            > .qld__breadcrumbs__item:not(:last-child),
+            > .qld__overflow_menu--breadcrumbs {
                 &::after{
                     background-color: var(--QLD-color-dark__action--secondary);
                 }

--- a/src/components/breadcrumbs/js/global.js
+++ b/src/components/breadcrumbs/js/global.js
@@ -141,7 +141,7 @@
     
     function appendOverflow( breadCrumbsUlLis, overflowMenu, breadcrumbUL) {
         breadCrumbsUlLis[1].innerHTML = "";
-        breadCrumbsUlLis[1].className = "qld__overflow_menu--breadcrumbs qld__breadcrumbs__item";
+        breadCrumbsUlLis[1].className = "qld__overflow_menu--breadcrumbs";
         breadCrumbsUlLis[1].appendChild(overflowMenu);
         breadCrumbsUlLis[1].style.display = "flex";
     }

--- a/src/components/breadcrumbs/js/global.js
+++ b/src/components/breadcrumbs/js/global.js
@@ -141,7 +141,7 @@
     
     function appendOverflow( breadCrumbsUlLis, overflowMenu, breadcrumbUL) {
         breadCrumbsUlLis[1].innerHTML = "";
-        breadCrumbsUlLis[1].className = "qld__overflow_menu--breadcrumbs";
+        breadCrumbsUlLis[1].className.add("qld__overflow_menu--breadcrumbs","qld__overflow_menu--breadcrumbs");
         breadCrumbsUlLis[1].appendChild(overflowMenu);
         breadCrumbsUlLis[1].style.display = "flex";
     }

--- a/src/components/breadcrumbs/js/global.js
+++ b/src/components/breadcrumbs/js/global.js
@@ -141,7 +141,7 @@
     
     function appendOverflow( breadCrumbsUlLis, overflowMenu, breadcrumbUL) {
         breadCrumbsUlLis[1].innerHTML = "";
-        breadCrumbsUlLis[1].className.add("qld__overflow_menu--breadcrumbs","qld__overflow_menu--breadcrumbs");
+        breadCrumbsUlLis[1].className = "qld__overflow_menu--breadcrumbs qld__breadcrumbs__item");
         breadCrumbsUlLis[1].appendChild(overflowMenu);
         breadCrumbsUlLis[1].style.display = "flex";
     }

--- a/src/components/breadcrumbs/js/global.js
+++ b/src/components/breadcrumbs/js/global.js
@@ -141,7 +141,7 @@
     
     function appendOverflow( breadCrumbsUlLis, overflowMenu, breadcrumbUL) {
         breadCrumbsUlLis[1].innerHTML = "";
-        breadCrumbsUlLis[1].className = "qld__overflow_menu--breadcrumbs qld__breadcrumbs__item");
+        breadCrumbsUlLis[1].className = "qld__overflow_menu--breadcrumbs qld__breadcrumbs__item";
         breadCrumbsUlLis[1].appendChild(overflowMenu);
         breadCrumbsUlLis[1].style.display = "flex";
     }


### PR DESCRIPTION
Update the chevron colour for the overflow breadcrumb.

This pull request includes a small but important change to the `src/components/breadcrumbs/css/component.scss` file. The change ensures that the `qld__overflow_menu--breadcrumbs` class is styled consistently with other breadcrumb items.

Styling consistency:

* [`src/components/breadcrumbs/css/component.scss`](diffhunk://#diff-c9fc5116312e9a8de14f60fb23058d8b41d5027ccc6439ec1d67ca1e25ae1929L136-R137): Added the `qld__overflow_menu--breadcrumbs` class to the list of breadcrumb items that should have a specific `::after` pseudo-element style.