### PR TITLE
Make Hint Text Accessible in Form Fields

### DIFF
--- a/src/components/_global/js/forms/global.js
+++ b/src/components/_global/js/forms/global.js
@@ -280,7 +280,7 @@
         }
     }
 
-    function linkHinttext($form) {
+    function linkHintText($form) {
         var $allFields = $form.find('.sq-form-question-answer');
     
         $allFields.each(function() {

--- a/src/components/_global/js/forms/global.js
+++ b/src/components/_global/js/forms/global.js
@@ -103,6 +103,8 @@
             //Add data auto complete to date field ---Matrix bug fix---
             dobFieldAutocomplete($form);
 
+            linkHintText($form);
+
             // Validate select fields when option is selected
             $form.find('select').on('change', function() {
                 console.log('select change');
@@ -277,5 +279,36 @@
             $(field).addClass('hidden');
         }
     }
+
+    function linkHinttext($form) {
+        var $allFields = $form.find('.sq-form-question-answer');
     
+        $allFields.each(function() {
+            var $field = $(this);
+    
+            // Get the direct child input/textarea/select element
+            var $inputElement = $field.find('input, textarea, select').first();
+    
+            if ($inputElement.length) {
+                // Get the ID of the input element
+                var inputId = $inputElement.attr('id');
+    
+                if (inputId) {
+                    // Find the sibling <em> element in the parent .sq-form-question
+                    var $hintElement = $field.closest('.sq-form-question').find('em').first();
+    
+                    if ($hintElement.length) {
+                        // Create a unique ID for the <em> element
+                        var hintId = inputId + '_hint';
+    
+                        // Apply the unique ID to the <em> element
+                        $hintElement.attr('id', hintId);
+    
+                        // Add the 'aria-describedby' attribute to the input element
+                        $inputElement.attr('aria-describedby', hintId);
+                    }
+                }
+            }
+        });
+    }
 }());

--- a/src/components/_global/js/forms/global.js
+++ b/src/components/_global/js/forms/global.js
@@ -103,13 +103,18 @@
             //Add data auto complete to date field ---Matrix bug fix---
             dobFieldAutocomplete($form);
 
-            linkHintText($form);
+            
+
 
             // Validate select fields when option is selected
             $form.find('select').on('change', function() {
                 console.log('select change');
                 $(this).valid();
             });
+        });
+
+        $('form').each(function() {
+            linkHintText($form);
         });
 
         $('[data-displayif-show]').each(function() {
@@ -282,7 +287,10 @@
 
     function linkHintText($form) {
         var $allFields = $form.find('.sq-form-question-answer');
-    
+        // Check if any fields are found before proceeding
+        if ($allFields.length === 0) {
+            return; // Exit early if no fields are found
+        }
         $allFields.each(function() {
             var $field = $(this);
     

--- a/src/components/_global/js/forms/global.js
+++ b/src/components/_global/js/forms/global.js
@@ -114,6 +114,7 @@
         });
 
         $('form').each(function() {
+            var $form = $(this);
             linkHintText($form);
         });
 
@@ -287,10 +288,12 @@
 
     function linkHintText($form) {
         var $allFields = $form.find('.sq-form-question-answer');
+
         // Check if any fields are found before proceeding
         if ($allFields.length === 0) {
             return; // Exit early if no fields are found
         }
+
         $allFields.each(function() {
             var $field = $(this);
     

--- a/src/html/component-forms.html
+++ b/src/html/component-forms.html
@@ -56,7 +56,7 @@
                         <div class="qld__abstract">
                             <p>Form desc</p>
                         </div>
-                        <div class="qld__body">
+                        <div class="qld__body qld__form">
                             <div class="container-fluid">
                                 <h2>Default (Light)</h2>
                                 <fieldset>


### PR DESCRIPTION
Make Hint Text Accessible in Form Fields

This pull request includes several changes to the `src/components/_global/js/forms/global.js` file and a minor change to the `src/html/component-forms.html` file. The changes focus on adding new functionality for form validation and accessibility improvements.

### Form validation and accessibility improvements:

* Added a new function `linkHintText` to associate hint text with form fields using `aria-describedby` for better accessibility.
* Modified the form initialization to call the `linkHintText` function for each form.

### Minor HTML update:

* Updated the class of a `div` element to `qld__body qld__form` for better styling consistency.