### PR TITLE
Break email text to fit container

### DIFF
--- a/src/styles/global.scss
+++ b/src/styles/global.scss
@@ -96,6 +96,11 @@ textarea {
     font-size: inherit;
     line-height: inherit;
 }
+
+a[href^="mailto:"] {
+    overflow-wrap: break-word;
+}
+
 .qld__body fieldset, fieldset {
     padding:0;
 }


### PR DESCRIPTION
Adjust email text to fit within the container

This pull request includes a small change to the `src/styles/global.scss` file. The change adds a new style rule to handle email links by breaking long words to improve readability.

Styling update:

* [`src/styles/global.scss`](diffhunk://#diff-2c0189636ff225dd87da97bcea9b585e70a25a5f601b816456f20bf146bec8adR99-R103): Added a new CSS rule to apply `overflow-wrap: break-word;` to email links (`a[href^="mailto:"]`).