### PR TITLE
QHWT-859: Update main-nav component to only render after dom load

### DIFF
--- a/src/components/main_navigation/html/component.hbs
+++ b/src/components/main_navigation/html/component.hbs
@@ -5,7 +5,7 @@
             <div class="qld__main-nav__menu
             {{#ifCond site.metadata.sitePreHeaderTheme.value '==' 'qld__header__pre-header--dark'}}qld__main-nav__menu--dark{{/ifCond}}
             {{#ifCond site.metadata.sitePreHeaderTheme.value '==' 'qld__header__pre-header--dark-alt'}}qld__main-nav__menu--dark-alt{{/ifCond}}
-            ">
+            " style="display: none;">
                 <div class="qld__main-nav__menu-inner">
                     <div class="qld__main-nav__focus-trap-top"></div>
                     <div class="qld__main-nav__header">

--- a/src/components/main_navigation/html/component.hbs
+++ b/src/components/main_navigation/html/component.hbs
@@ -5,7 +5,7 @@
             <div class="qld__main-nav__menu
             {{#ifCond site.metadata.sitePreHeaderTheme.value '==' 'qld__header__pre-header--dark'}}qld__main-nav__menu--dark{{/ifCond}}
             {{#ifCond site.metadata.sitePreHeaderTheme.value '==' 'qld__header__pre-header--dark-alt'}}qld__main-nav__menu--dark-alt{{/ifCond}}
-            " style="display: none;">
+            ">
                 <div class="qld__main-nav__menu-inner">
                     <div class="qld__main-nav__focus-trap-top"></div>
                     <div class="qld__main-nav__header">

--- a/src/components/main_navigation/js/global.js
+++ b/src/components/main_navigation/js/global.js
@@ -338,6 +338,11 @@
 
    
     window.addEventListener('DOMContentLoaded', function () {
+        // Remove all inline styling from the main navs
+        var mainNavs = this.document.querySelectorAll("#main-nav > div.qld__main-nav__menu");
+        mainNavs.forEach(function (nav) {
+            nav.removeAttribute("style");
+        });
         
         // Add toggle event to open mobile nav
         var navToggles = document.querySelectorAll('*[aria-controls="main-nav"]');

--- a/src/components/main_navigation/js/global.js
+++ b/src/components/main_navigation/js/global.js
@@ -338,11 +338,6 @@
 
    
     window.addEventListener('DOMContentLoaded', function () {
-        // Remove all inline styling from the main navs
-        var mainNavs = this.document.querySelectorAll("#main-nav > div.qld__main-nav__menu");
-        mainNavs.forEach(function (nav) {
-            nav.removeAttribute("style");
-        });
         
         // Add toggle event to open mobile nav
         var navToggles = document.querySelectorAll('*[aria-controls="main-nav"]');

--- a/src/components/mega_main_navigation/html/component.hbs
+++ b/src/components/mega_main_navigation/html/component.hbs
@@ -5,7 +5,7 @@
             <div class="qld__main-nav__menu
             {{#ifCond site.metadata.sitePreHeaderTheme.value '==' 'qld__header__pre-header--dark'}}qld__main-nav__menu--dark{{/ifCond}}
             {{#ifCond site.metadata.sitePreHeaderTheme.value '==' 'qld__header__pre-header--dark-alt'}}qld__main-nav__menu--dark-alt{{/ifCond}}
-            ">
+            " style="display: none;">
                 <div class="qld__main-nav__menu-inner">
                     <div class="qld__main-nav__focus-trap-top"></div>
                     <div class="qld__main-nav__header">

--- a/src/components/mega_main_navigation/html/component.hbs
+++ b/src/components/mega_main_navigation/html/component.hbs
@@ -5,7 +5,7 @@
             <div class="qld__main-nav__menu
             {{#ifCond site.metadata.sitePreHeaderTheme.value '==' 'qld__header__pre-header--dark'}}qld__main-nav__menu--dark{{/ifCond}}
             {{#ifCond site.metadata.sitePreHeaderTheme.value '==' 'qld__header__pre-header--dark-alt'}}qld__main-nav__menu--dark-alt{{/ifCond}}
-            " style="display: none;">
+            ">
                 <div class="qld__main-nav__menu-inner">
                     <div class="qld__main-nav__focus-trap-top"></div>
                     <div class="qld__main-nav__header">


### PR DESCRIPTION
https://squizgroup.atlassian.net/browse/QHWT-859

Changes made:
- Add inline styling on the component template files to hide the nav bar
- Add JS to remove the inline styling on page load

Test the development sites at:
- https://qhonline.com.au/qgds-development/_nocache
- https://qhonline.com.au/qgds-development-extended

Compare with the previous functionality as shown in the document attached to ticket QHWT-859.