### PR TITLE
QHWT-1276 | Header | Update svg icons

### DIFF
--- a/src/components/header/html/component.hbs
+++ b/src/components/header/html/component.hbs
@@ -50,13 +50,13 @@
             <div class="qld__header__main-nav-controls">
                 {{#if site.metadata.siteSearchAsset.value}}
                 <button aria-controls="qld-header-search" class="qld__header__toggle-main-nav qld__main-nav__toggle-search qld__main-nav__toggle-search--open" aria-expanded="false">
-                    <svg aria-hidden="true" focusable="false" xmlns="http://www.w3.org/2000/svg" class="qld__icon qld__icon--lg qld__main-nav__toggle-search-icon"><use href="{{@root.site.metadata.siteDefaultIcons.value}}#qld__icon__search"></use></svg> 
-                    <svg aria-hidden="true" focusable="false" xmlns="http://www.w3.org/2000/svg" class="qld__icon qld__icon--lg qld__main-nav__toggle-search-close-icon"><use href="{{@root.site.metadata.siteDefaultIcons.value}}#qld__icon__close"></use></svg> 
+                    <svg class="qld__icon qld__icon--lg qld__main-nav__toggle-search-icon" role="img" aria-hidden="true" focusable="false" xmlns="http://www.w3.org/2000/svg"><use href="{{@root.site.metadata.coreSiteIcons.value}}#search"></use></svg> 
+                    <svg class="qld__icon qld__icon--lg qld__main-nav__toggle-search-close-icon" role="img" aria-hidden="true" focusable="false" xmlns="http://www.w3.org/2000/svg"><use href="{{@root.site.metadata.coreSiteIcons.value}}#close"></use></svg> 
                     <span class="qld__main-nav__toggle-text">Search</span>
                 </button>
                 {{/if}}
                 <button aria-controls="main-nav" class="qld__header__toggle-main-nav qld__main-nav__toggle--open">
-                    <svg aria-hidden="true" focusable="false" xmlns="http://www.w3.org/2000/svg" class="qld__icon qld__icon--lg"><use href="{{@root.site.metadata.siteDefaultIcons.value}}#qld__icon__mobile-menu"></use></svg>
+                    <svg class="qld__icon qld__icon--lg" role="img" aria-hidden="true" focusable="false" xmlns="http://www.w3.org/2000/svg"><use href="{{@root.site.metadata.coreSiteIcons.value}}#menu"></use></svg>
                     <span class="qld__main-nav__toggle-text">Menu</span>
                 </button>
             </div>

--- a/src/components/header/html/component.hbs
+++ b/src/components/header/html/component.hbs
@@ -50,13 +50,13 @@
             <div class="qld__header__main-nav-controls">
                 {{#if site.metadata.siteSearchAsset.value}}
                 <button aria-controls="qld-header-search" class="qld__header__toggle-main-nav qld__main-nav__toggle-search qld__main-nav__toggle-search--open" aria-expanded="false">
-                    <svg class="qld__icon qld__icon--lg qld__main-nav__toggle-search-icon" role="img" aria-hidden="true" focusable="false" xmlns="http://www.w3.org/2000/svg"><use href="{{@root.site.metadata.coreSiteIcons.value}}#search"></use></svg> 
-                    <svg class="qld__icon qld__icon--lg qld__main-nav__toggle-search-close-icon" role="img" aria-hidden="true" focusable="false" xmlns="http://www.w3.org/2000/svg"><use href="{{@root.site.metadata.coreSiteIcons.value}}#close"></use></svg> 
+                    <svg class="qld__icon qld__main-nav__toggle-search-icon" aria-hidden="true" focusable="false" xmlns="http://www.w3.org/2000/svg"><use href="{{@root.site.metadata.coreSiteIcons.value}}#search"></use></svg> 
+                    <svg class="qld__icon qld__main-nav__toggle-search-close-icon" aria-hidden="true" focusable="false" xmlns="http://www.w3.org/2000/svg"><use href="{{@root.site.metadata.coreSiteIcons.value}}#close"></use></svg> 
                     <span class="qld__main-nav__toggle-text">Search</span>
                 </button>
                 {{/if}}
                 <button aria-controls="main-nav" class="qld__header__toggle-main-nav qld__main-nav__toggle--open">
-                    <svg class="qld__icon qld__icon--lg" role="img" aria-hidden="true" focusable="false" xmlns="http://www.w3.org/2000/svg"><use href="{{@root.site.metadata.coreSiteIcons.value}}#menu"></use></svg>
+                    <svg class="qld__icon" aria-hidden="true" focusable="false" xmlns="http://www.w3.org/2000/svg"><use href="{{@root.site.metadata.coreSiteIcons.value}}#menu"></use></svg>
                     <span class="qld__main-nav__toggle-text">Menu</span>
                 </button>
             </div>


### PR DESCRIPTION
https://squizgroup.atlassian.net/browse/QHWT-1276

This pull request includes changes to the `src/components/header/html/component.hbs` file to update the source of SVG icons used in the header component. 

Updates to SVG icon references:
- [src/components/header/html/component.hbs](https://github.com/Qld-Health-Online-Team/design-system/commit/d4ddc149bddb6f45ab97a3785da6b0b1526db6f6#diff-0fefeb5a96968b15037fcee3b4d70d411f4725e63317fbf0dbdddde72e4b30bc): Changed the use element references for search, close, and menu icons to use coreSiteIcons instead of siteDefaultIcons

Testing sites:
- https://qhonline.com.au/qgds-development/component-core
- https://www.designsystem.qld.gov.au/

Testing instructions:
- Compare icon changes, and that the url path to the svgs are updated
- Check accessibility using a screen reader
- Check pages in high contrast mode to ensure component elements are visible