### PR TITLE
QHWT-1272 | Back to top | Update svg icons and styling

### DIFF
--- a/src/components/updated_date/html/component.hbs
+++ b/src/components/updated_date/html/component.hbs
@@ -1,68 +1,73 @@
-{{#ifCond current.data.metadata.displayLastUpdated.value '==' 'yes'}}
-    {{#ifCond current.data.metadata.pageType.value '==' 'landing'}} 
+{{#ifCond current.data.metadata.displayLastUpdated.value "==" "yes"}}
+    {{#ifCond current.data.metadata.pageType.value "==" "landing"}}
         <section class="qld__body qld__pre-footer">
             <div class="container-fluid">
                 <p><strong style="padding-right: 12px;">Last updated:</strong>&nbsp;{{formatDate current.data.updated "F Y"}}</p>
                 {{#if site.metadata.siteBackToTopShow.value}}
-                <div class="qld__widgets__back_to_top">
-                    <a href="#content" class="qld__btn qld__btn--floating qld__btn--back-to-top show" aria-label="Back to top">
-                        <span>Back to top</span>
-                    </a>
-                </div>
+                    <div class="qld__widgets__back_to_top">
+                        <a href="#content" class="qld__btn qld__btn--floating qld__btn--back-to-top show" aria-label="Back to top">
+                            <span>Back to top</span>
+                            <svg class="qld__icon qld__icon--sm" role="img" aria-hidden="true" focusable="false" xmlns="http://www.w3.org/2000/svg"><use href="{{@root.site.metadata.coreSiteIcons.value}}#arrow-up"></use></svg>
+                        </a>
+                    </div>
                 {{/if}}
             </div>
         </section>
     {{/ifCond}}
-    {{#ifCond current.data.metadata.pageType.value '==' 'news_detail'}}
-         <section class="qld__body qld__pre-footer">
+    {{#ifCond current.data.metadata.pageType.value "==" "news_detail"}}
+        <section class="qld__body qld__pre-footer">
             <div class="container-fluid">
                 <p><strong style="padding-right: 12px;">Last updated:</strong>&nbsp;{{formatDate current.data.updated "F Y"}}</p>
                 {{#if site.metadata.siteBackToTopShow.value}}
-                <div class="qld__widgets__back_to_top">
-                    <a href="#content" class="qld__btn qld__btn--floating qld__btn--back-to-top show" aria-label="Back to top">
-                        <span>Back to top</span>
-                    </a>
-                </div>
+                    <div class="qld__widgets__back_to_top">
+                        <a href="#content" class="qld__btn qld__btn--floating qld__btn--back-to-top show" aria-label="Back to top">
+                            <span>Back to top</span>
+                            <svg class="qld__icon qld__icon--sm" role="img" aria-hidden="true" focusable="false" xmlns="http://www.w3.org/2000/svg"><use href="{{@root.site.metadata.coreSiteIcons.value}}#arrow-up"></use></svg>
+                        </a>
+                    </div>
                 {{/if}}
             </div>
         </section>
     {{/ifCond}}
-    {{#ifCond current.data.metadata.pageType.value '==' 'content'}}
-         <section class="qld__body qld__pre-footer">
+    {{#ifCond current.data.metadata.pageType.value "==" "content"}}
+        <section class="qld__body qld__pre-footer">
             <div class="container-fluid">
                 <p><strong style="padding-right: 12px;">Last updated:</strong>&nbsp;{{formatDate current.data.updated "F Y"}}</p>
                 {{#if site.metadata.siteBackToTopShow.value}}
-                <div class="qld__widgets__back_to_top">
-                    <a href="#content" class="qld__btn qld__btn--floating qld__btn--back-to-top show" aria-label="Back to top">
-                        <span>Back to top</span>
-                    </a>
-                </div>
+                    <div class="qld__widgets__back_to_top">
+                        <a href="#content" class="qld__btn qld__btn--floating qld__btn--back-to-top show" aria-label="Back to top">
+                            <span>Back to top</span>
+                            <svg class="qld__icon qld__icon--sm" role="img" aria-hidden="true" focusable="false" xmlns="http://www.w3.org/2000/svg"><use href="{{@root.site.metadata.coreSiteIcons.value}}#arrow-up"></use></svg>
+                        </a>
+                    </div>
                 {{/if}}
             </div>
         </section>
     {{/ifCond}}
-    {{#ifCond current.data.metadata.pageType.value '==' 'site_search'}} 
-         <section class="qld__body qld__pre-footer">
+    {{#ifCond current.data.metadata.pageType.value "==" "site_search"}}
+        <section class="qld__body qld__pre-footer">
             <div class="container-fluid">
                 <p><strong style="padding-right: 12px;">Last updated:</strong>&nbsp;{{formatDate current.data.updated "F Y"}}</p>
                 {{#if site.metadata.siteBackToTopShow.value}}
-                <div class="qld__widgets__back_to_top">
-                    <a href="#content" class="qld__btn qld__btn--floating qld__btn--back-to-top show" aria-label="Back to top">
-                        <span>Back to top</span>
-                    </a>
-                </div>
+                    <div class="qld__widgets__back_to_top">
+                        <a href="#content" class="qld__btn qld__btn--floating qld__btn--back-to-top show" aria-label="Back to top">
+                            <span>Back to top</span>
+                            <svg class="qld__icon qld__icon--sm" role="img" aria-hidden="true" focusable="false" xmlns="http://www.w3.org/2000/svg"><use href="{{@root.site.metadata.coreSiteIcons.value}}#arrow-up"></use></svg>
+                        </a>
+                    </div>
                 {{/if}}
             </div>
         </section>
     {{/ifCond}}
 {{/ifCond}}
 
-{{#ifCond current.data.metadata.displayLastUpdated.value '==' 'no'}}
+{{#ifCond current.data.metadata.displayLastUpdated.value "==" "no"}}
     {{#if site.metadata.siteBackToTopShow.value}}
-    <div class="qld__widgets__back_to_top">
-        <a href="#content" class="qld__btn qld__btn--floating qld__btn--back-to-top show" aria-label="Back to top">
-            <span>Back to top</span>
-        </a>
-    </div>
+        <div class="qld__widgets__back_to_top">
+            <a href="#content" class="qld__btn qld__btn--floating qld__btn--back-to-top show" aria-label="Back to top">
+                <span>Back to top</span>
+                <svg class="qld__icon qld__icon--sm" role="img" aria-hidden="true" focusable="false" xmlns="http://www.w3.org/2000/svg"><use href="{{@root.site.metadata.coreSiteIcons.value}}#arrow-up"></use></svg>
+            </a>
+        </div>
     {{/if}}
 {{/ifCond}}

--- a/src/components/widgets/css/component.scss
+++ b/src/components/widgets/css/component.scss
@@ -16,10 +16,9 @@
     align-items: flex-end;
     right: 0;
 
-    @include QLD-media (md) {
+    @include QLD-media(md) {
         padding-right: 2rem;
     }
-    
 
     .qld__btn--floating {
         box-shadow: none;
@@ -45,28 +44,47 @@ body a.qld__btn.qld__btn--floating.qld__btn--back-to-top {
     border-color: $QLD-color-neutral--lightest;
     color: var(--QLD-color-light__link);
     padding: 0.5rem 1rem;
-    
-    &:after {
-        @include QLD-space( width, 1unit );
-        @include QLD-space( height, 1unit );
-        @include QLD-space( margin, 0 0.25unit );
-        content: '↑';
+    line-height: 0; // Aligns the span with the svg
+
+    span,
+    svg {
+        vertical-align: middle;
+    }
+
+    svg {
         color: var(--QLD-color-light__action--secondary);
-        display: inline-block;
-        width: auto;
-        height: auto;
     }
 
     &:hover,
     &:focus,
     &:active {
         background-color: var(--QLD-color-light__background--alt-shade);
-        border-color:  var(--QLD-color-light__background--alt-shade);
+        border-color: var(--QLD-color-light__background--alt-shade);
         color: var(--QLD-color-light__link);
-        text-decoration-color: var(--QLD-color-light__link);
-        &::after{
-            content: '↑';
+        text-decoration: none;
+
+        svg {
             color: var(--QLD-color-light__action--secondary-hover);
+        }
+    }
+
+    &:hover span {
+        text-decoration: underline;
+        text-decoration-thickness: 2px;
+        text-decoration-color: var(--QLD-color-light__link);
+    }
+
+    @media (prefers-contrast: more) {
+        svg {
+            color: revert;
+        }
+
+        &:hover,
+        &:focus,
+        &:active {
+            svg {
+                color: revert;
+            }
         }
     }
 }


### PR DESCRIPTION
https://squizgroup.atlassian.net/browse/QHWT-1272

This pull request includes changes to the `src/components/updated_date/html/component.hbs` and `src/components/widgets/css/component.scss` files to update the source of SVG icons used in the back to top (updated date) component.

Updates to SVG icon references:
- [src/components/updated_date/html/component.hbs](https://github.com/Qld-Health-Online-Team/design-system/commit/0759eadfcad9800606c71dea2bcdb54eec08f913#diff-ad8ba1636509c5d4006e17a1c54eb21c9f6546a8f30a77bda0a6f46ad431212e): Added in-line svg elements to use the arrow-up icon. The `use` element within references `coreSiteIcons`

Updates to stylesheet:
- [src/components/widgets/css/component.scss](https://github.com/Qld-Health-Online-Team/design-system/commit/0759eadfcad9800606c71dea2bcdb54eec08f913#diff-734451c2f70e15271f0429621c704dabd45bf8f8b035c27c1a9d7ffc9dc50897)
  - Remove previous code that utilises `content: '↑'` to display the icon
  - Add rules to target the new svg element, mimicking previous behavior
  - Move the underline text decoration from the `a` element onto the `span` element
  - Add the media query `prefers-contrast: more` to specifically target high contrast mode

Testing sites (bottom of page):

- https://qhonline.com.au/qgds-development/component-core
- https://www.designsystem.qld.gov.au/

Testing instructions:
- Compare icon changes, and that the url path to the svgs are updated
- Check accessibility using a screen reader
- Check pages in high contrast mode to ensure component elements are visible