### PR TITLE
QHWT-1280 | Breadcrumbs | Update chevron styling

### DIFF
--- a/src/components/banner/html/component.hbs
+++ b/src/components/banner/html/component.hbs
@@ -15,7 +15,7 @@
 >
 <!--@@ Breadcrumbs - Mobile @@-->
 {{#ifCond current.data.metadata.displayBreadcrumbs.value '==' 'true'}}
-    <nav class="qld__breadcrumbs qld__banner__breadcrumbs qld__banner__breadcrumbs--mobile" aria-label="breadcrumb" data-path="{{@root.site.metadata.coreSiteIcons.value}}">
+    <nav class="qld__breadcrumbs qld__banner__breadcrumbs qld__banner__breadcrumbs--mobile" aria-label="breadcrumb">
         <div class="qld__link-list qld__link-list--inline">
             {{#with (itemAt current.lineage -2)}}
             {{#ifCond asset_type_code '!=' 'folder'}}  

--- a/src/components/banner/html/component.hbs
+++ b/src/components/banner/html/component.hbs
@@ -15,7 +15,7 @@
 >
 <!--@@ Breadcrumbs - Mobile @@-->
 {{#ifCond current.data.metadata.displayBreadcrumbs.value '==' 'true'}}
-    <nav class="qld__breadcrumbs qld__banner__breadcrumbs qld__banner__breadcrumbs--mobile" aria-label="breadcrumb">
+    <nav class="qld__breadcrumbs qld__banner__breadcrumbs qld__banner__breadcrumbs--mobile" aria-label="breadcrumb" data-path="{{@root.site.metadata.coreSiteIcons.value}}">
         <div class="qld__link-list qld__link-list--inline">
             {{#with (itemAt current.lineage -2)}}
             {{#ifCond asset_type_code '!=' 'folder'}}  
@@ -40,7 +40,7 @@
                 <nav class="qld__breadcrumbs 
                 {{#ifCond metadata.background_colour.value '==' 'dark'}}qld__breadcrumbs--dark{{/ifCond}} 
                 {{#ifCond metadata.background_colour.value '==' 'dark-alternate'}}qld__breadcrumbs--dark{{/ifCond}} 
-                qld__banner__breadcrumbs qld__banner__breadcrumbs--tablet" aria-label="breadcrumb">
+                qld__banner__breadcrumbs qld__banner__breadcrumbs--tablet" aria-label="breadcrumb" data-path="{{@root.site.metadata.coreSiteIcons.value}}">
                     <div class="qld__link-list qld__link-list--inline">
                         {{#with (itemAt ../current.lineage -2)}}
                         {{#ifCond asset_type_code '!=' 'folder'}} 
@@ -63,7 +63,7 @@
                 {{#ifCond site.metadata.defaultBannerColour.value '==' 'dark'}}qld__breadcrumbs--dark{{/ifCond}} 
                 {{#ifCond site.metadata.defaultBannerColour.value '==' 'dark-alternate'}}qld__breadcrumbs--dark{{/ifCond}} 
                 qld__banner__breadcrumbs qld__banner__breadcrumbs--desktop"
-                aria-label="breadcrumb">
+                aria-label="breadcrumb" data-path="{{@root.site.metadata.coreSiteIcons.value}}">
                     <ol class="qld__link-list qld__link-list--inline">
                         {{#each current.lineage}} 
                             {{#ifCond asset_type_code '!=' 'folder'}}          

--- a/src/components/banner_advanced/html/component.hbs
+++ b/src/components/banner_advanced/html/component.hbs
@@ -109,7 +109,7 @@
                         <nav class="qld__breadcrumbs 
                         {{#ifCond metadata.background_colour.value '==' 'dark'}}qld__breadcrumbs--dark{{/ifCond}} 
                         {{#ifCond metadata.background_colour.value '==' 'dark-alternate'}}qld__breadcrumbs--dark{{/ifCond}} 
-                        qld__banner__breadcrumbs qld__banner__breadcrumbs--tablet" aria-label="breadcrumb">
+                        qld__banner__breadcrumbs qld__banner__breadcrumbs--tablet" aria-label="breadcrumb" data-path="{{@root.site.metadata.coreSiteIcons.value}}">
                             <div class="qld__link-list qld__link-list--inline">
                                 {{#with (itemAt ../current.lineage -2)}}
                                 {{#ifCond asset_type_code '!=' 'folder'}} 
@@ -136,7 +136,7 @@
                         <nav class="qld__breadcrumbs 
                         {{#ifCond metadata.background_colour.value '==' 'dark'}}qld__breadcrumbs--dark{{/ifCond}} 
                         {{#ifCond metadata.background_colour.value '==' 'dark-alternate'}}qld__breadcrumbs--dark{{/ifCond}} 
-                        qld__banner__breadcrumbs qld__banner__breadcrumbs--desktop" aria-label="breadcrumb">
+                        qld__banner__breadcrumbs qld__banner__breadcrumbs--desktop" aria-label="breadcrumb" data-path="{{@root.site.metadata.coreSiteIcons.value}}">
                             <ol class="qld__link-list qld__link-list--inline">
                                 {{#each ../current.lineage}} 
                                 {{#ifCond asset_type_code '!=' 'folder'}}        

--- a/src/components/banner_basic/html/component.hbs
+++ b/src/components/banner_basic/html/component.hbs
@@ -89,7 +89,7 @@
                         <nav class="qld__breadcrumbs 
                         {{#ifCond metadata.background_colour.value '==' 'dark'}}qld__breadcrumbs--dark{{/ifCond}} 
                         {{#ifCond metadata.background_colour.value '==' 'dark-alternate'}}qld__breadcrumbs--dark{{/ifCond}} 
-                        qld__banner__breadcrumbs qld__banner__breadcrumbs--tablet" aria-label="breadcrumb">
+                        qld__banner__breadcrumbs qld__banner__breadcrumbs--tablet" aria-label="breadcrumb" data-path="{{@root.site.metadata.coreSiteIcons.value}}">
                             <div class="qld__link-list qld__link-list--inline">
                                 {{#with (itemAt ../current.lineage -2)}}
                                 {{#ifCond asset_type_code '!=' 'folder'}} 
@@ -113,7 +113,7 @@
                         <nav class="qld__breadcrumbs 
                         {{#ifCond metadata.background_colour.value '==' 'dark'}}qld__breadcrumbs--dark{{/ifCond}} 
                         {{#ifCond metadata.background_colour.value '==' 'dark-alternate'}}qld__breadcrumbs--dark{{/ifCond}} 
-                        qld__banner__breadcrumbs qld__banner__breadcrumbs--desktop" aria-label="breadcrumb">
+                        qld__banner__breadcrumbs qld__banner__breadcrumbs--desktop" aria-label="breadcrumb" data-path="{{@root.site.metadata.coreSiteIcons.value}}">
                             <ol class="qld__link-list qld__link-list--inline">
                                 {{#each ../current.lineage}}  
                                 {{#ifCond asset_type_code '!=' 'folder'}}       

--- a/src/components/banner_intermediate/html/component.hbs
+++ b/src/components/banner_intermediate/html/component.hbs
@@ -103,7 +103,7 @@
                         <nav class="qld__breadcrumbs 
                         {{#ifCond metadata.background_colour.value '==' 'dark'}}qld__breadcrumbs--dark{{/ifCond}} 
                         {{#ifCond metadata.background_colour.value '==' 'dark-alternate'}}qld__breadcrumbs--dark{{/ifCond}} 
-                        qld__banner__breadcrumbs qld__banner__breadcrumbs--tablet" aria-label="breadcrumb">
+                        qld__banner__breadcrumbs qld__banner__breadcrumbs--tablet" aria-label="breadcrumb" data-path="{{@root.site.metadata.coreSiteIcons.value}}">
                             <div class="qld__link-list qld__link-list--inline">
                                 {{#with (itemAt ../current.lineage -2)}}
                                 {{#ifCond asset_type_code '!=' 'folder'}} 
@@ -126,7 +126,7 @@
                         <nav class="qld__breadcrumbs 
                         {{#ifCond metadata.background_colour.value '==' 'dark'}}qld__breadcrumbs--dark{{/ifCond}} 
                         {{#ifCond metadata.background_colour.value '==' 'dark-alternate'}}qld__breadcrumbs--dark{{/ifCond}} 
-                        qld__banner__breadcrumbs qld__banner__breadcrumbs--desktop" aria-label="breadcrumb">
+                        qld__banner__breadcrumbs qld__banner__breadcrumbs--desktop" aria-label="breadcrumb" data-path="{{@root.site.metadata.coreSiteIcons.value}}">
                             <ol class="qld__link-list qld__link-list--inline">
                                 {{#each ../current.lineage}} 
                                 {{#ifCond asset_type_code '!=' 'folder'}}        

--- a/src/components/basic_search/html/component.hbs
+++ b/src/components/basic_search/html/component.hbs
@@ -52,7 +52,7 @@
 
                         {{#ifCond site.metadata.defaultBannerColour.value '==' 'dark-alternate'}}qld__breadcrumbs--dark-alt{{/ifCond}}
                         
-                        qld__banner__breadcrumbs qld__banner__breadcrumbs--tablet" aria-label="breadcrumb"> 
+                        qld__banner__breadcrumbs qld__banner__breadcrumbs--tablet" aria-label="breadcrumb" data-path="{{@root.site.metadata.coreSiteIcons.value}}"> 
                         <div class="qld__link-list qld__link-list--inline">
                             {{#with (itemAt current.lineage -2)}}
                                 {{#ifCond asset_type_code '!=' 'folder'}} 
@@ -69,7 +69,7 @@
                         <nav class="qld__breadcrumbs 
                         {{#ifCond site.metadata.defaultBannerColour.value '==' 'dark'}}qld__breadcrumbs--dark{{/ifCond}} 
                         {{#ifCond site.metadata.defaultBannerColour.value '==' 'dark-alternate'}}qld__breadcrumbs--dark{{/ifCond}} 
-                        qld__banner__breadcrumbs qld__banner__breadcrumbs--desktop" aria-label="breadcrumb">
+                        qld__banner__breadcrumbs qld__banner__breadcrumbs--desktop" aria-label="breadcrumb" data-path="{{@root.site.metadata.coreSiteIcons.value}}">
                             <ol class="qld__link-list qld__link-list--inline">
                                 {{#each current.lineage}}   
                                 {{#ifCond asset_type_code '!=' 'folder'}}      

--- a/src/components/breadcrumbs/css/component.scss
+++ b/src/components/breadcrumbs/css/component.scss
@@ -62,7 +62,7 @@
         .qld__overflow_menu--breadcrumbs {
             display: flex;
             align-items: center;
-            padding: none;
+            padding: 0;
         }
         .qld__overflow_menu_wrapper {
             display: inline;

--- a/src/components/breadcrumbs/css/component.scss
+++ b/src/components/breadcrumbs/css/component.scss
@@ -277,7 +277,7 @@
     .qld__body--dark &,
     .qld__body--dark-alt & {
         .qld__breadcrumbs__item::before {
-            background-color: var(--QLD-color-dark__action--secondary);
+            border-color: var(--QLD-color-dark__action--secondary);
         }
     }
 }

--- a/src/components/breadcrumbs/css/component.scss
+++ b/src/components/breadcrumbs/css/component.scss
@@ -145,7 +145,7 @@
             > .qld__breadcrumbs__item:not(:last-child),
             > .qld__overflow_menu--breadcrumbs {
                 &::after {
-                    background-color: var(--QLD-color-dark__action--secondary);
+                    border-color: var(--QLD-color-dark__action--secondary);
                 }
             }
 

--- a/src/components/breadcrumbs/css/component.scss
+++ b/src/components/breadcrumbs/css/component.scss
@@ -270,6 +270,10 @@
         }
     }
 
+    .qld__overflow_menu--breadcrumbs {
+        left: 15px;
+    }
+
     &.qld__breadcrumbs--dark,
     .qld__breadcrumbs--alt-dark,
     .qld__banner--dark &,

--- a/src/components/breadcrumbs/css/component.scss
+++ b/src/components/breadcrumbs/css/component.scss
@@ -4,18 +4,18 @@
 
 .qld__breadcrumbs {
     width: 100%;
-    
+
     * + & {
         @include QLD-space(margin-top, 1unit);
     }
-    
+
     @include QLD-media(sm) {
         display: flex;
         flex-direction: row;
         flex-wrap: wrap;
         align-items: center;
     }
-    & &__list--desktop{
+    & &__list--desktop {
         display: none;
         @include QLD-media(lg) {
             display: flex;
@@ -24,16 +24,16 @@
             align-items: center;
         }
     }
-    & &__list--tablet{
+    & &__list--tablet {
         @include QLD-media(lg) {
             display: none;
         }
 
-        @include QLD-media(md, 'down') {
+        @include QLD-media(md, "down") {
             display: none;
         }
     }
-    & &__list--mobile{
+    & &__list--mobile {
         @include QLD-media(md) {
             display: none;
         }
@@ -67,38 +67,42 @@
         .qld__overflow_menu_wrapper {
             display: inline;
         }
-        
+
         > li {
             margin: 0; //Intentionally flush with the container, as breadcrumbs are designed to sit on a full viewport width bg.
             display: none;
-            @include QLD-space(padding, 0.25unit 0);
+            position: relative;
             flex-shrink: 0;
+            margin-right: 1.25rem;
+            @include QLD-space(padding, 0.25unit 0);
+
             a {
-                @include QLD-underline('light','underline','default','noVisited');
+                @include QLD-underline("light", "underline", "default", "noVisited");
                 color: var(--QLD-color-light__link);
             }
-            
+
             &:after {
-                content: " ";
-                display: inline-block;
-                @include QLD-space(width, 0.5unit);
-                @include QLD-space(height, 1unit);
-                @include QLD-space(margin, 0 0.5unit);
-                // background-image: QLD-svg-with-fill($QLD-icon-chevron-right, var(--QLD-color-light__action--secondary));
-                // background-size: contain;
-                // background-repeat: no-repeat;
-                vertical-align: middle;
-                mask-image: QLD-svguri($QLD-icon-chevron-right);
-                mask-repeat: no-repeat;
-                mask-position: center;
-                background-color: var(--QLD-color-light__action--secondary);
+                content: "";
+                border-right: 1px solid var(--QLD-color-light__action--secondary);
+                border-top: 1px solid var(--QLD-color-light__action--secondary);
+                font-size: max(16px, 1em);
+                transform: rotate(45deg);
+                display: block;
+                position: absolute;
+                top: 0;
+                bottom: 0;
+                right: -0.75rem;
+                width: 0.4375em;
+                height: 0.4375em;
+                margin: auto 0;
+                background-color: transparent;
             }
-            
+
             &:last-child {
                 display: flex;
                 white-space: wrap;
                 text-overflow: ellipsis;
-                flex: 0 1 auto; 
+                flex: 0 1 auto;
                 flex-shrink: 3;
 
                 &:after {
@@ -106,14 +110,10 @@
                 }
 
                 @include QLD-media(lg) {
-                    
                     white-space: nowrap;
                 }
-
             }
 
-
-            
             .ie8 &,
             .lt-ie8 & {
                 &:after {
@@ -138,13 +138,13 @@
     .qld__body--dark &,
     .qld__body--dark-alt &,
     .qld__banner--dark &,
-    .qld__banner--dark-alt &{
+    .qld__banner--dark-alt & {
         color: var(--QLD-color-dark__text--lighter);
-        
+
         > .qld__link-list {
             > .qld__breadcrumbs__item:not(:last-child),
             > .qld__overflow_menu--breadcrumbs {
-                &::after{
+                &::after {
                     background-color: var(--QLD-color-dark__action--secondary);
                 }
             }
@@ -152,7 +152,7 @@
             > .qld__breadcrumbs__item {
                 a {
                     // @include QLD-underline('dark');
-                    @include QLD-underline('dark','underline','default','noVisited');
+                    @include QLD-underline("dark", "underline", "default", "noVisited");
                     color: var(--QLD-color-dark__text);
                 }
             }
@@ -171,11 +171,11 @@
         // &.qld__breadcrumbs--alt {
         //     background-color: var(--QLD-color-light__background--alt);
         // }
-    
+
         // &.qld__breadcrumbs--dark {
         //     background-color: var(--QLD-color-dark__background);
         // }
-    
+
         // &.qld__breadcrumbs--alt-dark {
         //     background-color: var(--QLD-color-dark__background--alt);
         // }
@@ -186,12 +186,11 @@
         @include QLD-media(lg) {
             display: none;
         }
-        @include QLD-media(md, 'down') {
+        @include QLD-media(md, "down") {
             display: none;
         }
     }
 }
-
 
 .qld__banner__breadcrumbs--desktop {
     display: none;
@@ -200,7 +199,6 @@
         @include QLD-space(margin, 0 0 1rem);
         display: inline-block;
         > .qld__link-list > .qld__breadcrumbs__item {
-
             flex: 0 0 auto;
             flex-shrink: 0;
             // Hide current page
@@ -211,7 +209,7 @@
             &:after {
                 content: none;
             }
-        }   
+        }
     }
 
     @include QLD-media(lg) {
@@ -246,26 +244,30 @@
 .qld__banner__breadcrumbs--desktop,
 .qld__breadcrumbs__list--tablet,
 .qld__breadcrumbs__list--mobile {
-    .qld__breadcrumbs__item .qld__icon{
-     color: var(--QLD-color-light__action--secondary);
+    .qld__breadcrumbs__item .qld__icon {
+        color: var(--QLD-color-light__action--secondary);
     }
-    
-    .qld__breadcrumbs__item::before {
-        @include QLD-space(width, 0.5unit);
-        @include QLD-space(height, 1unit);
-        @include QLD-space(margin, 0 0.25unit 0 0);
-        // background-image: QLD-svg-with-fill($QLD-icon-chevron-left, var(--QLD-color-light__action--secondary));
-        // background-size: 100%;
-        // background-repeat: no-repeat;
-        // background-size: contain;
-        content: " ";
-        display: inline-block;
-        vertical-align: middle;
-        background-position: center;
-        mask-image: QLD-svguri($QLD-icon-chevron-left);
-		mask-repeat: no-repeat;
-		mask-position: center;
-		background-color: var(--QLD-color-light__action--secondary);
+
+    .qld__breadcrumbs__item {
+        position: relative;
+        left: 15px;
+
+        &:before {
+            content: "";
+            border-right: 1px solid var(--QLD-color-light__action--secondary);
+            border-top: 1px solid var(--QLD-color-light__action--secondary);
+            font-size: max(16px, 1em);
+            transform: rotate(225deg);
+            display: block;
+            position: absolute;
+            top: 0;
+            bottom: 0;
+            left: -0.75rem;
+            width: 0.4375em;
+            height: 0.4375em;
+            margin: auto 0;
+            background-color: transparent;
+        }
     }
 
     &.qld__breadcrumbs--dark,
@@ -273,15 +275,10 @@
     .qld__banner--dark &,
     .qld__banner--dark-alt &,
     .qld__body--dark &,
-    .qld__body--dark-alt &  {
-
-        .qld__breadcrumbs__item::before{
+    .qld__body--dark-alt & {
+        .qld__breadcrumbs__item::before {
             background-color: var(--QLD-color-dark__action--secondary);
-           }
-
-        // li::before {
-        //     background-image: QLD-svg-with-fill($QLD-icon-chevron-left, var(--QLD-color-dark__action--secondary));
-        // }
+        }
     }
 }
 

--- a/src/components/breadcrumbs/html/component.hbs
+++ b/src/components/breadcrumbs/html/component.hbs
@@ -1,5 +1,5 @@
 {{#ifCond current.data.metadata.displayBreadcrumbs.value '==' 'true'}}
-<nav class="qld__breadcrumbs" aria-label="breadcrumb" data-path="{{@root.site.metadata.coreSiteIcons.value}}">
+<nav class="qld__breadcrumbs qld__breadcrumbs-svg-path-{{@root.site.metadata.coreSiteIcons.value}}" aria-label="breadcrumbs">
     <ol class="qld__breadcrumbs__list--desktop qld__link-list qld__link-list--inline">
         {{#each current.lineage}} 
             {{#ifCond asset_type_code '!=' 'folder'}}       

--- a/src/components/breadcrumbs/html/component.hbs
+++ b/src/components/breadcrumbs/html/component.hbs
@@ -1,5 +1,5 @@
 {{#ifCond current.data.metadata.displayBreadcrumbs.value '==' 'true'}}
-<nav class="qld__breadcrumbs qld__breadcrumbs-svg-path-{{@root.site.metadata.coreSiteIcons.value}}" aria-label="breadcrumbs">
+<nav class="qld__breadcrumbs" data-path="{{@root.site.metadata.coreSiteIcons.value}}" aria-label="breadcrumbs">
     <ol class="qld__breadcrumbs__list--desktop qld__link-list qld__link-list--inline">
         {{#each current.lineage}} 
             {{#ifCond asset_type_code '!=' 'folder'}}       

--- a/src/components/breadcrumbs/html/component.hbs
+++ b/src/components/breadcrumbs/html/component.hbs
@@ -1,5 +1,5 @@
 {{#ifCond current.data.metadata.displayBreadcrumbs.value '==' 'true'}}
-<nav class="qld__breadcrumbs" data-path="{{@root.site.metadata.coreSiteIcons.value}}" aria-label="breadcrumbs">
+<nav class="qld__breadcrumbs" aria-label="breadcrumb" data-path="{{@root.site.metadata.coreSiteIcons.value}}">
     <ol class="qld__breadcrumbs__list--desktop qld__link-list qld__link-list--inline">
         {{#each current.lineage}} 
             {{#ifCond asset_type_code '!=' 'folder'}}       

--- a/src/components/breadcrumbs/html/component.hbs
+++ b/src/components/breadcrumbs/html/component.hbs
@@ -1,3 +1,5 @@
+<use href="{{@root.site.metadata.coreSiteIcons.value}}#more-horizontal" data-ref="breadcrumb-overflow"></use>
+
 {{#ifCond current.data.metadata.displayBreadcrumbs.value '==' 'true'}}
 <nav class="qld__breadcrumbs" aria-label="breadcrumb">
     <ol class="qld__breadcrumbs__list--desktop qld__link-list qld__link-list--inline">

--- a/src/components/breadcrumbs/html/component.hbs
+++ b/src/components/breadcrumbs/html/component.hbs
@@ -1,7 +1,5 @@
-<div style="display: none;" id="icon-data" data-path="{{@root.site.metadata.coreSiteIcons.value}}"></div>
-
 {{#ifCond current.data.metadata.displayBreadcrumbs.value '==' 'true'}}
-<nav class="qld__breadcrumbs" aria-label="breadcrumb">
+<nav class="qld__breadcrumbs" aria-label="breadcrumb" data-path="{{@root.site.metadata.coreSiteIcons.value}}">
     <ol class="qld__breadcrumbs__list--desktop qld__link-list qld__link-list--inline">
         {{#each current.lineage}} 
             {{#ifCond asset_type_code '!=' 'folder'}}       

--- a/src/components/breadcrumbs/html/component.hbs
+++ b/src/components/breadcrumbs/html/component.hbs
@@ -1,4 +1,4 @@
-<use href="{{@root.site.metadata.coreSiteIcons.value}}#more-horizontal" data-ref="breadcrumb-overflow"></use>
+<div style="display: none;" id="icon-data" data-path="{{@root.site.metadata.coreSiteIcons.value}}"></div>
 
 {{#ifCond current.data.metadata.displayBreadcrumbs.value '==' 'true'}}
 <nav class="qld__breadcrumbs" aria-label="breadcrumb">

--- a/src/components/breadcrumbs/js/global.js
+++ b/src/components/breadcrumbs/js/global.js
@@ -75,12 +75,16 @@
         svg.setAttribute("height", "32");
         svg.setAttribute("role", "img");
 
-        const usePath = document.querySelector("nav.qld__breadcrumbs[data-path]").getAttribute("data-path");
-        let use = document.createElement("use");
-        use.setAttribute("href", `${usePath}#more-horizontal`);
-
-        svg.appendChild(use);
-        button.appendChild(svg);
+        const svgPathPrefix = "qld__breadcrumbs-svg-path-";
+        const breadcrumbs = document.querySelector("nav.qld__breadcrumbs");
+        const usePath = Array.from(breadcrumbs.classList).find((className) => className.startsWith("qld__breadcrumbs-svg-path-"));
+        if (usePath) {
+            breadcrumbs.classList.remove(usePath);
+            let use = document.createElement("use");
+            use.setAttribute("href", `${usePath.replace(svgPathPrefix, "")}#more-horizontal`);
+            svg.appendChild(use);
+            button.appendChild(svg);
+        }
 
         overFlowWrapper.appendChild(button);
 

--- a/src/components/breadcrumbs/js/global.js
+++ b/src/components/breadcrumbs/js/global.js
@@ -64,17 +64,8 @@
         button.setAttribute("aria-controls", "overflow-menu--");
         button.setAttribute("aria-expanded", "false");
 
-        const svg = document.createElementNS("http://www.w3.org/2000/svg", "svg");
-        svg.classList.add("qld__icon");
-        svg.classList.add("qld__icon--lg");
-        svg.setAttribute("aria-hidden", "true");
-        svg.setAttribute("xmlns", "http://www.w3.org/2000/svg");
-
         if (svgPath) {
-            let use = document.createElement("use");
-            use.setAttribute("href", svgPath + "#more-horizontal");
-            svg.appendChild(use);
-            button.appendChild(svg);
+            button.innerHTML = `<svg class="qld__icon qld__icon--lg" aria-hidden="true" xmlns="http://www.w3.org/2000/svg"><use href="${svgPath}#more-horizontal"></use></svg>`;
         }
 
         overFlowWrapper.appendChild(button);

--- a/src/components/breadcrumbs/js/global.js
+++ b/src/components/breadcrumbs/js/global.js
@@ -9,79 +9,62 @@
     var originalBreadCrumbUl = null;
 
     function getTheElements(resized = false) {
-            const bannerBreadCrumbsAll = document.querySelectorAll(
-                "nav.qld__banner__breadcrumbs--desktop"
-            );
+        const bannerBreadCrumbsAll = document.querySelectorAll("nav.qld__banner__breadcrumbs--desktop");
 
-            const bodyBreadCrumbsAll = document.querySelectorAll(
-                'section.qld__body--breadcrumb nav.qld__breadcrumbs'
-            );
+        const bodyBreadCrumbsAll = document.querySelectorAll("section.qld__body--breadcrumb nav.qld__breadcrumbs");
 
-            const bannerBreadCrumbArray = [...bannerBreadCrumbsAll, ...bodyBreadCrumbsAll];
-            const bannerBreadCrumb = bannerBreadCrumbArray.find(
-                (breadcrumb) => {
-                    return breadcrumb.offsetWidth > 0;
-                }
-            );
+        const bannerBreadCrumbArray = [...bannerBreadCrumbsAll, ...bodyBreadCrumbsAll];
+        const bannerBreadCrumb = bannerBreadCrumbArray.find((breadcrumb) => {
+            return breadcrumb.offsetWidth > 0;
+        });
 
-            if(bannerBreadCrumb) {
-                if(!originalBreadCrumbUl) {
-                    originalBreadCrumbUl = bannerBreadCrumb.querySelector("ol.qld__link-list").cloneNode(true);
-                }
-    
-                if(resized) {
-                    bannerBreadCrumb.querySelector("ol.qld__link-list").innerHTML = originalBreadCrumbUl.innerHTML;
-                }
-    
-                const breadCrumbsUl = bannerBreadCrumb.querySelector("ol.qld__link-list");
-                if (bannerBreadCrumb.parentElement && bannerBreadCrumb.parentElement.classList.contains("qld__banner__content")) {
-                    const contentBanner = bannerBreadCrumb.closest('.qld__banner__content');
-                    const contentBannerStyle = window.getComputedStyle(contentBanner);
-                
-                    const contentPaddings = 
-                        parseFloat(contentBannerStyle.getPropertyValue('padding-right').replace(/[^\d.]/g, '')) + 
-                        parseFloat(contentBannerStyle.getPropertyValue('padding-left').replace(/[^\d.]/g, ''));
-                
-                    bannerBreadCrumb.style.maxWidth = (contentBanner.offsetWidth - contentPaddings) + 'px';
-                
-                    breadCrumbsUl.style.maxWidth = (contentBanner.offsetWidth - contentPaddings) + 'px';
-                
-                } else {
-                    const containerFluid = bannerBreadCrumb.closest('.container-fluid');
-                    const containerFluidStyle = window.getComputedStyle(containerFluid);
-                    if(containerFluid) {
-                        const paddings = 
-                        parseFloat(containerFluidStyle.getPropertyValue('padding-right').replace(/[^\d.]/g, '')) + 
-                        parseFloat(containerFluidStyle.getPropertyValue('padding-left').replace(/[^\d.]/g, ''));
-                
-                        bannerBreadCrumb.style.maxWidth = (containerFluid.offsetWidth - paddings) + 'px';
-                        breadCrumbsUl.style.maxWidth = (containerFluid.offsetWidth - paddings) + 'px';
-                    }
-
-                }                
-                return {
-                    bannerBreadCrumb,
-                    breadCrumbsUl,
-                };
+        if (bannerBreadCrumb) {
+            if (!originalBreadCrumbUl) {
+                originalBreadCrumbUl = bannerBreadCrumb.querySelector("ol.qld__link-list").cloneNode(true);
             }
+
+            if (resized) {
+                bannerBreadCrumb.querySelector("ol.qld__link-list").innerHTML = originalBreadCrumbUl.innerHTML;
+            }
+
+            const breadCrumbsUl = bannerBreadCrumb.querySelector("ol.qld__link-list");
+            if (bannerBreadCrumb.parentElement && bannerBreadCrumb.parentElement.classList.contains("qld__banner__content")) {
+                const contentBanner = bannerBreadCrumb.closest(".qld__banner__content");
+                const contentBannerStyle = window.getComputedStyle(contentBanner);
+
+                const contentPaddings = parseFloat(contentBannerStyle.getPropertyValue("padding-right").replace(/[^\d.]/g, "")) + parseFloat(contentBannerStyle.getPropertyValue("padding-left").replace(/[^\d.]/g, ""));
+
+                bannerBreadCrumb.style.maxWidth = contentBanner.offsetWidth - contentPaddings + "px";
+
+                breadCrumbsUl.style.maxWidth = contentBanner.offsetWidth - contentPaddings + "px";
+            } else {
+                const containerFluid = bannerBreadCrumb.closest(".container-fluid");
+                const containerFluidStyle = window.getComputedStyle(containerFluid);
+                if (containerFluid) {
+                    const paddings = parseFloat(containerFluidStyle.getPropertyValue("padding-right").replace(/[^\d.]/g, "")) + parseFloat(containerFluidStyle.getPropertyValue("padding-left").replace(/[^\d.]/g, ""));
+
+                    bannerBreadCrumb.style.maxWidth = containerFluid.offsetWidth - paddings + "px";
+                    breadCrumbsUl.style.maxWidth = containerFluid.offsetWidth - paddings + "px";
+                }
+            }
+            return {
+                bannerBreadCrumb,
+                breadCrumbsUl,
+            };
+        }
     }
 
     function createOverFlow() {
-
         const overFlowWrapper = document.createElement("div");
         overFlowWrapper.className = "qld__overflow_menu_wrapper";
 
         const button = document.createElement("button");
-        button.className =
-            "qld__btn qld__btn--toggle qld__overflow_menu__btn qld__accordion--closed";
+        button.className = "qld__btn qld__btn--toggle qld__overflow_menu__btn qld__accordion--closed";
         button.setAttribute("href", "#");
         button.setAttribute("aria-controls", "overflow-menu--");
         button.setAttribute("aria-expanded", "false");
 
-        const svg = document.createElementNS(
-            "http://www.w3.org/2000/svg",
-            "svg"
-        );
+        const svg = document.createElementNS("http://www.w3.org/2000/svg", "svg");
         svg.classList.add("qld__icon");
         svg.classList.add("qld__icon--lg");
         svg.setAttribute("xmlns", "http://www.w3.org/2000/svg");
@@ -92,17 +75,11 @@
         svg.setAttribute("height", "32");
         svg.setAttribute("role", "img");
 
-        const path = document.createElementNS(
-            "http://www.w3.org/2000/svg",
-            "path"
-        );
-        path.setAttribute("fill", "currentColor");
-        path.setAttribute(
-            "d",
-            "M352 256C352 238.3 366.3 224 384 224C401.7 224 416 238.3 416 256C416 273.7 401.7 288 384 288C366.3 288 352 273.7 352 256zM192 256C192 238.3 206.3 224 224 224C241.7 224 256 238.3 256 256C256 273.7 241.7 288 224 288C206.3 288 192 273.7 192 256zM96 256C96 273.7 81.67 288 64 288C46.33 288 32 273.7 32 256C32 238.3 46.33 224 64 224C81.67 224 96 238.3 96 256z"
-        );
+        const usePath = document.querySelector('use[data-ref="breadcrumb-overflow"]').getAttribute("href");
+        let use = document.createElement("use");
+        use.setAttribute("href", usePath);
 
-        svg.appendChild(path);
+        svg.appendChild(use);
         button.appendChild(svg);
 
         overFlowWrapper.appendChild(button);
@@ -142,8 +119,8 @@
     function truncateLastLi(breadCrumbsUlLis) {
         breadCrumbsUlLis[breadCrumbsUlLis.length - 1].style.overflow = "hidden";
     }
-    
-    function appendOverflow( breadCrumbsUlLis, overflowMenu, breadcrumbUL) {
+
+    function appendOverflow(breadCrumbsUlLis, overflowMenu, breadcrumbUL) {
         breadCrumbsUlLis[1].innerHTML = "";
         breadCrumbsUlLis[1].className = "qld__overflow_menu--breadcrumbs";
         breadCrumbsUlLis[1].appendChild(overflowMenu);
@@ -159,29 +136,26 @@
                 const overflowMenu = createOverFlow();
                 let breadcrumbLisLength = breadCrumbsUlLis.length;
                 let i = 1;
-                
 
                 let totalLisOffsetWidth = 0;
-                
+
                 for (let i = 0; i < breadCrumbsUlLis.length; i++) {
                     totalLisOffsetWidth += breadCrumbsUlLis[i].offsetWidth;
                 }
 
-                if(breadcrumbLisLength > 5) {
+                if (breadcrumbLisLength > 5) {
                     insertOverFlowButton(overflowMenu, breadCrumbsUlLis[1]);
                     breadCrumbsUlLis[1].style.display = "none";
                     appendOverflow(breadCrumbsUlLis, overflowMenu, breadCrumbsUl);
                     i = 2;
 
-                    while(i < breadCrumbsUlLis.length - 2) {
+                    while (i < breadCrumbsUlLis.length - 2) {
                         insertOverFlowButton(overflowMenu, breadCrumbsUlLis[i]);
                         breadCrumbsUlLis[i].style.display = "none";
                         i++;
                     }
-
-                } else if((breadCrumbsUl.offsetHeight > (breadCrumbsUlLis[0].offsetHeight * 1.9))) {
-
-                    if(breadcrumbLisLength > 3) { 
+                } else if (breadCrumbsUl.offsetHeight > breadCrumbsUlLis[0].offsetHeight * 1.9) {
+                    if (breadcrumbLisLength > 3) {
                         insertOverFlowButton(overflowMenu, breadCrumbsUlLis[1]);
                         breadCrumbsUlLis[1].style.display = "none";
                         appendOverflow(breadCrumbsUlLis, overflowMenu, breadCrumbsUl);
@@ -189,30 +163,23 @@
 
                     i = 2;
 
-                    while ((breadCrumbsUl.offsetHeight > (breadCrumbsUlLis[0].offsetHeight * 1.9)) &&
-                    (i < breadcrumbLisLength - 2)
-                    ) {
-
+                    while (breadCrumbsUl.offsetHeight > breadCrumbsUlLis[0].offsetHeight * 1.9 && i < breadcrumbLisLength - 2) {
                         insertOverFlowButton(overflowMenu, breadCrumbsUlLis[i]);
                         breadCrumbsUlLis[i].style.display = "none";
 
                         i++;
                     }
-                } else if(parseFloat(breadCrumbsUl.style.maxWidth.replace(/[^\d.]/g, '')) < totalLisOffsetWidth) {
-                    
-                    if(breadcrumbLisLength > 3) {
+                } else if (parseFloat(breadCrumbsUl.style.maxWidth.replace(/[^\d.]/g, "")) < totalLisOffsetWidth) {
+                    if (breadcrumbLisLength > 3) {
                         insertOverFlowButton(overflowMenu, breadCrumbsUlLis[1]);
                         breadCrumbsUlLis[1].style.display = "none";
                         appendOverflow(breadCrumbsUlLis, overflowMenu, breadCrumbsUl);
                         totalLisOffsetWidth -= breadCrumbsUlLis[1].offsetWidth;
                     }
-                    
+
                     i = 2;
 
-                    while ((parseFloat(breadCrumbsUl.style.maxWidth.replace(/[^\d.]/g, ''))< totalLisOffsetWidth) &&
-                    (i < breadcrumbLisLength - 2)
-                    ) {                        
-
+                    while (parseFloat(breadCrumbsUl.style.maxWidth.replace(/[^\d.]/g, "")) < totalLisOffsetWidth && i < breadcrumbLisLength - 2) {
                         insertOverFlowButton(overflowMenu, breadCrumbsUlLis[i]);
                         totalLisOffsetWidth -= breadCrumbsUlLis[1].offsetWidth;
                         breadCrumbsUlLis[i].style.display = "none";
@@ -229,14 +196,12 @@
 
     window.addEventListener("DOMContentLoaded", function () {
         QLD.breadcrumb.init();
-        QLD.accordion.init('overflow');
+        QLD.accordion.init("overflow");
     });
 
-    window.addEventListener('resize' , function() {
+    window.addEventListener("resize", function () {
         getTheElements(true);
         QLD.breadcrumb.init();
-        QLD.accordion.init('overflow');
+        QLD.accordion.init("overflow");
     });
-
 })();
-

--- a/src/components/breadcrumbs/js/global.js
+++ b/src/components/breadcrumbs/js/global.js
@@ -54,7 +54,7 @@
         }
     }
 
-    function createOverFlow() {
+    function createOverFlow(svgPath) {
         const overFlowWrapper = document.createElement("div");
         overFlowWrapper.className = "qld__overflow_menu_wrapper";
 
@@ -67,21 +67,12 @@
         const svg = document.createElementNS("http://www.w3.org/2000/svg", "svg");
         svg.classList.add("qld__icon");
         svg.classList.add("qld__icon--lg");
-        svg.setAttribute("xmlns", "http://www.w3.org/2000/svg");
-        svg.setAttribute("viewBox", "0 0 448 512");
         svg.setAttribute("aria-hidden", "true");
-        svg.setAttribute("focusable", "false");
-        svg.setAttribute("width", "24");
-        svg.setAttribute("height", "32");
-        svg.setAttribute("role", "img");
+        svg.setAttribute("xmlns", "http://www.w3.org/2000/svg");
 
-        const svgPathPrefix = "qld__breadcrumbs-svg-path-";
-        const breadcrumbs = document.querySelector("nav.qld__breadcrumbs");
-        const usePath = Array.from(breadcrumbs.classList).find((className) => className.startsWith("qld__breadcrumbs-svg-path-"));
-        if (usePath) {
-            breadcrumbs.classList.remove(usePath);
+        if (svgPath) {
             let use = document.createElement("use");
-            use.setAttribute("href", `${usePath.replace(svgPathPrefix, "")}#more-horizontal`);
+            use.setAttribute("href", svgPath + "#more-horizontal");
             svg.appendChild(use);
             button.appendChild(svg);
         }
@@ -137,7 +128,10 @@
 
             const breadCrumbsUlLis = breadCrumbsUl.querySelectorAll("li");
             if (breadCrumbsUlLis.length > 2 && breadCrumbsUlLis[0].offsetHeight > 0) {
-                const overflowMenu = createOverFlow();
+                const parent = breadCrumbsUl.parentElement;
+                const svgPath = parent.getAttribute("data-path");
+                const overflowMenu = createOverFlow(svgPath);
+
                 let breadcrumbLisLength = breadCrumbsUlLis.length;
                 let i = 1;
 

--- a/src/components/breadcrumbs/js/global.js
+++ b/src/components/breadcrumbs/js/global.js
@@ -75,9 +75,9 @@
         svg.setAttribute("height", "32");
         svg.setAttribute("role", "img");
 
-        const usePath = document.querySelector('use[data-ref="breadcrumb-overflow"]').getAttribute("href");
+        const usePath = document.getElementById("icon-data").getAttribute("data-path");
         let use = document.createElement("use");
-        use.setAttribute("href", usePath);
+        use.setAttribute("href", `${usePath}#more-horizontal`);
 
         svg.appendChild(use);
         button.appendChild(svg);

--- a/src/components/breadcrumbs/js/global.js
+++ b/src/components/breadcrumbs/js/global.js
@@ -75,7 +75,7 @@
         svg.setAttribute("height", "32");
         svg.setAttribute("role", "img");
 
-        const usePath = document.getElementById("icon-data").getAttribute("data-path");
+        const usePath = document.querySelector("nav.qld__breadcrumbs[data-path]").getAttribute("data-path");
         let use = document.createElement("use");
         use.setAttribute("href", `${usePath}#more-horizontal`);
 

--- a/src/components/overflow_menu/html/component.hbs
+++ b/src/components/overflow_menu/html/component.hbs
@@ -1,7 +1,7 @@
 {{#with component.data}}
     <div class="qld__overflow_menu_wrapper">
         <button href="#" class="qld__btn qld__btn--toggle qld__overflow_menu__btn qld__accordion--closed" aria-controls="overflow-menu-{{../assetid}}-{{this.fieldid}}" aria-expanded="false">
-            <svg class="qld__icon qld__icon--lg" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 448 512" aria-hidden="true" focusable="false" width="24" height="32" role="img"><path fill="currentColor" d="M352 256C352 238.3 366.3 224 384 224C401.7 224 416 238.3 416 256C416 273.7 401.7 288 384 288C366.3 288 352 273.7 352 256zM192 256C192 238.3 206.3 224 224 224C241.7 224 256 238.3 256 256C256 273.7 241.7 288 224 288C206.3 288 192 273.7 192 256zM96 256C96 273.7 81.67 288 64 288C46.33 288 32 273.7 32 256C32 238.3 46.33 224 64 224C81.67 224 96 238.3 96 256z"></path></svg>
+            <svg class="qld__icon qld__icon--lg" role="img" aria-hidden="true" focusable="false" xmlns="http://www.w3.org/2000/svg"><use href="{{@root.site.metadata.coreSiteIcons.value}}#more-horizontal"></use></svg>
         </button>
         <div class="qld__overflow_menu qld__accordion--closed" id="overflow-menu-{{../assetid}}-{{this.fieldid}}">
             <ul area-label="qld__overflow_menu qld__link-columns" class="qld__overflow_menu_list" >

--- a/src/components/overflow_menu/html/component.hbs
+++ b/src/components/overflow_menu/html/component.hbs
@@ -1,7 +1,7 @@
 {{#with component.data}}
     <div class="qld__overflow_menu_wrapper">
         <button href="#" class="qld__btn qld__btn--toggle qld__overflow_menu__btn qld__accordion--closed" aria-controls="overflow-menu-{{../assetid}}-{{this.fieldid}}" aria-expanded="false">
-            <svg class="qld__icon qld__icon--lg" role="img" aria-hidden="true" focusable="false" xmlns="http://www.w3.org/2000/svg"><use href="{{@root.site.metadata.coreSiteIcons.value}}#more-horizontal"></use></svg>
+            <svg class="qld__icon qld__icon--lg" aria-hidden="true" xmlns="http://www.w3.org/2000/svg"><use href="{{@root.site.metadata.coreSiteIcons.value}}#more-horizontal"></use></svg>
         </button>
         <div class="qld__overflow_menu qld__accordion--closed" id="overflow-menu-{{../assetid}}-{{this.fieldid}}">
             <ul area-label="qld__overflow_menu qld__link-columns" class="qld__overflow_menu_list" >

--- a/src/html/component-breadcrumbs.html
+++ b/src/html/component-breadcrumbs.html
@@ -14,75 +14,202 @@
 
     <head>
         <title>Queensland Design System</title>
-        
+
         ${require('../components/_global/html/head.html')}
         <script>
-            var globals = {"site":{"data":{"assetid":"136","type_code":"site","version":"0.0.8","name":"Design System","short_name":"Design System","status":"2","force_secure":"0","languages":"en","charset":"utf-8","created":"2020-12-09 13:11:12","created_userid":"54","updated":"2021-01-20 15:08:30","updated_userid":"312","published":"Never","published_userid":"","status_changed":"2020-12-09 13:11:12","status_changed_userid":"54","thumbnail":"","attributes":{"name":{"attrid":"685","type":"text","value":"Design System","is_contextable":true,"use_default":true},"not_found_page_cache_globally":{"attrid":"686","type":"boolean","value":false,"is_contextable":false,"use_default":true},"available_conditions":{"attrid":"687","type":"serialise","value":[],"is_contextable":false,"use_default":true}},"metadata":{"displayInPageNav":{"value":"","fieldid":"808","type":"metadata_field_select","is_contextable":true,"default_value":true,"use_default":true},"inPageNav_heading":{"value":"On this page","fieldid":"809","type":"metadata_field_text","is_contextable":true,"default_value":true,"use_default":true},"inPageNav_headingType":{"value":"h2","fieldid":"810","type":"metadata_field_select","is_contextable":true,"default_value":true,"use_default":true},"siteTitle":{"value":"Queensland Health Design System","fieldid":"166","type":"metadata_field_text","is_contextable":true,"default_value":false,"use_default":true},"siteLogo":{"value":"169","fieldid":"127","type":"metadata_field_related_asset","is_contextable":true,"default_value":false,"use_default":true},"siteFavicon":{"value":"106","fieldid":"128","type":"metadata_field_related_asset","is_contextable":true,"default_value":false,"use_default":true},"siteAppleTouch":{"value":"106","fieldid":"129","type":"metadata_field_related_asset","is_contextable":true,"default_value":false,"use_default":true},"sitePreHeaderLogo":{"value":"170","fieldid":"171","type":"metadata_field_related_asset","is_contextable":true,"default_value":false,"use_default":true},"sitePreHeaderText":{"value":"digital.qld.gov.au","fieldid":"167","type":"metadata_field_text","is_contextable":true,"default_value":false,"use_default":true},"sitePreHeaderURL":{"value":"http://www.digital.qld.gov.au","fieldid":"168","type":"metadata_field_text","is_contextable":true,"default_value":false,"use_default":true},"showHomeIcon":{"value":"true","fieldid":"481","type":"metadata_field_select","is_contextable":true,"default_value":true,"use_default":true},"siteRepository":{"value":"164","fieldid":"213","type":"metadata_field_related_asset","is_contextable":true,"default_value":false,"use_default":true},"footerLinks":{"value":"[\"186\",\"194\",\"198\",\"458\",\"676\"]","fieldid":"715","type":"metadata_field_related_asset","is_contextable":true,"default_value":false,"use_default":true},"footerCopyrightMessage":{"value":"© The State of Queensland 2020","fieldid":"722","type":"metadata_field_text","is_contextable":true,"default_value":true,"use_default":true},"footerCopyrightLink":{"value":"206","fieldid":"723","type":"metadata_field_related_asset","is_contextable":true,"default_value":false,"use_default":true},"footerCTAHeading":{"value":"Help us improve","fieldid":"724","type":"metadata_field_text","is_contextable":true,"default_value":false,"use_default":true},"footerCTALead":{"value":"We are always looking for ways to improve our website.","fieldid":"725","type":"metadata_field_text","is_contextable":true,"default_value":false,"use_default":true},"footerCTALink":{"value":"186","fieldid":"726","type":"metadata_field_related_asset","is_contextable":true,"default_value":false,"use_default":true}}},"metadata":{"displayInPageNav":{"value":"","fieldid":"808","type":"metadata_field_select","is_contextable":true,"default_value":true,"use_default":true},"inPageNav_heading":{"value":"On this page","fieldid":"809","type":"metadata_field_text","is_contextable":true,"default_value":true,"use_default":true},"inPageNav_headingType":{"value":"h2","fieldid":"810","type":"metadata_field_select","is_contextable":true,"default_value":true,"use_default":true},"siteTitle":{"value":"Queensland Health Design System","fieldid":"166","type":"metadata_field_text","is_contextable":true,"default_value":false,"use_default":true},"siteLogo":{"value":"169","fieldid":"127","type":"metadata_field_related_asset","is_contextable":true,"default_value":false,"use_default":true},"siteFavicon":{"value":"106","fieldid":"128","type":"metadata_field_related_asset","is_contextable":true,"default_value":false,"use_default":true},"siteAppleTouch":{"value":"106","fieldid":"129","type":"metadata_field_related_asset","is_contextable":true,"default_value":false,"use_default":true},"sitePreHeaderLogo":{"value":"170","fieldid":"171","type":"metadata_field_related_asset","is_contextable":true,"default_value":false,"use_default":true},"sitePreHeaderText":{"value":"digital.qld.gov.au","fieldid":"167","type":"metadata_field_text","is_contextable":true,"default_value":false,"use_default":true},"sitePreHeaderURL":{"value":"http://www.digital.qld.gov.au","fieldid":"168","type":"metadata_field_text","is_contextable":true,"default_value":false,"use_default":true},"showHomeIcon":{"value":"true","fieldid":"481","type":"metadata_field_select","is_contextable":true,"default_value":true,"use_default":true},"siteRepository":{"value":"164","fieldid":"213","type":"metadata_field_related_asset","is_contextable":true,"default_value":false,"use_default":true},"footerLinks":{"value":"[\"186\",\"194\",\"198\",\"458\",\"676\"]","fieldid":"715","type":"metadata_field_related_asset","is_contextable":true,"default_value":false,"use_default":true},"footerCopyrightMessage":{"value":"© The State of Queensland 2020","fieldid":"722","type":"metadata_field_text","is_contextable":true,"default_value":true,"use_default":true},"footerCopyrightLink":{"value":"206","fieldid":"723","type":"metadata_field_related_asset","is_contextable":true,"default_value":false,"use_default":true},"footerCTAHeading":{"value":"Help us improve","fieldid":"724","type":"metadata_field_text","is_contextable":true,"default_value":false,"use_default":true},"footerCTALead":{"value":"We are always looking for ways to improve our website.","fieldid":"725","type":"metadata_field_text","is_contextable":true,"default_value":false,"use_default":true},"footerCTALink":{"value":"186","fieldid":"726","type":"metadata_field_related_asset","is_contextable":true,"default_value":false,"use_default":true}},"children":[{"asset_name":"Get started","asset_assetid":"186"},{"asset_name":"Brand guidelines","asset_assetid":"190"},{"asset_name":"Content guidelines","asset_assetid":"194"},{"asset_name":"Components","asset_assetid":"198"},{"asset_name":"Examples","asset_assetid":"202"},{"asset_name":"Support","asset_assetid":"206"}]},"current":{"data":{"assetid":"676","type_code":"page_standard","version":"0.0.16","name":"Links","short_name":"Links","status":"2","force_secure":"0","languages":"en","charset":"utf-8","created":"2021-01-11 11:48:22","created_userid":"312","updated":"2021-01-20 15:08:29","updated_userid":"312","published":"Never","published_userid":"","status_changed":"2021-01-11 11:48:22","status_changed_userid":"312","thumbnail":"","attributes":{"name":{"attrid":"631","type":"text","value":"Links","is_contextable":true,"use_default":true},"short_name":{"attrid":"632","type":"text","value":"Links","is_contextable":true,"use_default":true},"available_conditions":{"attrid":"633","type":"serialise","value":[],"is_contextable":false,"use_default":true},"conditions":{"attrid":"634","type":"serialise","value":[],"is_contextable":true,"use_default":true}},"metadata":{"description":{"value":"","fieldid":"132","type":"metadata_field_text","is_contextable":true,"default_value":true,"use_default":true},"pageType":{"value":"landing","fieldid":"680","type":"metadata_field_select","is_contextable":true,"default_value":false,"use_default":true},"displayBreadcrumbs":{"value":"true","fieldid":"681","type":"metadata_field_select","is_contextable":true,"default_value":true,"use_default":true},"displayBanner":{"value":"true","fieldid":"682","type":"metadata_field_select","is_contextable":true,"default_value":true,"use_default":true},"displayInPageNav":{"value":"true","fieldid":"808","type":"metadata_field_select","is_contextable":true,"default_value":true,"use_default":true},"inPageNav_heading":{"value":"On this page","fieldid":"809","type":"metadata_field_text","is_contextable":true,"default_value":true,"use_default":true},"inPageNav_headingType":{"value":"h2","fieldid":"810","type":"metadata_field_select","is_contextable":true,"default_value":true,"use_default":true}}},"home":0,"children":[{"asset_assetid":"458","asset_url":"https://qhscb.squiz.cloud/components/accordion","asset_name":"Accordion","children":[]},{"asset_assetid":"325","asset_url":"https://qhscb.squiz.cloud/components/callout","asset_name":"Callout","children":[]},{"asset_assetid":"659","asset_url":"https://qhscb.squiz.cloud/components/card-listing","asset_name":"Card Listing","children":[]},{"asset_assetid":"676","asset_url":"https://qhscb.squiz.cloud/components/links","asset_name":"Links","children":[]},{"asset_assetid":"683","asset_url":"https://qhscb.squiz.cloud/components/search-box","asset_name":"Search Box","children":[]},{"asset_assetid":"785","asset_url":"https://qhscb.squiz.cloud/components/page-alert","asset_name":"Page Alert","children":[]}],"lineage":[{"asset_assetid":"136","asset_name":"Design System","asset_url":"https://qhscb.squiz.cloud"},{"asset_assetid":"198","asset_name":"Components","asset_url":"https://qhscb.squiz.cloud/components"},{"asset_assetid":"676","asset_name":"Links","asset_url":"https://qhscb.squiz.cloud/components/links"}],"top":{"asset_assetid":"198","asset_name":"Components","asset_url":"https://qhscb.squiz.cloud/components"}}};
+            var globals = {
+                site: {
+                    data: {
+                        assetid: "136",
+                        type_code: "site",
+                        version: "0.0.8",
+                        name: "Design System",
+                        short_name: "Design System",
+                        status: "2",
+                        force_secure: "0",
+                        languages: "en",
+                        charset: "utf-8",
+                        created: "2020-12-09 13:11:12",
+                        created_userid: "54",
+                        updated: "2021-01-20 15:08:30",
+                        updated_userid: "312",
+                        published: "Never",
+                        published_userid: "",
+                        status_changed: "2020-12-09 13:11:12",
+                        status_changed_userid: "54",
+                        thumbnail: "",
+                        attributes: {
+                            name: { attrid: "685", type: "text", value: "Design System", is_contextable: true, use_default: true },
+                            not_found_page_cache_globally: { attrid: "686", type: "boolean", value: false, is_contextable: false, use_default: true },
+                            available_conditions: { attrid: "687", type: "serialise", value: [], is_contextable: false, use_default: true },
+                        },
+                        metadata: {
+                            displayInPageNav: { value: "", fieldid: "808", type: "metadata_field_select", is_contextable: true, default_value: true, use_default: true },
+                            inPageNav_heading: { value: "On this page", fieldid: "809", type: "metadata_field_text", is_contextable: true, default_value: true, use_default: true },
+                            inPageNav_headingType: { value: "h2", fieldid: "810", type: "metadata_field_select", is_contextable: true, default_value: true, use_default: true },
+                            siteTitle: { value: "Queensland Health Design System", fieldid: "166", type: "metadata_field_text", is_contextable: true, default_value: false, use_default: true },
+                            siteLogo: { value: "169", fieldid: "127", type: "metadata_field_related_asset", is_contextable: true, default_value: false, use_default: true },
+                            siteFavicon: { value: "106", fieldid: "128", type: "metadata_field_related_asset", is_contextable: true, default_value: false, use_default: true },
+                            siteAppleTouch: { value: "106", fieldid: "129", type: "metadata_field_related_asset", is_contextable: true, default_value: false, use_default: true },
+                            sitePreHeaderLogo: { value: "170", fieldid: "171", type: "metadata_field_related_asset", is_contextable: true, default_value: false, use_default: true },
+                            sitePreHeaderText: { value: "digital.qld.gov.au", fieldid: "167", type: "metadata_field_text", is_contextable: true, default_value: false, use_default: true },
+                            sitePreHeaderURL: { value: "http://www.digital.qld.gov.au", fieldid: "168", type: "metadata_field_text", is_contextable: true, default_value: false, use_default: true },
+                            showHomeIcon: { value: "true", fieldid: "481", type: "metadata_field_select", is_contextable: true, default_value: true, use_default: true },
+                            siteRepository: { value: "164", fieldid: "213", type: "metadata_field_related_asset", is_contextable: true, default_value: false, use_default: true },
+                            footerLinks: { value: '["186","194","198","458","676"]', fieldid: "715", type: "metadata_field_related_asset", is_contextable: true, default_value: false, use_default: true },
+                            footerCopyrightMessage: { value: "© The State of Queensland 2020", fieldid: "722", type: "metadata_field_text", is_contextable: true, default_value: true, use_default: true },
+                            footerCopyrightLink: { value: "206", fieldid: "723", type: "metadata_field_related_asset", is_contextable: true, default_value: false, use_default: true },
+                            footerCTAHeading: { value: "Help us improve", fieldid: "724", type: "metadata_field_text", is_contextable: true, default_value: false, use_default: true },
+                            footerCTALead: { value: "We are always looking for ways to improve our website.", fieldid: "725", type: "metadata_field_text", is_contextable: true, default_value: false, use_default: true },
+                            footerCTALink: { value: "186", fieldid: "726", type: "metadata_field_related_asset", is_contextable: true, default_value: false, use_default: true },
+                        },
+                    },
+                    metadata: {
+                        displayInPageNav: { value: "", fieldid: "808", type: "metadata_field_select", is_contextable: true, default_value: true, use_default: true },
+                        inPageNav_heading: { value: "On this page", fieldid: "809", type: "metadata_field_text", is_contextable: true, default_value: true, use_default: true },
+                        inPageNav_headingType: { value: "h2", fieldid: "810", type: "metadata_field_select", is_contextable: true, default_value: true, use_default: true },
+                        siteTitle: { value: "Queensland Health Design System", fieldid: "166", type: "metadata_field_text", is_contextable: true, default_value: false, use_default: true },
+                        siteLogo: { value: "169", fieldid: "127", type: "metadata_field_related_asset", is_contextable: true, default_value: false, use_default: true },
+                        siteFavicon: { value: "106", fieldid: "128", type: "metadata_field_related_asset", is_contextable: true, default_value: false, use_default: true },
+                        siteAppleTouch: { value: "106", fieldid: "129", type: "metadata_field_related_asset", is_contextable: true, default_value: false, use_default: true },
+                        sitePreHeaderLogo: { value: "170", fieldid: "171", type: "metadata_field_related_asset", is_contextable: true, default_value: false, use_default: true },
+                        sitePreHeaderText: { value: "digital.qld.gov.au", fieldid: "167", type: "metadata_field_text", is_contextable: true, default_value: false, use_default: true },
+                        sitePreHeaderURL: { value: "http://www.digital.qld.gov.au", fieldid: "168", type: "metadata_field_text", is_contextable: true, default_value: false, use_default: true },
+                        showHomeIcon: { value: "true", fieldid: "481", type: "metadata_field_select", is_contextable: true, default_value: true, use_default: true },
+                        siteRepository: { value: "164", fieldid: "213", type: "metadata_field_related_asset", is_contextable: true, default_value: false, use_default: true },
+                        footerLinks: { value: '["186","194","198","458","676"]', fieldid: "715", type: "metadata_field_related_asset", is_contextable: true, default_value: false, use_default: true },
+                        footerCopyrightMessage: { value: "© The State of Queensland 2020", fieldid: "722", type: "metadata_field_text", is_contextable: true, default_value: true, use_default: true },
+                        footerCopyrightLink: { value: "206", fieldid: "723", type: "metadata_field_related_asset", is_contextable: true, default_value: false, use_default: true },
+                        footerCTAHeading: { value: "Help us improve", fieldid: "724", type: "metadata_field_text", is_contextable: true, default_value: false, use_default: true },
+                        footerCTALead: { value: "We are always looking for ways to improve our website.", fieldid: "725", type: "metadata_field_text", is_contextable: true, default_value: false, use_default: true },
+                        footerCTALink: { value: "186", fieldid: "726", type: "metadata_field_related_asset", is_contextable: true, default_value: false, use_default: true },
+                    },
+                    children: [
+                        { asset_name: "Get started", asset_assetid: "186" },
+                        { asset_name: "Brand guidelines", asset_assetid: "190" },
+                        { asset_name: "Content guidelines", asset_assetid: "194" },
+                        { asset_name: "Components", asset_assetid: "198" },
+                        { asset_name: "Examples", asset_assetid: "202" },
+                        { asset_name: "Support", asset_assetid: "206" },
+                    ],
+                },
+                current: {
+                    data: {
+                        assetid: "676",
+                        type_code: "page_standard",
+                        version: "0.0.16",
+                        name: "Links",
+                        short_name: "Links",
+                        status: "2",
+                        force_secure: "0",
+                        languages: "en",
+                        charset: "utf-8",
+                        created: "2021-01-11 11:48:22",
+                        created_userid: "312",
+                        updated: "2021-01-20 15:08:29",
+                        updated_userid: "312",
+                        published: "Never",
+                        published_userid: "",
+                        status_changed: "2021-01-11 11:48:22",
+                        status_changed_userid: "312",
+                        thumbnail: "",
+                        attributes: {
+                            name: { attrid: "631", type: "text", value: "Links", is_contextable: true, use_default: true },
+                            short_name: { attrid: "632", type: "text", value: "Links", is_contextable: true, use_default: true },
+                            available_conditions: { attrid: "633", type: "serialise", value: [], is_contextable: false, use_default: true },
+                            conditions: { attrid: "634", type: "serialise", value: [], is_contextable: true, use_default: true },
+                        },
+                        metadata: {
+                            description: { value: "", fieldid: "132", type: "metadata_field_text", is_contextable: true, default_value: true, use_default: true },
+                            pageType: { value: "landing", fieldid: "680", type: "metadata_field_select", is_contextable: true, default_value: false, use_default: true },
+                            displayBreadcrumbs: { value: "true", fieldid: "681", type: "metadata_field_select", is_contextable: true, default_value: true, use_default: true },
+                            displayBanner: { value: "true", fieldid: "682", type: "metadata_field_select", is_contextable: true, default_value: true, use_default: true },
+                            displayInPageNav: { value: "true", fieldid: "808", type: "metadata_field_select", is_contextable: true, default_value: true, use_default: true },
+                            inPageNav_heading: { value: "On this page", fieldid: "809", type: "metadata_field_text", is_contextable: true, default_value: true, use_default: true },
+                            inPageNav_headingType: { value: "h2", fieldid: "810", type: "metadata_field_select", is_contextable: true, default_value: true, use_default: true },
+                        },
+                    },
+                    home: 0,
+                    children: [
+                        { asset_assetid: "458", asset_url: "https://qhscb.squiz.cloud/components/accordion", asset_name: "Accordion", children: [] },
+                        { asset_assetid: "325", asset_url: "https://qhscb.squiz.cloud/components/callout", asset_name: "Callout", children: [] },
+                        { asset_assetid: "659", asset_url: "https://qhscb.squiz.cloud/components/card-listing", asset_name: "Card Listing", children: [] },
+                        { asset_assetid: "676", asset_url: "https://qhscb.squiz.cloud/components/links", asset_name: "Links", children: [] },
+                        { asset_assetid: "683", asset_url: "https://qhscb.squiz.cloud/components/search-box", asset_name: "Search Box", children: [] },
+                        { asset_assetid: "785", asset_url: "https://qhscb.squiz.cloud/components/page-alert", asset_name: "Page Alert", children: [] },
+                    ],
+                    lineage: [
+                        { asset_assetid: "136", asset_name: "Design System", asset_url: "https://qhscb.squiz.cloud" },
+                        { asset_assetid: "198", asset_name: "Components", asset_url: "https://qhscb.squiz.cloud/components" },
+                        { asset_assetid: "676", asset_name: "Links", asset_url: "https://qhscb.squiz.cloud/components/links" },
+                    ],
+                    top: { asset_assetid: "198", asset_name: "Components", asset_url: "https://qhscb.squiz.cloud/components" },
+                },
+            };
         </script>
     </head>
 
     <body class="qld__grid">
         <!--noindex-->
-        ${require('../components/header/html/component.hbs')({
-            "site":require('/src/data/site.json')
-        })}
+        ${require('../components/header/html/component.hbs')({ "site":require('/src/data/site.json') })}
         <!--endnoindex-->
-        ${require('../components/mega_main_navigation/html/component.hbs')({
-            "site":require('/src/data/site.json')
-        })}
+        ${require('../components/mega_main_navigation/html/component.hbs')({ "site":require('/src/data/site.json') })}
         <!-- MAIN BODY -->
         <main class="main" role="main">
             <section class="qld__body qld__body--breadcrumb">
                 <div class="container-fluid">
-                    ${require('../components/breadcrumbs/html/component.hbs')({
-                        "site":require('/src/data/site.json'),
-                        "current":require('/src/data/current.json'),
-                    })}
+                    <nav class="qld__breadcrumbs" aria-label="breadcrumb">
+                        <ol class="qld__breadcrumbs__list--desktop qld__link-list qld__link-list--inline">
+                            <li class="qld__breadcrumbs__item">
+                                <a href="#">Home</a>
+                            </li>
+                            <li class="qld__breadcrumbs__item">
+                                <a href="#">Component test</a>
+                            </li>
+                            <li class="qld__breadcrumbs__item">
+                                <a href="#">Component test</a>
+                            </li>
+                            <li class="qld__breadcrumbs__item">
+                                <a href="#">Component test</a>
+                            </li>
+                            <li class="qld__breadcrumbs__item">
+                                <a href="#">Component test</a>
+                            </li>
+                            <li class="qld__breadcrumbs__item" aria-current="page">Breadcrumbs</li>
+                        </ol>
+                    </nav>
                 </div>
             </section>
+
+            <section class="qld__body qld__body--breadcrumb">
+                <div class="container-fluid">${require('../components/breadcrumbs/html/component.hbs')({ "site":require('/src/data/site.json'), "current":require('/src/data/current.json'), })}</div>
+            </section>
+
             <!--CONTENT-->
             <div class="qld__body">
                 <div class="container-fluid">
                     <div class="row">
                         <div class="col-xs-12 col-lg-4 col-xl-3">
                             <!-- INTERNAL NAVIGATION -->
-                            ${require('../components/internal_navigation/html/component.hbs')({
-                                "site":require('/src/data/site.json'),
-                                "current":require('/src/data/current.json')
-                            })}
+                            ${require('../components/internal_navigation/html/component.hbs')({ "site":require('/src/data/site.json'), "current":require('/src/data/current.json') })}
                         </div>
                         <div class="col-xs-12 col-lg-8 col-xl-8" id="content">
-                            
-                            ${require('../components/_global/html/component.hbs')({
-                                "manifest":require('../components/breadcrumbs/js/manifest.json'),
-                                "component":require('!url-loader!../components/breadcrumbs/html/component.hbs'),
-                                "component_output":require('../components/breadcrumbs/html/component.hbs')({
-                                    "data":require('../components/breadcrumbs/js/manifest.json').data,
-                                    "site":require('/src/data/site.json'),
-                                    "current":require('/src/data/current.json'),
-                                    "content":"Lorem Ipsum"
-                                })
-                            })}
+                            ${require('../components/_global/html/component.hbs')({ "manifest":require('../components/breadcrumbs/js/manifest.json'), "component":require('!url-loader!../components/breadcrumbs/html/component.hbs'),
+                            "component_output":require('../components/breadcrumbs/html/component.hbs')({ "data":require('../components/breadcrumbs/js/manifest.json').data, "site":require('/src/data/site.json'),
+                            "current":require('/src/data/current.json'), "content":"Lorem Ipsum" }) })}
                         </div>
                     </div>
                 </div>
-            </div>  
+            </div>
         </main>
         <!-- END MAIN BODY -->
 
         <!-- WIDGETS -->
-        ${require('../components/widgets/html/component.hbs')({
-            "site":require('/src/data/site.json'),
-            "current":require('/src/data/current.json')
-        })}
-        
-        <!-- FOOTER-->
-        ${require('../components/footer/html/component.hbs')({
-            "site":require('/src/data/site.json')
-        })}
+        ${require('../components/widgets/html/component.hbs')({ "site":require('/src/data/site.json'), "current":require('/src/data/current.json') })}
 
-        <div class="footer-scripts" id="footer_js" style="display: none !important;">
-            ${require('../components/_global/html/scripts.html')}
-        </div>
+        <!-- FOOTER-->
+        ${require('../components/footer/html/component.hbs')({ "site":require('/src/data/site.json') })}
+
+        <div class="footer-scripts" id="footer_js" style="display: none !important">${require('../components/_global/html/scripts.html')}</div>
     </body>
 </html>

--- a/src/html/component-breadcrumbs.html
+++ b/src/html/component-breadcrumbs.html
@@ -14,202 +14,75 @@
 
     <head>
         <title>Queensland Design System</title>
-
+        
         ${require('../components/_global/html/head.html')}
         <script>
-            var globals = {
-                site: {
-                    data: {
-                        assetid: "136",
-                        type_code: "site",
-                        version: "0.0.8",
-                        name: "Design System",
-                        short_name: "Design System",
-                        status: "2",
-                        force_secure: "0",
-                        languages: "en",
-                        charset: "utf-8",
-                        created: "2020-12-09 13:11:12",
-                        created_userid: "54",
-                        updated: "2021-01-20 15:08:30",
-                        updated_userid: "312",
-                        published: "Never",
-                        published_userid: "",
-                        status_changed: "2020-12-09 13:11:12",
-                        status_changed_userid: "54",
-                        thumbnail: "",
-                        attributes: {
-                            name: { attrid: "685", type: "text", value: "Design System", is_contextable: true, use_default: true },
-                            not_found_page_cache_globally: { attrid: "686", type: "boolean", value: false, is_contextable: false, use_default: true },
-                            available_conditions: { attrid: "687", type: "serialise", value: [], is_contextable: false, use_default: true },
-                        },
-                        metadata: {
-                            displayInPageNav: { value: "", fieldid: "808", type: "metadata_field_select", is_contextable: true, default_value: true, use_default: true },
-                            inPageNav_heading: { value: "On this page", fieldid: "809", type: "metadata_field_text", is_contextable: true, default_value: true, use_default: true },
-                            inPageNav_headingType: { value: "h2", fieldid: "810", type: "metadata_field_select", is_contextable: true, default_value: true, use_default: true },
-                            siteTitle: { value: "Queensland Health Design System", fieldid: "166", type: "metadata_field_text", is_contextable: true, default_value: false, use_default: true },
-                            siteLogo: { value: "169", fieldid: "127", type: "metadata_field_related_asset", is_contextable: true, default_value: false, use_default: true },
-                            siteFavicon: { value: "106", fieldid: "128", type: "metadata_field_related_asset", is_contextable: true, default_value: false, use_default: true },
-                            siteAppleTouch: { value: "106", fieldid: "129", type: "metadata_field_related_asset", is_contextable: true, default_value: false, use_default: true },
-                            sitePreHeaderLogo: { value: "170", fieldid: "171", type: "metadata_field_related_asset", is_contextable: true, default_value: false, use_default: true },
-                            sitePreHeaderText: { value: "digital.qld.gov.au", fieldid: "167", type: "metadata_field_text", is_contextable: true, default_value: false, use_default: true },
-                            sitePreHeaderURL: { value: "http://www.digital.qld.gov.au", fieldid: "168", type: "metadata_field_text", is_contextable: true, default_value: false, use_default: true },
-                            showHomeIcon: { value: "true", fieldid: "481", type: "metadata_field_select", is_contextable: true, default_value: true, use_default: true },
-                            siteRepository: { value: "164", fieldid: "213", type: "metadata_field_related_asset", is_contextable: true, default_value: false, use_default: true },
-                            footerLinks: { value: '["186","194","198","458","676"]', fieldid: "715", type: "metadata_field_related_asset", is_contextable: true, default_value: false, use_default: true },
-                            footerCopyrightMessage: { value: "© The State of Queensland 2020", fieldid: "722", type: "metadata_field_text", is_contextable: true, default_value: true, use_default: true },
-                            footerCopyrightLink: { value: "206", fieldid: "723", type: "metadata_field_related_asset", is_contextable: true, default_value: false, use_default: true },
-                            footerCTAHeading: { value: "Help us improve", fieldid: "724", type: "metadata_field_text", is_contextable: true, default_value: false, use_default: true },
-                            footerCTALead: { value: "We are always looking for ways to improve our website.", fieldid: "725", type: "metadata_field_text", is_contextable: true, default_value: false, use_default: true },
-                            footerCTALink: { value: "186", fieldid: "726", type: "metadata_field_related_asset", is_contextable: true, default_value: false, use_default: true },
-                        },
-                    },
-                    metadata: {
-                        displayInPageNav: { value: "", fieldid: "808", type: "metadata_field_select", is_contextable: true, default_value: true, use_default: true },
-                        inPageNav_heading: { value: "On this page", fieldid: "809", type: "metadata_field_text", is_contextable: true, default_value: true, use_default: true },
-                        inPageNav_headingType: { value: "h2", fieldid: "810", type: "metadata_field_select", is_contextable: true, default_value: true, use_default: true },
-                        siteTitle: { value: "Queensland Health Design System", fieldid: "166", type: "metadata_field_text", is_contextable: true, default_value: false, use_default: true },
-                        siteLogo: { value: "169", fieldid: "127", type: "metadata_field_related_asset", is_contextable: true, default_value: false, use_default: true },
-                        siteFavicon: { value: "106", fieldid: "128", type: "metadata_field_related_asset", is_contextable: true, default_value: false, use_default: true },
-                        siteAppleTouch: { value: "106", fieldid: "129", type: "metadata_field_related_asset", is_contextable: true, default_value: false, use_default: true },
-                        sitePreHeaderLogo: { value: "170", fieldid: "171", type: "metadata_field_related_asset", is_contextable: true, default_value: false, use_default: true },
-                        sitePreHeaderText: { value: "digital.qld.gov.au", fieldid: "167", type: "metadata_field_text", is_contextable: true, default_value: false, use_default: true },
-                        sitePreHeaderURL: { value: "http://www.digital.qld.gov.au", fieldid: "168", type: "metadata_field_text", is_contextable: true, default_value: false, use_default: true },
-                        showHomeIcon: { value: "true", fieldid: "481", type: "metadata_field_select", is_contextable: true, default_value: true, use_default: true },
-                        siteRepository: { value: "164", fieldid: "213", type: "metadata_field_related_asset", is_contextable: true, default_value: false, use_default: true },
-                        footerLinks: { value: '["186","194","198","458","676"]', fieldid: "715", type: "metadata_field_related_asset", is_contextable: true, default_value: false, use_default: true },
-                        footerCopyrightMessage: { value: "© The State of Queensland 2020", fieldid: "722", type: "metadata_field_text", is_contextable: true, default_value: true, use_default: true },
-                        footerCopyrightLink: { value: "206", fieldid: "723", type: "metadata_field_related_asset", is_contextable: true, default_value: false, use_default: true },
-                        footerCTAHeading: { value: "Help us improve", fieldid: "724", type: "metadata_field_text", is_contextable: true, default_value: false, use_default: true },
-                        footerCTALead: { value: "We are always looking for ways to improve our website.", fieldid: "725", type: "metadata_field_text", is_contextable: true, default_value: false, use_default: true },
-                        footerCTALink: { value: "186", fieldid: "726", type: "metadata_field_related_asset", is_contextable: true, default_value: false, use_default: true },
-                    },
-                    children: [
-                        { asset_name: "Get started", asset_assetid: "186" },
-                        { asset_name: "Brand guidelines", asset_assetid: "190" },
-                        { asset_name: "Content guidelines", asset_assetid: "194" },
-                        { asset_name: "Components", asset_assetid: "198" },
-                        { asset_name: "Examples", asset_assetid: "202" },
-                        { asset_name: "Support", asset_assetid: "206" },
-                    ],
-                },
-                current: {
-                    data: {
-                        assetid: "676",
-                        type_code: "page_standard",
-                        version: "0.0.16",
-                        name: "Links",
-                        short_name: "Links",
-                        status: "2",
-                        force_secure: "0",
-                        languages: "en",
-                        charset: "utf-8",
-                        created: "2021-01-11 11:48:22",
-                        created_userid: "312",
-                        updated: "2021-01-20 15:08:29",
-                        updated_userid: "312",
-                        published: "Never",
-                        published_userid: "",
-                        status_changed: "2021-01-11 11:48:22",
-                        status_changed_userid: "312",
-                        thumbnail: "",
-                        attributes: {
-                            name: { attrid: "631", type: "text", value: "Links", is_contextable: true, use_default: true },
-                            short_name: { attrid: "632", type: "text", value: "Links", is_contextable: true, use_default: true },
-                            available_conditions: { attrid: "633", type: "serialise", value: [], is_contextable: false, use_default: true },
-                            conditions: { attrid: "634", type: "serialise", value: [], is_contextable: true, use_default: true },
-                        },
-                        metadata: {
-                            description: { value: "", fieldid: "132", type: "metadata_field_text", is_contextable: true, default_value: true, use_default: true },
-                            pageType: { value: "landing", fieldid: "680", type: "metadata_field_select", is_contextable: true, default_value: false, use_default: true },
-                            displayBreadcrumbs: { value: "true", fieldid: "681", type: "metadata_field_select", is_contextable: true, default_value: true, use_default: true },
-                            displayBanner: { value: "true", fieldid: "682", type: "metadata_field_select", is_contextable: true, default_value: true, use_default: true },
-                            displayInPageNav: { value: "true", fieldid: "808", type: "metadata_field_select", is_contextable: true, default_value: true, use_default: true },
-                            inPageNav_heading: { value: "On this page", fieldid: "809", type: "metadata_field_text", is_contextable: true, default_value: true, use_default: true },
-                            inPageNav_headingType: { value: "h2", fieldid: "810", type: "metadata_field_select", is_contextable: true, default_value: true, use_default: true },
-                        },
-                    },
-                    home: 0,
-                    children: [
-                        { asset_assetid: "458", asset_url: "https://qhscb.squiz.cloud/components/accordion", asset_name: "Accordion", children: [] },
-                        { asset_assetid: "325", asset_url: "https://qhscb.squiz.cloud/components/callout", asset_name: "Callout", children: [] },
-                        { asset_assetid: "659", asset_url: "https://qhscb.squiz.cloud/components/card-listing", asset_name: "Card Listing", children: [] },
-                        { asset_assetid: "676", asset_url: "https://qhscb.squiz.cloud/components/links", asset_name: "Links", children: [] },
-                        { asset_assetid: "683", asset_url: "https://qhscb.squiz.cloud/components/search-box", asset_name: "Search Box", children: [] },
-                        { asset_assetid: "785", asset_url: "https://qhscb.squiz.cloud/components/page-alert", asset_name: "Page Alert", children: [] },
-                    ],
-                    lineage: [
-                        { asset_assetid: "136", asset_name: "Design System", asset_url: "https://qhscb.squiz.cloud" },
-                        { asset_assetid: "198", asset_name: "Components", asset_url: "https://qhscb.squiz.cloud/components" },
-                        { asset_assetid: "676", asset_name: "Links", asset_url: "https://qhscb.squiz.cloud/components/links" },
-                    ],
-                    top: { asset_assetid: "198", asset_name: "Components", asset_url: "https://qhscb.squiz.cloud/components" },
-                },
-            };
+            var globals = {"site":{"data":{"assetid":"136","type_code":"site","version":"0.0.8","name":"Design System","short_name":"Design System","status":"2","force_secure":"0","languages":"en","charset":"utf-8","created":"2020-12-09 13:11:12","created_userid":"54","updated":"2021-01-20 15:08:30","updated_userid":"312","published":"Never","published_userid":"","status_changed":"2020-12-09 13:11:12","status_changed_userid":"54","thumbnail":"","attributes":{"name":{"attrid":"685","type":"text","value":"Design System","is_contextable":true,"use_default":true},"not_found_page_cache_globally":{"attrid":"686","type":"boolean","value":false,"is_contextable":false,"use_default":true},"available_conditions":{"attrid":"687","type":"serialise","value":[],"is_contextable":false,"use_default":true}},"metadata":{"displayInPageNav":{"value":"","fieldid":"808","type":"metadata_field_select","is_contextable":true,"default_value":true,"use_default":true},"inPageNav_heading":{"value":"On this page","fieldid":"809","type":"metadata_field_text","is_contextable":true,"default_value":true,"use_default":true},"inPageNav_headingType":{"value":"h2","fieldid":"810","type":"metadata_field_select","is_contextable":true,"default_value":true,"use_default":true},"siteTitle":{"value":"Queensland Health Design System","fieldid":"166","type":"metadata_field_text","is_contextable":true,"default_value":false,"use_default":true},"siteLogo":{"value":"169","fieldid":"127","type":"metadata_field_related_asset","is_contextable":true,"default_value":false,"use_default":true},"siteFavicon":{"value":"106","fieldid":"128","type":"metadata_field_related_asset","is_contextable":true,"default_value":false,"use_default":true},"siteAppleTouch":{"value":"106","fieldid":"129","type":"metadata_field_related_asset","is_contextable":true,"default_value":false,"use_default":true},"sitePreHeaderLogo":{"value":"170","fieldid":"171","type":"metadata_field_related_asset","is_contextable":true,"default_value":false,"use_default":true},"sitePreHeaderText":{"value":"digital.qld.gov.au","fieldid":"167","type":"metadata_field_text","is_contextable":true,"default_value":false,"use_default":true},"sitePreHeaderURL":{"value":"http://www.digital.qld.gov.au","fieldid":"168","type":"metadata_field_text","is_contextable":true,"default_value":false,"use_default":true},"showHomeIcon":{"value":"true","fieldid":"481","type":"metadata_field_select","is_contextable":true,"default_value":true,"use_default":true},"siteRepository":{"value":"164","fieldid":"213","type":"metadata_field_related_asset","is_contextable":true,"default_value":false,"use_default":true},"footerLinks":{"value":"[\"186\",\"194\",\"198\",\"458\",\"676\"]","fieldid":"715","type":"metadata_field_related_asset","is_contextable":true,"default_value":false,"use_default":true},"footerCopyrightMessage":{"value":"© The State of Queensland 2020","fieldid":"722","type":"metadata_field_text","is_contextable":true,"default_value":true,"use_default":true},"footerCopyrightLink":{"value":"206","fieldid":"723","type":"metadata_field_related_asset","is_contextable":true,"default_value":false,"use_default":true},"footerCTAHeading":{"value":"Help us improve","fieldid":"724","type":"metadata_field_text","is_contextable":true,"default_value":false,"use_default":true},"footerCTALead":{"value":"We are always looking for ways to improve our website.","fieldid":"725","type":"metadata_field_text","is_contextable":true,"default_value":false,"use_default":true},"footerCTALink":{"value":"186","fieldid":"726","type":"metadata_field_related_asset","is_contextable":true,"default_value":false,"use_default":true}}},"metadata":{"displayInPageNav":{"value":"","fieldid":"808","type":"metadata_field_select","is_contextable":true,"default_value":true,"use_default":true},"inPageNav_heading":{"value":"On this page","fieldid":"809","type":"metadata_field_text","is_contextable":true,"default_value":true,"use_default":true},"inPageNav_headingType":{"value":"h2","fieldid":"810","type":"metadata_field_select","is_contextable":true,"default_value":true,"use_default":true},"siteTitle":{"value":"Queensland Health Design System","fieldid":"166","type":"metadata_field_text","is_contextable":true,"default_value":false,"use_default":true},"siteLogo":{"value":"169","fieldid":"127","type":"metadata_field_related_asset","is_contextable":true,"default_value":false,"use_default":true},"siteFavicon":{"value":"106","fieldid":"128","type":"metadata_field_related_asset","is_contextable":true,"default_value":false,"use_default":true},"siteAppleTouch":{"value":"106","fieldid":"129","type":"metadata_field_related_asset","is_contextable":true,"default_value":false,"use_default":true},"sitePreHeaderLogo":{"value":"170","fieldid":"171","type":"metadata_field_related_asset","is_contextable":true,"default_value":false,"use_default":true},"sitePreHeaderText":{"value":"digital.qld.gov.au","fieldid":"167","type":"metadata_field_text","is_contextable":true,"default_value":false,"use_default":true},"sitePreHeaderURL":{"value":"http://www.digital.qld.gov.au","fieldid":"168","type":"metadata_field_text","is_contextable":true,"default_value":false,"use_default":true},"showHomeIcon":{"value":"true","fieldid":"481","type":"metadata_field_select","is_contextable":true,"default_value":true,"use_default":true},"siteRepository":{"value":"164","fieldid":"213","type":"metadata_field_related_asset","is_contextable":true,"default_value":false,"use_default":true},"footerLinks":{"value":"[\"186\",\"194\",\"198\",\"458\",\"676\"]","fieldid":"715","type":"metadata_field_related_asset","is_contextable":true,"default_value":false,"use_default":true},"footerCopyrightMessage":{"value":"© The State of Queensland 2020","fieldid":"722","type":"metadata_field_text","is_contextable":true,"default_value":true,"use_default":true},"footerCopyrightLink":{"value":"206","fieldid":"723","type":"metadata_field_related_asset","is_contextable":true,"default_value":false,"use_default":true},"footerCTAHeading":{"value":"Help us improve","fieldid":"724","type":"metadata_field_text","is_contextable":true,"default_value":false,"use_default":true},"footerCTALead":{"value":"We are always looking for ways to improve our website.","fieldid":"725","type":"metadata_field_text","is_contextable":true,"default_value":false,"use_default":true},"footerCTALink":{"value":"186","fieldid":"726","type":"metadata_field_related_asset","is_contextable":true,"default_value":false,"use_default":true}},"children":[{"asset_name":"Get started","asset_assetid":"186"},{"asset_name":"Brand guidelines","asset_assetid":"190"},{"asset_name":"Content guidelines","asset_assetid":"194"},{"asset_name":"Components","asset_assetid":"198"},{"asset_name":"Examples","asset_assetid":"202"},{"asset_name":"Support","asset_assetid":"206"}]},"current":{"data":{"assetid":"676","type_code":"page_standard","version":"0.0.16","name":"Links","short_name":"Links","status":"2","force_secure":"0","languages":"en","charset":"utf-8","created":"2021-01-11 11:48:22","created_userid":"312","updated":"2021-01-20 15:08:29","updated_userid":"312","published":"Never","published_userid":"","status_changed":"2021-01-11 11:48:22","status_changed_userid":"312","thumbnail":"","attributes":{"name":{"attrid":"631","type":"text","value":"Links","is_contextable":true,"use_default":true},"short_name":{"attrid":"632","type":"text","value":"Links","is_contextable":true,"use_default":true},"available_conditions":{"attrid":"633","type":"serialise","value":[],"is_contextable":false,"use_default":true},"conditions":{"attrid":"634","type":"serialise","value":[],"is_contextable":true,"use_default":true}},"metadata":{"description":{"value":"","fieldid":"132","type":"metadata_field_text","is_contextable":true,"default_value":true,"use_default":true},"pageType":{"value":"landing","fieldid":"680","type":"metadata_field_select","is_contextable":true,"default_value":false,"use_default":true},"displayBreadcrumbs":{"value":"true","fieldid":"681","type":"metadata_field_select","is_contextable":true,"default_value":true,"use_default":true},"displayBanner":{"value":"true","fieldid":"682","type":"metadata_field_select","is_contextable":true,"default_value":true,"use_default":true},"displayInPageNav":{"value":"true","fieldid":"808","type":"metadata_field_select","is_contextable":true,"default_value":true,"use_default":true},"inPageNav_heading":{"value":"On this page","fieldid":"809","type":"metadata_field_text","is_contextable":true,"default_value":true,"use_default":true},"inPageNav_headingType":{"value":"h2","fieldid":"810","type":"metadata_field_select","is_contextable":true,"default_value":true,"use_default":true}}},"home":0,"children":[{"asset_assetid":"458","asset_url":"https://qhscb.squiz.cloud/components/accordion","asset_name":"Accordion","children":[]},{"asset_assetid":"325","asset_url":"https://qhscb.squiz.cloud/components/callout","asset_name":"Callout","children":[]},{"asset_assetid":"659","asset_url":"https://qhscb.squiz.cloud/components/card-listing","asset_name":"Card Listing","children":[]},{"asset_assetid":"676","asset_url":"https://qhscb.squiz.cloud/components/links","asset_name":"Links","children":[]},{"asset_assetid":"683","asset_url":"https://qhscb.squiz.cloud/components/search-box","asset_name":"Search Box","children":[]},{"asset_assetid":"785","asset_url":"https://qhscb.squiz.cloud/components/page-alert","asset_name":"Page Alert","children":[]}],"lineage":[{"asset_assetid":"136","asset_name":"Design System","asset_url":"https://qhscb.squiz.cloud"},{"asset_assetid":"198","asset_name":"Components","asset_url":"https://qhscb.squiz.cloud/components"},{"asset_assetid":"676","asset_name":"Links","asset_url":"https://qhscb.squiz.cloud/components/links"}],"top":{"asset_assetid":"198","asset_name":"Components","asset_url":"https://qhscb.squiz.cloud/components"}}};
         </script>
     </head>
 
     <body class="qld__grid">
         <!--noindex-->
-        ${require('../components/header/html/component.hbs')({ "site":require('/src/data/site.json') })}
+        ${require('../components/header/html/component.hbs')({
+            "site":require('/src/data/site.json')
+        })}
         <!--endnoindex-->
-        ${require('../components/mega_main_navigation/html/component.hbs')({ "site":require('/src/data/site.json') })}
+        ${require('../components/mega_main_navigation/html/component.hbs')({
+            "site":require('/src/data/site.json')
+        })}
         <!-- MAIN BODY -->
         <main class="main" role="main">
             <section class="qld__body qld__body--breadcrumb">
                 <div class="container-fluid">
-                    <nav class="qld__breadcrumbs" aria-label="breadcrumb">
-                        <ol class="qld__breadcrumbs__list--desktop qld__link-list qld__link-list--inline">
-                            <li class="qld__breadcrumbs__item">
-                                <a href="#">Home</a>
-                            </li>
-                            <li class="qld__breadcrumbs__item">
-                                <a href="#">Component test</a>
-                            </li>
-                            <li class="qld__breadcrumbs__item">
-                                <a href="#">Component test</a>
-                            </li>
-                            <li class="qld__breadcrumbs__item">
-                                <a href="#">Component test</a>
-                            </li>
-                            <li class="qld__breadcrumbs__item">
-                                <a href="#">Component test</a>
-                            </li>
-                            <li class="qld__breadcrumbs__item" aria-current="page">Breadcrumbs</li>
-                        </ol>
-                    </nav>
+                    ${require('../components/breadcrumbs/html/component.hbs')({
+                        "site":require('/src/data/site.json'),
+                        "current":require('/src/data/current.json'),
+                    })}
                 </div>
             </section>
-
-            <section class="qld__body qld__body--breadcrumb">
-                <div class="container-fluid">${require('../components/breadcrumbs/html/component.hbs')({ "site":require('/src/data/site.json'), "current":require('/src/data/current.json'), })}</div>
-            </section>
-
             <!--CONTENT-->
             <div class="qld__body">
                 <div class="container-fluid">
                     <div class="row">
                         <div class="col-xs-12 col-lg-4 col-xl-3">
                             <!-- INTERNAL NAVIGATION -->
-                            ${require('../components/internal_navigation/html/component.hbs')({ "site":require('/src/data/site.json'), "current":require('/src/data/current.json') })}
+                            ${require('../components/internal_navigation/html/component.hbs')({
+                                "site":require('/src/data/site.json'),
+                                "current":require('/src/data/current.json')
+                            })}
                         </div>
                         <div class="col-xs-12 col-lg-8 col-xl-8" id="content">
-                            ${require('../components/_global/html/component.hbs')({ "manifest":require('../components/breadcrumbs/js/manifest.json'), "component":require('!url-loader!../components/breadcrumbs/html/component.hbs'),
-                            "component_output":require('../components/breadcrumbs/html/component.hbs')({ "data":require('../components/breadcrumbs/js/manifest.json').data, "site":require('/src/data/site.json'),
-                            "current":require('/src/data/current.json'), "content":"Lorem Ipsum" }) })}
+                            
+                            ${require('../components/_global/html/component.hbs')({
+                                "manifest":require('../components/breadcrumbs/js/manifest.json'),
+                                "component":require('!url-loader!../components/breadcrumbs/html/component.hbs'),
+                                "component_output":require('../components/breadcrumbs/html/component.hbs')({
+                                    "data":require('../components/breadcrumbs/js/manifest.json').data,
+                                    "site":require('/src/data/site.json'),
+                                    "current":require('/src/data/current.json'),
+                                    "content":"Lorem Ipsum"
+                                })
+                            })}
                         </div>
                     </div>
                 </div>
-            </div>
+            </div>  
         </main>
         <!-- END MAIN BODY -->
 
         <!-- WIDGETS -->
-        ${require('../components/widgets/html/component.hbs')({ "site":require('/src/data/site.json'), "current":require('/src/data/current.json') })}
-
+        ${require('../components/widgets/html/component.hbs')({
+            "site":require('/src/data/site.json'),
+            "current":require('/src/data/current.json')
+        })}
+        
         <!-- FOOTER-->
-        ${require('../components/footer/html/component.hbs')({ "site":require('/src/data/site.json') })}
+        ${require('../components/footer/html/component.hbs')({
+            "site":require('/src/data/site.json')
+        })}
 
-        <div class="footer-scripts" id="footer_js" style="display: none !important">${require('../components/_global/html/scripts.html')}</div>
+        <div class="footer-scripts" id="footer_js" style="display: none !important;">
+            ${require('../components/_global/html/scripts.html')}
+        </div>
     </body>
 </html>


### PR DESCRIPTION
https://squizgroup.atlassian.net/browse/QHWT-1280

This pull request includes changes to `src/components/breadcrumbs/css/component.scss`, `src/components/breadcrumbs/js/global.js`, and all other handlebar files that utilize the breadcrumb component. These changes update the way the chevron is styled on the ::after pseudo-element, and the way that the icon is displayed during a breadcrumb overflow.

Updates to stylesheet:
- [src/components/breadcrumbs/css/component.scss](https://github.com/Qld-Health-Online-Team/design-system/pull/243/files#diff-c9fc5116312e9a8de14f60fb23058d8b41d5027ccc6439ec1d67ca1e25ae1929)
  - Remove previous code that utilises the properties of `mask-image`
  - Add styling to the border of the `::after` pseudo-element
  - Add left spacing to overflow button to fix the alignment during an overflow

Updates to js:
- [src/components/breadcrumbs/js/global.js](https://github.com/Qld-Health-Online-Team/design-system/pull/243/files#diff-c9fc5116312e9a8de14f60fb23058d8b41d5027ccc6439ec1d67ca1e25ae1929)
  - Remove previous code that adds a static svg to the overflow
  - Modify `createOverflow` function to take a dynamic data path for the new svg. Also appends the svg
 
Updates to hbs files:
- Add data-path to all components that utilize the breadcrumbs component
  - Breadcrumbs
  - Banner
  - Banner advanced
  - Banner basic
  - Banner intermediate
  - Basic search

Testing sites:
- https://qhonline.com.au/qgds-development/component-core/breadcrumbs
- https://qhonline.com.au/qgds-development/for-health-professionals/test-child-2/one/_nocache
- https://www.designsystem.qld.gov.au/components/breadcrumbs

Testing instructions:
- Compare the chevrons on each page
- Compare the overflows on each page
- Check accessibility using a screen reader