### PR TITLE
QHWT-1285 | Pagination | Update svg icons

### DIFF
--- a/src/components/basic_search/html/component.hbs
+++ b/src/components/basic_search/html/component.hbs
@@ -337,7 +337,7 @@
                         {{#each resultsPage.pagination}}
                             {{#ifCond linkType '===' 'last'}}
                                 <li class="ellipsis">
-                                    <svg  class="qld__icon qld__icon--lg"xmlns="http://www.w3.org/2000/svg" viewBox="0 0 448 512" aria-hidden="true" focusable="false" width="24" height="32" role="img"><path fill="currentColor" d="M352 256C352 238.3 366.3 224 384 224C401.7 224 416 238.3 416 256C416 273.7 401.7 288 384 288C366.3 288 352 273.7 352 256zM192 256C192 238.3 206.3 224 224 224C241.7 224 256 238.3 256 256C256 273.7 241.7 288 224 288C206.3 288 192 273.7 192 256zM96 256C96 273.7 81.67 288 64 288C46.33 288 32 273.7 32 256C32 238.3 46.33 224 64 224C81.67 224 96 238.3 96 256z"/></svg>
+                                    <svg class="qld__icon qld__icon--lg" xmlns="http://www.w3.org/2000/svg" aria-hidden="true"><use href="{{@root.site.metadata.coreSiteIcons.value}}#more-horizontal"></use></svg>
                                 </li>
                             {{/ifCond}}
 
@@ -345,28 +345,29 @@
                                 {{#ifCond linkType '===' 'prev'}}
                                 <li class="prev">
                                     <a href="{{{url}}}" rel="prev" aria-label="Previous page of results">
-                                        <svg class="qld__icon qld__icon--sm" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 448 512" aria-hidden="true" focusable="false" width="16" height="16" role="img"><path fill="currentColor" d="M448 256C448 264.8 440.6 272 431.4 272H54.11l140.7 149.3c6.157 6.531 5.655 16.66-1.118 22.59C190.5 446.6 186.5 448 182.5 448c-4.505 0-9.009-1.75-12.28-5.25l-165.9-176c-5.752-6.094-5.752-15.41 0-21.5l165.9-176c6.19-6.562 16.69-7 23.45-1.094c6.773 5.938 7.275 16.06 1.118 22.59L54.11 240h377.3C440.6 240 448 247.2 448 256z"/></svg>
+                                        <svg class="qld__icon qld__icon--sm" xmlns="http://www.w3.org/2000/svg" aria-hidden="true"><use href="{{@root.site.metadata.coreSiteIcons.value}}#arrow-left"></use></svg>
                                         <span>Back</span>
                                     </a>
                                 {{/ifCond}}
                                 
                                 {{#if label}}
                                 <li class="{{linkType}}{{#if isCurrent}} active{{/if}}">
-                                    <a href="{{{url}}}" aria-current="page">{{label}}</a></li>
+                                    <a href="{{{url}}}" aria-current="page">{{label}}</a>
+                                </li>
                                 {{/if}}
 
                                 {{#ifCond linkType '===' 'next'}}
                                 <li class="next">
                                     <a href="{{{url}}}" rel="next" aria-label="Next page of results">
-                                    <span>Next</span>
-                                    <svg class="qld__icon qld__icon--sm" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 448 512" aria-hidden="true" focusable="false" width="16" height="16" role="img"><path fill="currentColor" d="M443.7 266.8l-165.9 176C274.5 446.3 269.1 448 265.5 448c-3.986 0-7.988-1.375-11.16-4.156c-6.773-5.938-7.275-16.06-1.118-22.59L393.9 272H16.59c-9.171 0-16.59-7.155-16.59-15.1S7.421 240 16.59 240h377.3l-140.7-149.3c-6.157-6.531-5.655-16.66 1.118-22.59c6.789-5.906 17.27-5.469 23.45 1.094l165.9 176C449.4 251.3 449.4 260.7 443.7 266.8z"/></svg>
+                                        <span>Next</span>
+                                        <svg class="qld__icon qld__icon--sm" xmlns="http://www.w3.org/2000/svg" aria-hidden="true"><use href="{{@root.site.metadata.coreSiteIcons.value}}#arrow-right"></use></svg>
                                     </a>
                                 {{/ifCond}}
                             </li>
                         
                             {{#ifCond linkType '===' 'first'}}
                                 <li class="ellipsis">
-                                    <svg class="qld__icon qld__icon--sm" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 448 512" aria-hidden="true" focusable="false" width="24" height="32" role="img"><path fill="currentColor" d="M352 256C352 238.3 366.3 224 384 224C401.7 224 416 238.3 416 256C416 273.7 401.7 288 384 288C366.3 288 352 273.7 352 256zM192 256C192 238.3 206.3 224 224 224C241.7 224 256 238.3 256 256C256 273.7 241.7 288 224 288C206.3 288 192 273.7 192 256zM96 256C96 273.7 81.67 288 64 288C46.33 288 32 273.7 32 256C32 238.3 46.33 224 64 224C81.67 224 96 238.3 96 256z"/></svg>
+                                    <svg class="qld__icon qld__icon--sm" xmlns="http://www.w3.org/2000/svg" aria-hidden="true"><use href="{{@root.site.metadata.coreSiteIcons.value}}#more-horizontal"></use></svg>
                                 </li>
                             {{/ifCond}}
                         {{/each}}

--- a/src/components/pagination/html/component.hbs
+++ b/src/components/pagination/html/component.hbs
@@ -4,7 +4,7 @@
         {{#each pagination}}
             {{#ifCond linkType '===' 'last'}}
                 <li class="ellipsis">
-                    <svg aria-hidden="true" focusable="false" xmlns="http://www.w3.org/2000/svg" class="qld__icon qld__icon--lg"><use href="{{@root.site.metadata.siteDefaultIcons.value}}#qld__icon__ellipsis"></use></svg>
+                    <svg aria-hidden="true" xmlns="http://www.w3.org/2000/svg" class="qld__icon qld__icon--lg"><use href="{{@root.site.metadata.coreSiteIcons.value}}#more-horizontal"></use></svg>
                 </li>
             {{/ifCond}}
 
@@ -12,7 +12,7 @@
                 {{#ifCond linkType '===' 'prev'}}
                 <li class="prev">
                     <a href="{{url}}" rel="prev" aria-label="Previous page of results" class="qld__search-pagination_link">
-                        <svg aria-hidden="true" focusable="false" xmlns="http://www.w3.org/2000/svg" class="qld__icon qld__icon--sm"><use href="{{@root.site.metadata.siteDefaultIcons.value}}#qld__icon__arrow-left"></use></svg>
+                        <svg aria-hidden="true" xmlns="http://www.w3.org/2000/svg" class="qld__icon qld__icon--sm"><use href="{{@root.site.metadata.coreSiteIcons.value}}#arrow-left"></use></svg>
                         <span>Back</span>
                     </a>
                 {{/ifCond}}
@@ -27,14 +27,14 @@
                 <li class="next">
                     <a href="{{url}}" rel="next" aria-label="Next page of results" class="qld__search-pagination_link">
                     <span>Next</span>
-                    <svg aria-hidden="true" focusable="false" xmlns="http://www.w3.org/2000/svg" class="qld__icon qld__icon--sm"><use href="{{site.metadata.siteDefaultIcons.value}}#qld__icon__arrow-right"></use></svg>
+                    <svg aria-hidden="true" xmlns="http://www.w3.org/2000/svg" class="qld__icon qld__icon--sm"><use href="{{@root.site.metadata.coreSiteIcons.value}}#arrow-right"></use></svg>
                     </a>
                 {{/ifCond}}
             </li>
         
             {{#ifCond linkType '===' 'first'}}
                 <li class="ellipsis">
-                    <svg aria-hidden="true" focusable="false" xmlns="http://www.w3.org/2000/svg" class="qld__icon qld__icon--lg"><use href="{{site.metadata.siteDefaultIcons.value}}#qld__icon__ellipsis"></use></svg>
+                    <svg aria-hidden="true" xmlns="http://www.w3.org/2000/svg" class="qld__icon qld__icon--lg"><use href="{{@root.site.metadata.coreSiteIcons.value}}#more-horizontal"></use></svg>
                 </li>
             {{/ifCond}}
         {{/each}}

--- a/src/components/pagination/js/manifest.json
+++ b/src/components/pagination/js/manifest.json
@@ -5,38 +5,49 @@
         "version": "1.0",
         "status": "Released",
         "type": "design",
-        "pagination": [{
-            "label": 1,
-            "isCurrent": true,
-            "linkType": "num",
-            "url": "?&start_rank=1"
-        }, {
-            "label": 2,
-            "isCurrent": false,
-            "linkType": "num",
-            "url": "?&start_rank=4"
-        }, {
-            "label": 3,
-            "isCurrent": false,
-            "linkType": "num",
-            "url": "?&start_rank=7"
-        }, {
-            "label": 4,
-            "isCurrent": false,
-            "linkType": "num",
-            "url": "?&start_rank=10"
-        }, {
-            "label": 5,
-            "isCurrent": false,
-            "linkType": "num",
-            "url": "?&start_rank=13"
-        }, {
-            "label": 8,
-            "linkType": "last",
-            "url": "?&start_rank=22"
-        }, {
-            "linkType": "next",
-            "url": "?&start_rank=4"
-        }]
+        "pagination": [
+            {
+                "linkType": "prev"
+            },
+            {
+                "label": 1,
+                "isCurrent": false,
+                "linkType": "num",
+                "url": "?&start_rank=1"
+            },
+            {
+                "label": 2,
+                "isCurrent": false,
+                "linkType": "num",
+                "url": "?&start_rank=4"
+            },
+            {
+                "label": 3,
+                "isCurrent": true,
+                "linkType": "num",
+                "url": "?&start_rank=7"
+            },
+            {
+                "label": 4,
+                "isCurrent": false,
+                "linkType": "num",
+                "url": "?&start_rank=10"
+            },
+            {
+                "label": 5,
+                "isCurrent": false,
+                "linkType": "num",
+                "url": "?&start_rank=13"
+            },
+            {
+                "label": 8,
+                "linkType": "last",
+                "url": "?&start_rank=22"
+            },
+            {
+                "linkType": "next",
+                "url": "?&start_rank=4"
+            }
+        ]
     }
 }

--- a/src/html/component-pagination.html
+++ b/src/html/component-pagination.html
@@ -14,31 +14,150 @@
 
     <head>
         <title>Queensland Design System</title>
-        
+
         ${require('../components/_global/html/head.html')}
         <script>
-            var globals = {"site":{"data":{"assetid":"136","type_code":"site","version":"0.0.8","name":"Design System","short_name":"Design System","status":"2","force_secure":"0","languages":"en","charset":"utf-8","created":"2020-12-09 13:11:12","created_userid":"54","updated":"2021-01-20 15:08:30","updated_userid":"312","published":"Never","published_userid":"","status_changed":"2020-12-09 13:11:12","status_changed_userid":"54","thumbnail":"","attributes":{"name":{"attrid":"685","type":"text","value":"Design System","is_contextable":true,"use_default":true},"not_found_page_cache_globally":{"attrid":"686","type":"boolean","value":false,"is_contextable":false,"use_default":true},"available_conditions":{"attrid":"687","type":"serialise","value":[],"is_contextable":false,"use_default":true}},"metadata":{"displayInPageNav":{"value":"","fieldid":"808","type":"metadata_field_select","is_contextable":true,"default_value":true,"use_default":true},"inPageNav_heading":{"value":"On this page","fieldid":"809","type":"metadata_field_text","is_contextable":true,"default_value":true,"use_default":true},"inPageNav_headingType":{"value":"h2","fieldid":"810","type":"metadata_field_select","is_contextable":true,"default_value":true,"use_default":true},"siteTitle":{"value":"Queensland Health Design System","fieldid":"166","type":"metadata_field_text","is_contextable":true,"default_value":false,"use_default":true},"siteLogo":{"value":"169","fieldid":"127","type":"metadata_field_related_asset","is_contextable":true,"default_value":false,"use_default":true},"siteFavicon":{"value":"106","fieldid":"128","type":"metadata_field_related_asset","is_contextable":true,"default_value":false,"use_default":true},"siteAppleTouch":{"value":"106","fieldid":"129","type":"metadata_field_related_asset","is_contextable":true,"default_value":false,"use_default":true},"sitePreHeaderLogo":{"value":"170","fieldid":"171","type":"metadata_field_related_asset","is_contextable":true,"default_value":false,"use_default":true},"sitePreHeaderText":{"value":"digital.qld.gov.au","fieldid":"167","type":"metadata_field_text","is_contextable":true,"default_value":false,"use_default":true},"sitePreHeaderURL":{"value":"http://www.digital.qld.gov.au","fieldid":"168","type":"metadata_field_text","is_contextable":true,"default_value":false,"use_default":true},"showHomeIcon":{"value":"true","fieldid":"481","type":"metadata_field_select","is_contextable":true,"default_value":true,"use_default":true},"siteRepository":{"value":"164","fieldid":"213","type":"metadata_field_related_asset","is_contextable":true,"default_value":false,"use_default":true},"footerLinks":{"value":"[\"186\",\"194\",\"198\",\"458\",\"676\"]","fieldid":"715","type":"metadata_field_related_asset","is_contextable":true,"default_value":false,"use_default":true},"footerCopyrightMessage":{"value":"© The State of Queensland 2020","fieldid":"722","type":"metadata_field_text","is_contextable":true,"default_value":true,"use_default":true},"footerCopyrightLink":{"value":"206","fieldid":"723","type":"metadata_field_related_asset","is_contextable":true,"default_value":false,"use_default":true},"footerCTAHeading":{"value":"Help us improve","fieldid":"724","type":"metadata_field_text","is_contextable":true,"default_value":false,"use_default":true},"footerCTALead":{"value":"We are always looking for ways to improve our website.","fieldid":"725","type":"metadata_field_text","is_contextable":true,"default_value":false,"use_default":true},"footerCTALink":{"value":"186","fieldid":"726","type":"metadata_field_related_asset","is_contextable":true,"default_value":false,"use_default":true}}},"metadata":{"displayInPageNav":{"value":"","fieldid":"808","type":"metadata_field_select","is_contextable":true,"default_value":true,"use_default":true},"inPageNav_heading":{"value":"On this page","fieldid":"809","type":"metadata_field_text","is_contextable":true,"default_value":true,"use_default":true},"inPageNav_headingType":{"value":"h2","fieldid":"810","type":"metadata_field_select","is_contextable":true,"default_value":true,"use_default":true},"siteTitle":{"value":"Queensland Health Design System","fieldid":"166","type":"metadata_field_text","is_contextable":true,"default_value":false,"use_default":true},"siteLogo":{"value":"169","fieldid":"127","type":"metadata_field_related_asset","is_contextable":true,"default_value":false,"use_default":true},"siteFavicon":{"value":"106","fieldid":"128","type":"metadata_field_related_asset","is_contextable":true,"default_value":false,"use_default":true},"siteAppleTouch":{"value":"106","fieldid":"129","type":"metadata_field_related_asset","is_contextable":true,"default_value":false,"use_default":true},"sitePreHeaderLogo":{"value":"170","fieldid":"171","type":"metadata_field_related_asset","is_contextable":true,"default_value":false,"use_default":true},"sitePreHeaderText":{"value":"digital.qld.gov.au","fieldid":"167","type":"metadata_field_text","is_contextable":true,"default_value":false,"use_default":true},"sitePreHeaderURL":{"value":"http://www.digital.qld.gov.au","fieldid":"168","type":"metadata_field_text","is_contextable":true,"default_value":false,"use_default":true},"showHomeIcon":{"value":"true","fieldid":"481","type":"metadata_field_select","is_contextable":true,"default_value":true,"use_default":true},"siteRepository":{"value":"164","fieldid":"213","type":"metadata_field_related_asset","is_contextable":true,"default_value":false,"use_default":true},"footerLinks":{"value":"[\"186\",\"194\",\"198\",\"458\",\"676\"]","fieldid":"715","type":"metadata_field_related_asset","is_contextable":true,"default_value":false,"use_default":true},"footerCopyrightMessage":{"value":"© The State of Queensland 2020","fieldid":"722","type":"metadata_field_text","is_contextable":true,"default_value":true,"use_default":true},"footerCopyrightLink":{"value":"206","fieldid":"723","type":"metadata_field_related_asset","is_contextable":true,"default_value":false,"use_default":true},"footerCTAHeading":{"value":"Help us improve","fieldid":"724","type":"metadata_field_text","is_contextable":true,"default_value":false,"use_default":true},"footerCTALead":{"value":"We are always looking for ways to improve our website.","fieldid":"725","type":"metadata_field_text","is_contextable":true,"default_value":false,"use_default":true},"footerCTALink":{"value":"186","fieldid":"726","type":"metadata_field_related_asset","is_contextable":true,"default_value":false,"use_default":true}},"children":[{"asset_name":"Get started","asset_assetid":"186"},{"asset_name":"Brand guidelines","asset_assetid":"190"},{"asset_name":"Content guidelines","asset_assetid":"194"},{"asset_name":"Components","asset_assetid":"198"},{"asset_name":"Examples","asset_assetid":"202"},{"asset_name":"Support","asset_assetid":"206"}]},"current":{"data":{"assetid":"676","type_code":"page_standard","version":"0.0.16","name":"Links","short_name":"Links","status":"2","force_secure":"0","languages":"en","charset":"utf-8","created":"2021-01-11 11:48:22","created_userid":"312","updated":"2021-01-20 15:08:29","updated_userid":"312","published":"Never","published_userid":"","status_changed":"2021-01-11 11:48:22","status_changed_userid":"312","thumbnail":"","attributes":{"name":{"attrid":"631","type":"text","value":"Links","is_contextable":true,"use_default":true},"short_name":{"attrid":"632","type":"text","value":"Links","is_contextable":true,"use_default":true},"available_conditions":{"attrid":"633","type":"serialise","value":[],"is_contextable":false,"use_default":true},"conditions":{"attrid":"634","type":"serialise","value":[],"is_contextable":true,"use_default":true}},"metadata":{"description":{"value":"","fieldid":"132","type":"metadata_field_text","is_contextable":true,"default_value":true,"use_default":true},"pageType":{"value":"landing","fieldid":"680","type":"metadata_field_select","is_contextable":true,"default_value":false,"use_default":true},"displayBreadcrumbs":{"value":"true","fieldid":"681","type":"metadata_field_select","is_contextable":true,"default_value":true,"use_default":true},"displayBanner":{"value":"true","fieldid":"682","type":"metadata_field_select","is_contextable":true,"default_value":true,"use_default":true},"displayInPageNav":{"value":"true","fieldid":"808","type":"metadata_field_select","is_contextable":true,"default_value":true,"use_default":true},"inPageNav_heading":{"value":"On this page","fieldid":"809","type":"metadata_field_text","is_contextable":true,"default_value":true,"use_default":true},"inPageNav_headingType":{"value":"h2","fieldid":"810","type":"metadata_field_select","is_contextable":true,"default_value":true,"use_default":true}}},"home":0,"children":[{"asset_assetid":"458","asset_url":"https://qhscb.squiz.cloud/components/accordion","asset_name":"Accordion","children":[]},{"asset_assetid":"325","asset_url":"https://qhscb.squiz.cloud/components/callout","asset_name":"Callout","children":[]},{"asset_assetid":"659","asset_url":"https://qhscb.squiz.cloud/components/card-listing","asset_name":"Card Listing","children":[]},{"asset_assetid":"676","asset_url":"https://qhscb.squiz.cloud/components/links","asset_name":"Links","children":[]},{"asset_assetid":"683","asset_url":"https://qhscb.squiz.cloud/components/search-box","asset_name":"Search Box","children":[]},{"asset_assetid":"785","asset_url":"https://qhscb.squiz.cloud/components/page-alert","asset_name":"Page Alert","children":[]}],"lineage":[{"asset_assetid":"136","asset_name":"Design System","asset_url":"https://qhscb.squiz.cloud"},{"asset_assetid":"198","asset_name":"Components","asset_url":"https://qhscb.squiz.cloud/components"},{"asset_assetid":"676","asset_name":"Links","asset_url":"https://qhscb.squiz.cloud/components/links"}],"top":{"asset_assetid":"198","asset_name":"Components","asset_url":"https://qhscb.squiz.cloud/components"}}};
+            var globals = {
+                site: {
+                    data: {
+                        assetid: "136",
+                        type_code: "site",
+                        version: "0.0.8",
+                        name: "Design System",
+                        short_name: "Design System",
+                        status: "2",
+                        force_secure: "0",
+                        languages: "en",
+                        charset: "utf-8",
+                        created: "2020-12-09 13:11:12",
+                        created_userid: "54",
+                        updated: "2021-01-20 15:08:30",
+                        updated_userid: "312",
+                        published: "Never",
+                        published_userid: "",
+                        status_changed: "2020-12-09 13:11:12",
+                        status_changed_userid: "54",
+                        thumbnail: "",
+                        attributes: {
+                            name: { attrid: "685", type: "text", value: "Design System", is_contextable: true, use_default: true },
+                            not_found_page_cache_globally: { attrid: "686", type: "boolean", value: false, is_contextable: false, use_default: true },
+                            available_conditions: { attrid: "687", type: "serialise", value: [], is_contextable: false, use_default: true },
+                        },
+                        metadata: {
+                            displayInPageNav: { value: "", fieldid: "808", type: "metadata_field_select", is_contextable: true, default_value: true, use_default: true },
+                            inPageNav_heading: { value: "On this page", fieldid: "809", type: "metadata_field_text", is_contextable: true, default_value: true, use_default: true },
+                            inPageNav_headingType: { value: "h2", fieldid: "810", type: "metadata_field_select", is_contextable: true, default_value: true, use_default: true },
+                            siteTitle: { value: "Queensland Health Design System", fieldid: "166", type: "metadata_field_text", is_contextable: true, default_value: false, use_default: true },
+                            siteLogo: { value: "169", fieldid: "127", type: "metadata_field_related_asset", is_contextable: true, default_value: false, use_default: true },
+                            siteFavicon: { value: "106", fieldid: "128", type: "metadata_field_related_asset", is_contextable: true, default_value: false, use_default: true },
+                            siteAppleTouch: { value: "106", fieldid: "129", type: "metadata_field_related_asset", is_contextable: true, default_value: false, use_default: true },
+                            sitePreHeaderLogo: { value: "170", fieldid: "171", type: "metadata_field_related_asset", is_contextable: true, default_value: false, use_default: true },
+                            sitePreHeaderText: { value: "digital.qld.gov.au", fieldid: "167", type: "metadata_field_text", is_contextable: true, default_value: false, use_default: true },
+                            sitePreHeaderURL: { value: "http://www.digital.qld.gov.au", fieldid: "168", type: "metadata_field_text", is_contextable: true, default_value: false, use_default: true },
+                            showHomeIcon: { value: "true", fieldid: "481", type: "metadata_field_select", is_contextable: true, default_value: true, use_default: true },
+                            siteRepository: { value: "164", fieldid: "213", type: "metadata_field_related_asset", is_contextable: true, default_value: false, use_default: true },
+                            footerLinks: { value: '["186","194","198","458","676"]', fieldid: "715", type: "metadata_field_related_asset", is_contextable: true, default_value: false, use_default: true },
+                            footerCopyrightMessage: { value: "© The State of Queensland 2020", fieldid: "722", type: "metadata_field_text", is_contextable: true, default_value: true, use_default: true },
+                            footerCopyrightLink: { value: "206", fieldid: "723", type: "metadata_field_related_asset", is_contextable: true, default_value: false, use_default: true },
+                            footerCTAHeading: { value: "Help us improve", fieldid: "724", type: "metadata_field_text", is_contextable: true, default_value: false, use_default: true },
+                            footerCTALead: { value: "We are always looking for ways to improve our website.", fieldid: "725", type: "metadata_field_text", is_contextable: true, default_value: false, use_default: true },
+                            footerCTALink: { value: "186", fieldid: "726", type: "metadata_field_related_asset", is_contextable: true, default_value: false, use_default: true },
+                        },
+                    },
+                    metadata: {
+                        displayInPageNav: { value: "", fieldid: "808", type: "metadata_field_select", is_contextable: true, default_value: true, use_default: true },
+                        inPageNav_heading: { value: "On this page", fieldid: "809", type: "metadata_field_text", is_contextable: true, default_value: true, use_default: true },
+                        inPageNav_headingType: { value: "h2", fieldid: "810", type: "metadata_field_select", is_contextable: true, default_value: true, use_default: true },
+                        siteTitle: { value: "Queensland Health Design System", fieldid: "166", type: "metadata_field_text", is_contextable: true, default_value: false, use_default: true },
+                        siteLogo: { value: "169", fieldid: "127", type: "metadata_field_related_asset", is_contextable: true, default_value: false, use_default: true },
+                        siteFavicon: { value: "106", fieldid: "128", type: "metadata_field_related_asset", is_contextable: true, default_value: false, use_default: true },
+                        siteAppleTouch: { value: "106", fieldid: "129", type: "metadata_field_related_asset", is_contextable: true, default_value: false, use_default: true },
+                        sitePreHeaderLogo: { value: "170", fieldid: "171", type: "metadata_field_related_asset", is_contextable: true, default_value: false, use_default: true },
+                        sitePreHeaderText: { value: "digital.qld.gov.au", fieldid: "167", type: "metadata_field_text", is_contextable: true, default_value: false, use_default: true },
+                        sitePreHeaderURL: { value: "http://www.digital.qld.gov.au", fieldid: "168", type: "metadata_field_text", is_contextable: true, default_value: false, use_default: true },
+                        showHomeIcon: { value: "true", fieldid: "481", type: "metadata_field_select", is_contextable: true, default_value: true, use_default: true },
+                        siteRepository: { value: "164", fieldid: "213", type: "metadata_field_related_asset", is_contextable: true, default_value: false, use_default: true },
+                        footerLinks: { value: '["186","194","198","458","676"]', fieldid: "715", type: "metadata_field_related_asset", is_contextable: true, default_value: false, use_default: true },
+                        footerCopyrightMessage: { value: "© The State of Queensland 2020", fieldid: "722", type: "metadata_field_text", is_contextable: true, default_value: true, use_default: true },
+                        footerCopyrightLink: { value: "206", fieldid: "723", type: "metadata_field_related_asset", is_contextable: true, default_value: false, use_default: true },
+                        footerCTAHeading: { value: "Help us improve", fieldid: "724", type: "metadata_field_text", is_contextable: true, default_value: false, use_default: true },
+                        footerCTALead: { value: "We are always looking for ways to improve our website.", fieldid: "725", type: "metadata_field_text", is_contextable: true, default_value: false, use_default: true },
+                        footerCTALink: { value: "186", fieldid: "726", type: "metadata_field_related_asset", is_contextable: true, default_value: false, use_default: true },
+                    },
+                    children: [
+                        { asset_name: "Get started", asset_assetid: "186" },
+                        { asset_name: "Brand guidelines", asset_assetid: "190" },
+                        { asset_name: "Content guidelines", asset_assetid: "194" },
+                        { asset_name: "Components", asset_assetid: "198" },
+                        { asset_name: "Examples", asset_assetid: "202" },
+                        { asset_name: "Support", asset_assetid: "206" },
+                    ],
+                },
+                current: {
+                    data: {
+                        assetid: "676",
+                        type_code: "page_standard",
+                        version: "0.0.16",
+                        name: "Links",
+                        short_name: "Links",
+                        status: "2",
+                        force_secure: "0",
+                        languages: "en",
+                        charset: "utf-8",
+                        created: "2021-01-11 11:48:22",
+                        created_userid: "312",
+                        updated: "2021-01-20 15:08:29",
+                        updated_userid: "312",
+                        published: "Never",
+                        published_userid: "",
+                        status_changed: "2021-01-11 11:48:22",
+                        status_changed_userid: "312",
+                        thumbnail: "",
+                        attributes: {
+                            name: { attrid: "631", type: "text", value: "Links", is_contextable: true, use_default: true },
+                            short_name: { attrid: "632", type: "text", value: "Links", is_contextable: true, use_default: true },
+                            available_conditions: { attrid: "633", type: "serialise", value: [], is_contextable: false, use_default: true },
+                            conditions: { attrid: "634", type: "serialise", value: [], is_contextable: true, use_default: true },
+                        },
+                        metadata: {
+                            description: { value: "", fieldid: "132", type: "metadata_field_text", is_contextable: true, default_value: true, use_default: true },
+                            pageType: { value: "landing", fieldid: "680", type: "metadata_field_select", is_contextable: true, default_value: false, use_default: true },
+                            displayBreadcrumbs: { value: "true", fieldid: "681", type: "metadata_field_select", is_contextable: true, default_value: true, use_default: true },
+                            displayBanner: { value: "true", fieldid: "682", type: "metadata_field_select", is_contextable: true, default_value: true, use_default: true },
+                            displayInPageNav: { value: "true", fieldid: "808", type: "metadata_field_select", is_contextable: true, default_value: true, use_default: true },
+                            inPageNav_heading: { value: "On this page", fieldid: "809", type: "metadata_field_text", is_contextable: true, default_value: true, use_default: true },
+                            inPageNav_headingType: { value: "h2", fieldid: "810", type: "metadata_field_select", is_contextable: true, default_value: true, use_default: true },
+                        },
+                    },
+                    home: 0,
+                    children: [
+                        { asset_assetid: "458", asset_url: "https://qhscb.squiz.cloud/components/accordion", asset_name: "Accordion", children: [] },
+                        { asset_assetid: "325", asset_url: "https://qhscb.squiz.cloud/components/callout", asset_name: "Callout", children: [] },
+                        { asset_assetid: "659", asset_url: "https://qhscb.squiz.cloud/components/card-listing", asset_name: "Card Listing", children: [] },
+                        { asset_assetid: "676", asset_url: "https://qhscb.squiz.cloud/components/links", asset_name: "Links", children: [] },
+                        { asset_assetid: "683", asset_url: "https://qhscb.squiz.cloud/components/search-box", asset_name: "Search Box", children: [] },
+                        { asset_assetid: "785", asset_url: "https://qhscb.squiz.cloud/components/page-alert", asset_name: "Page Alert", children: [] },
+                    ],
+                    lineage: [
+                        { asset_assetid: "136", asset_name: "Design System", asset_url: "https://qhscb.squiz.cloud" },
+                        { asset_assetid: "198", asset_name: "Components", asset_url: "https://qhscb.squiz.cloud/components" },
+                        { asset_assetid: "676", asset_name: "Links", asset_url: "https://qhscb.squiz.cloud/components/links" },
+                    ],
+                    top: { asset_assetid: "198", asset_name: "Components", asset_url: "https://qhscb.squiz.cloud/components" },
+                },
+            };
         </script>
     </head>
 
     <body class="qld__grid">
         <!--noindex-->
-        ${require('../components/header/html/component.hbs')({
-            "site":require('/src/data/site.json')
-        })}
+        ${require('../components/header/html/component.hbs')({ "site":require('/src/data/site.json') })}
         <!--endnoindex-->
-        ${require('../components/mega_main_navigation/html/component.hbs')({
-            "site":require('/src/data/site.json')
-        })}
+        ${require('../components/mega_main_navigation/html/component.hbs')({ "site":require('/src/data/site.json') })}
         <!-- MAIN BODY -->
         <main class="main" role="main">
             <section class="qld__body qld__body--breadcrumb">
-                <div class="container-fluid">
-                    ${require('../components/breadcrumbs/html/component.hbs')({
-                        "site":require('/src/data/site.json'),
-                        "current":require('/src/data/current.json'),
-                    })}
-                </div>
+                <div class="container-fluid">${require('../components/breadcrumbs/html/component.hbs')({ "site":require('/src/data/site.json'), "current":require('/src/data/current.json'), })}</div>
             </section>
             <!--CONTENT-->
             <div class="qld__body">
@@ -46,41 +165,25 @@
                     <div class="row">
                         <div class="col-xs-12 col-lg-4 col-xl-3">
                             <!-- INTERNAL NAVIGATION -->
-                            ${require('../components/internal_navigation/html/component.hbs')({
-                                "site":require('/src/data/site.json'),
-                                "current":require('/src/data/current.json')
-                            })}
+                            ${require('../components/internal_navigation/html/component.hbs')({ "site":require('/src/data/site.json'), "current":require('/src/data/current.json') })}
                         </div>
                         <div class="col-xs-12 col-lg-8 col-xl-8" id="content">
-                            
-                            ${require('../components/_global/html/component.hbs')({
-                                "manifest":require('../components/pagination/js/manifest.json'),
-                                "component":require('!url-loader!../components/pagination/html/component.hbs'),
-                                "component_output":require('../components/pagination/html/component.hbs')({
-                                    "pagination": require('../components/pagination/js/manifest.json').component.pagination,
-                                    "content":"Lorem Ipsum"
-                                })
-                            })}
+                            ${require('../components/_global/html/component.hbs')({ "manifest":require('../components/pagination/js/manifest.json'), "component":require('!url-loader!../components/pagination/html/component.hbs'),
+                            "component_output":require('../components/pagination/html/component.hbs')({ "site":require('/src/data/site.json'), "pagination": require('../components/pagination/js/manifest.json').component.pagination,
+                            "content":"Lorem Ipsum" }) })}
                         </div>
                     </div>
                 </div>
-            </div>  
+            </div>
         </main>
         <!-- END MAIN BODY -->
 
         <!-- WIDGETS -->
-        ${require('../components/widgets/html/component.hbs')({
-            "site":require('/src/data/site.json'),
-            "current":require('/src/data/current.json')
-        })}
-        
-        <!-- FOOTER-->
-        ${require('../components/footer/html/component.hbs')({
-            "site":require('/src/data/site.json')
-        })}
+        ${require('../components/widgets/html/component.hbs')({ "site":require('/src/data/site.json'), "current":require('/src/data/current.json') })}
 
-        <div class="footer-scripts" id="footer_js" style="display: none !important;">
-            ${require('../components/_global/html/scripts.html')}
-        </div>
+        <!-- FOOTER-->
+        ${require('../components/footer/html/component.hbs')({ "site":require('/src/data/site.json') })}
+
+        <div class="footer-scripts" id="footer_js" style="display: none !important">${require('../components/_global/html/scripts.html')}</div>
     </body>
 </html>


### PR DESCRIPTION
This pull request updates the pagination components to use a new icon set and improves the structure of the pagination manifest. The most significant changes include replacing hardcoded SVG paths with references to a centralized icon library, ensuring consistency and maintainability, and restructuring the `manifest.json` file for better readability and alignment with the updated pagination logic.

### Icon Updates:
* Replaced hardcoded SVG paths with `<use>` references to the centralized `coreSiteIcons` library for the "ellipsis," "arrow-left," and "arrow-right" icons in `src/components/basic_search/html/component.hbs`.
* Updated `src/components/pagination/html/component.hbs` to use the `coreSiteIcons` library instead of the `siteDefaultIcons` library for the same icons, ensuring consistency across components. [[1]](diffhunk://#diff-d224824148499ce9c2a4e79727d314a649520cd680f8ed4ff352cd0d6cdf6542L7-R15) [[2]](diffhunk://#diff-d224824148499ce9c2a4e79727d314a649520cd680f8ed4ff352cd0d6cdf6542L30-R37)

### Manifest Restructuring:
* Reformatted the `pagination` array in `src/components/pagination/js/manifest.json` for better readability and added explicit entries for "prev" and "next" link types. This change improves the clarity and alignment of the manifest with the pagination logic.