### PR TITLE
QHWT-1296 | Tabs | Update svg icons

### DIFF
--- a/src/components/_global/css/tabs/component.scss
+++ b/src/components/_global/css/tabs/component.scss
@@ -1,14 +1,14 @@
 .qld__tab_panel {
     &.qld__tab--closed,
     &[hidden] {
-        display:none !important;
+        display: none !important;
     }
 }
 
 .qld__tab {
-    cursor:pointer;
+    cursor: pointer;
     background-color: $QLD-color-neutral--white !important;
-    
+
     &[aria-selected="true"] {
         background-color: $QLD-color-neutral--lightest !important;
     }
@@ -20,12 +20,12 @@
     margin-bottom: pxToRem(24);
 
     .qld__tab {
-        cursor:pointer;
+        cursor: pointer;
         background-color: transparent !important;
         border: 0;
         line-height: pxToRem(32);
         padding: pxToRem(15) pxToRem(15);
-        
+
         &[aria-selected="true"] {
             background-color: transparent !important;
             font-weight: 600;
@@ -35,9 +35,5 @@
         &:hover {
             font-weight: 600;
         }
-    }
-
-    .qld__tab + .qld__tab {
-
     }
 }

--- a/src/components/tab/css/component.scss
+++ b/src/components/tab/css/component.scss
@@ -3,13 +3,13 @@
 //--------------------------------------------------------------------------------------------------------------------------------------------------------------
 
 .qld__tab {
-    &-intro{
+    &-intro {
         @include QLD-space(padding-bottom, 1.5unit);
         @include QLD-media(lg) {
             @include QLD-space(padding-bottom, 2unit);
         }
     }
-	
+
     &s {
         display: flex;
         flex-direction: row;
@@ -107,7 +107,7 @@
                 background-color: var(--QLD-color-light__design-accent);
             }
 
-            &:focus::after{
+            &:focus::after {
                 background-color: var(--QLD-color-light__design-accent);
                 transition: background-color 0.2s ease-in-out;
             }
@@ -127,52 +127,20 @@
             pointer-events: auto;
         }
 
-        &.focused{
+        &.focused {
             border-color: var(--QLD-color-light__focus);
         }
-
     }
 
     &-nav__item-scroll {
         position: absolute;
-        color: var(--QLD-color-light__action--secondary);
         z-index: 2;
         height: 47px;
         width: 48px;
         border: none;
 
-        i {
-            min-height: 32px;
-            min-width: 32px;
-            background-color: $QLD-color-neutral--white;
-            align-self: center;
-            box-shadow: 0px 1px 2px rgba(0, 0, 0, 0.2), 0px 1px 3px 1px rgba(0, 0, 0, 0.1);
-            cursor: pointer;
-            border: none;
-            border-radius: 50%;
-            position: relative;
-            font-size: 0.625rem;
-            display: inline-block;
-            line-height: 32px;
-            transition: all 0.2s ease-in-out;
-
-            &:hover {
-                box-shadow: 0px 1px 2px rgba(0, 0, 0, 0.1), 0px 1px 3px 1px rgba(0, 0, 0, 0.05);
-                transform: scale(1.125);
-            }
-        }
-
-        &:hover {
-            position: absolute;
-            color: var(--QLD-color-light__action--secondary-hover);
-            z-index: 2;
-            height: 47px;
-            width: 48px;
-            border: none;
-        }
-
         &:focus {
-            i {
+            .qld__icon {
                 outline: 3px solid var(--QLD-color-light__focus);
                 outline-offset: 2px;
             }
@@ -182,9 +150,8 @@
             display: none;
             left: 0;
             background: linear-gradient(to left, rgba(255, 255, 255, 0), $QLD-color-neutral--white);
-    
         }
-    
+
         &.tab-overflow-nav-button-right {
             display: none;
             right: 0;
@@ -193,6 +160,31 @@
     }
 
     &-container {
+        .qld__tab-nav__item-scroll {
+            .qld__icon {
+                min-height: 32px;
+                min-width: 32px;
+                padding: 10px;
+                background-color: $QLD-color-neutral--white;
+                color: var(--QLD-color-light__action--secondary);
+                box-shadow: 0px 1px 2px rgba(0, 0, 0, 0.2), 0px 1px 3px 1px rgba(0, 0, 0, 0.1);
+                cursor: pointer;
+                border-radius: 50%;
+                transition: all 0.2s ease-in-out;
+
+                &:hover {
+                    box-shadow: 0px 1px 2px rgba(0, 0, 0, 0.1), 0px 1px 3px 1px rgba(0, 0, 0, 0.05);
+                    transform: scale(1.125);
+                }
+            }
+
+            &:hover {
+                .qld__icon {
+                    color: var(--QLD-color-light__action--secondary-hover);
+                }
+            }
+        }
+
         &__fixed {
             width: 100%;
             position: relative;
@@ -295,11 +287,6 @@
                     }
                 }
 
-                // &:focus {
-                //     outline: 3px solid var(--QLD-color-dark__focus);
-                //     outline-offset: -8px;
-                // }
-
                 &[tabindex="-1"]:focus,
                 &:focus-visible,
                 &:focus {
@@ -307,7 +294,7 @@
                     outline-offset: -8px;
                 }
             }
-            
+
             .qld__tab-nav__item-scroll {
                 &.tab-overflow-nav-button-left {
                     display: none;
@@ -349,7 +336,7 @@
                     z-index: 1;
                     text-decoration: none;
                     outline: none;
-                    
+
                     &::after {
                         background-color: var(--QLD-color-dark__design-accent);
                     }
@@ -362,8 +349,6 @@
                 }
 
                 &:not(.active) {
-                    // background: var(--QLD-color-light__background--alt-shade);
-                    // color: var(--QLD-color-light__link);
                     &:focus {
                         outline: 3px solid var(--QLD-color-dark__focus);
                         outline-offset: -8px;
@@ -385,16 +370,6 @@
                     }
                 }
 
-                // &:focus {
-                //     outline: 3px solid var(--QLD-color-dark__focus);
-                //     outline-offset: -8px;
-                // }
-
-                // &[tabindex="-1"]:focus,
-                // &:focus-visible {
-                //     outline: 3px solid var(--QLD-color-dark__focus);
-                //     outline-offset: -8px;
-                // }
                 &.active {
                     &:focus {
                         outline: 3px solid var(--QLD-color-dark__focus);
@@ -426,13 +401,12 @@
     }
 }
 
-#content .qld__tab-container{
-    .qld__tab-content{
-        
-        > section.qld__body:first-of-type{
+#content .qld__tab-container {
+    .qld__tab-content {
+        > section.qld__body:first-of-type {
             padding-top: 0;
         }
-        > section.qld__body:last-of-type{
+        > section.qld__body:last-of-type {
             padding-bottom: 0;
         }
 
@@ -443,13 +417,12 @@
     }
 }
 
-#content .qld__tab-section .qld__tab-container{
-    .qld__tab-content{   
+#content .qld__tab-section .qld__tab-container {
+    .qld__tab-content {
         padding-left: 0px;
         padding-right: 0px;
     }
 }
-    
 
 *:not(.row) + .qld__tab-container {
     margin-top: 32px;
@@ -460,8 +433,8 @@
     margin-top: 48px;
     box-shadow: 0 -49px 0 0 $QLD-color-neutral--white;
 
-    .qld__tab-button[tabindex="0"]:focus{
-        border-color:var(--QLD-color-light__border--alt);
+    .qld__tab-button[tabindex="0"]:focus {
+        border-color: var(--QLD-color-light__border--alt);
     }
 
     .qld__tab-container {
@@ -509,25 +482,22 @@
     }
 }
 
-.qld__banner.qld__banner--light+#content > section:first-child,
-.qld__banner.qld__banner--light+#content > data:first-child + section {
-
-    &.qld__tab-section{
+.qld__banner.qld__banner--light + #content > section:first-child,
+.qld__banner.qld__banner--light + #content > data:first-child + section {
+    &.qld__tab-section {
         box-shadow: 0 -49px 0 0 var(--QLD-color-light__background);
 
-
         .qld__tab-nav__item-scroll {
-        
             &.tab-overflow-nav-button-left {
                 display: none;
                 left: 0;
-                background: linear-gradient(to left, rgba(255,255,255,0), var(--QLD-color-light__background));
+                background: linear-gradient(to left, rgba(255, 255, 255, 0), var(--QLD-color-light__background));
             }
-        
+
             &.tab-overflow-nav-button-right {
                 display: none;
                 right: 0;
-                background: linear-gradient(to right, rgba(255,255,255,0), var(--QLD-color-light__background));
+                background: linear-gradient(to right, rgba(255, 255, 255, 0), var(--QLD-color-light__background));
             }
         }
 
@@ -535,42 +505,40 @@
             &:not(.active) {
                 background: var(--QLD-color-light__background--shade);
                 color: var(--QLD--color-light__link);
-    
-                    span i {
-                        color: var(--QLD-color-light__action--secondary);
-                    }
-    
+
+                span i {
+                    color: var(--QLD-color-light__action--secondary);
+                }
+
                 &:hover {
                     background: var(--QLD-color-light__action--primary-hover);
                     color: var(--QLD-color-light__link--on-action);
                     text-decoration-color: var(--QLD--color-light__link--on-action);
-    
+
                     span i {
-                        color: var(--QLD-color-light__link--on-action)
+                        color: var(--QLD-color-light__link--on-action);
                     }
                 }
             }
         }
-    }  
+    }
 }
 
-.qld__banner.qld__banner--alt+#content > section:first-child,
-.qld__banner.qld__banner--alt+#content > data:first-child + section {
-
-    &.qld__tab-section{
+.qld__banner.qld__banner--alt + #content > section:first-child,
+.qld__banner.qld__banner--alt + #content > data:first-child + section {
+    &.qld__tab-section {
         box-shadow: 0 -49px 0 0 var(--QLD-color-light__background--alt);
         .qld__tab-nav__item-scroll {
-            
             &.tab-overflow-nav-button-left {
                 display: none;
                 left: 0;
-                background: linear-gradient(to left, rgba(255,255,255,0), var(--QLD-color-light__background--alt));
+                background: linear-gradient(to left, rgba(255, 255, 255, 0), var(--QLD-color-light__background--alt));
             }
-        
+
             &.tab-overflow-nav-button-right {
                 display: none;
                 right: 0;
-                background: linear-gradient(to right, rgba(255,255,255,0), var(--QLD-color-light__background--alt));
+                background: linear-gradient(to right, rgba(255, 255, 255, 0), var(--QLD-color-light__background--alt));
             }
         }
 
@@ -579,9 +547,9 @@
                 background: var(--QLD-color-light__background--alt-shade);
                 color: var(--QLD--color-light__link);
 
-                    span i {
-                        color: var(--QLD-color-light__action--secondary);
-                    }
+                span i {
+                    color: var(--QLD-color-light__action--secondary);
+                }
 
                 &:hover {
                     background: var(--QLD-color-light__action--primary-hover);
@@ -589,33 +557,29 @@
                     text-decoration-color: var(--QLD--color-light__link--on-action);
 
                     span i {
-                        color: var(--QLD-color-light__link--on-action)
+                        color: var(--QLD-color-light__link--on-action);
                     }
                 }
             }
-        }    
+        }
     }
-
-    
 }
 
-.qld__banner.qld__banner--dark+#content > section:first-child,
-.qld__banner.qld__banner--dark+#content > data:first-child + section {
-
-    &.qld__tab-section{
+.qld__banner.qld__banner--dark + #content > section:first-child,
+.qld__banner.qld__banner--dark + #content > data:first-child + section {
+    &.qld__tab-section {
         box-shadow: 0 -49px 0 0 var(--QLD-color-dark__background);
         .qld__tab-nav__item-scroll {
-                
             &.tab-overflow-nav-button-left {
                 display: none;
                 left: 0;
-                background: linear-gradient(to left, rgba(255,255,255,0), var(--QLD-color-dark__background));
+                background: linear-gradient(to left, rgba(255, 255, 255, 0), var(--QLD-color-dark__background));
             }
-        
+
             &.tab-overflow-nav-button-right {
                 display: none;
                 right: 0;
-                background: linear-gradient(to right, rgba(255,255,255,0), var(--QLD-color-dark__background));
+                background: linear-gradient(to right, rgba(255, 255, 255, 0), var(--QLD-color-dark__background));
             }
         }
 
@@ -635,31 +599,27 @@
                 text-decoration-color: var(--QLD--color-dark__link--on-action);
 
                 span i {
-                    color: var(--QLD-color-dark__link--on-action)
+                    color: var(--QLD-color-dark__link--on-action);
                 }
             }
         }
     }
-
-    
 }
-.qld__banner.qld__banner--dark-alt+#content > section:first-child,
-.qld__banner.qld__banner--dark-alt+#content > data:first-child + section {
-
-    &.qld__tab-section{
+.qld__banner.qld__banner--dark-alt + #content > section:first-child,
+.qld__banner.qld__banner--dark-alt + #content > data:first-child + section {
+    &.qld__tab-section {
         box-shadow: 0 -49px 0 0 var(--QLD-color-dark__background--alt);
         .qld__tab-nav__item-scroll {
-                    
             &.tab-overflow-nav-button-left {
                 display: none;
                 left: 0;
-                background: linear-gradient(to left, rgba(255,255,255,0), var(--QLD-color-dark__background--alt));
+                background: linear-gradient(to left, rgba(255, 255, 255, 0), var(--QLD-color-dark__background--alt));
             }
-        
+
             &.tab-overflow-nav-button-right {
                 display: none;
                 right: 0;
-                background: linear-gradient(to right, rgba(255,255,255,0), var(--QLD-color-dark__background--alt));
+                background: linear-gradient(to right, rgba(255, 255, 255, 0), var(--QLD-color-dark__background--alt));
             }
         }
 
@@ -679,49 +639,46 @@
                 text-decoration-color: var(--QLD--color-dark__link--on-action);
 
                 span i {
-                    color: var(--QLD-color-dark__link--on-action)
+                    color: var(--QLD-color-dark__link--on-action);
                 }
             }
-        } 
+        }
     }
-
 }
 
-.qld__body--light+.qld__tab-section,
-.qld__body--light+data+.qld__tab-section{
+.qld__body--light + .qld__tab-section,
+.qld__body--light + data + .qld__tab-section {
     box-shadow: 0 -49px 0 0 var(--QLD-color-light__background);
     .qld__tab-nav__item-scroll {
-        
         &.tab-overflow-nav-button-left {
             display: none;
             left: 0;
-            background: linear-gradient(to left, rgba(255,255,255,0), var(--QLD-color-light__background));
+            background: linear-gradient(to left, rgba(255, 255, 255, 0), var(--QLD-color-light__background));
         }
-    
+
         &.tab-overflow-nav-button-right {
             display: none;
             right: 0;
-            background: linear-gradient(to right, rgba(255,255,255,0), var(--QLD-color-light__background));
+            background: linear-gradient(to right, rgba(255, 255, 255, 0), var(--QLD-color-light__background));
         }
     }
     .qld__tab-container {
-
         .qld__tab-button {
             &:not(.active) {
                 background: var(--QLD-color-light__background--shade);
                 color: var(--QLD--color-light__link);
-    
-                    span i {
-                        color: var(--QLD-color-light__action--secondary);
-                    }
-    
+
+                span i {
+                    color: var(--QLD-color-light__action--secondary);
+                }
+
                 &:hover {
                     background: var(--QLD-color-light__action--primary-hover);
                     color: var(--QLD-color-light__link--on-action);
                     text-decoration-color: var(--QLD--color-light__link--on-action);
-    
+
                     span i {
-                        color: var(--QLD-color-light__link--on-action)
+                        color: var(--QLD-color-light__link--on-action);
                     }
                 }
                 &:focus {
@@ -732,43 +689,41 @@
     }
 }
 
-.qld__body--alt+.qld__tab-section,
-.qld__body--alt+data+.qld__tab-section {
+.qld__body--alt + .qld__tab-section,
+.qld__body--alt + data + .qld__tab-section {
     box-shadow: 0 -49px 0 0 var(--QLD-color-light__background--alt);
 
     .qld__tab-nav__item-scroll {
-        
         &.tab-overflow-nav-button-left {
             display: none;
             left: 0;
-            background: linear-gradient(to left, rgba(255,255,255,0), var(--QLD-color-light__background--alt));
+            background: linear-gradient(to left, rgba(255, 255, 255, 0), var(--QLD-color-light__background--alt));
         }
-    
+
         &.tab-overflow-nav-button-right {
             display: none;
             right: 0;
-            background: linear-gradient(to right, rgba(255,255,255,0), var(--QLD-color-light__background--alt));
+            background: linear-gradient(to right, rgba(255, 255, 255, 0), var(--QLD-color-light__background--alt));
         }
     }
 
     .qld__tab-container {
-
         .qld__tab-button {
             &:not(.active) {
                 background: var(--QLD-color-light__background--alt-shade);
                 color: var(--QLD-color-light__link);
-    
-                    span i {
-                        color: var(--QLD-color-light__action--secondary);
-                    }
-    
+
+                span i {
+                    color: var(--QLD-color-light__action--secondary);
+                }
+
                 &:hover {
                     background: var(--QLD-color-light__action--primary-hover);
                     color: var(--QLD-color-light__link--on-action);
                     text-decoration-color: var(--QLD--color-light__link--on-action);
-    
+
                     span i {
-                        color: var(--QLD-color-light__link--on-action)
+                        color: var(--QLD-color-light__link--on-action);
                     }
                 }
                 &:focus {
@@ -776,35 +731,32 @@
                 }
             }
         }
-
     }
 }
 
-.qld__body--dark+.qld__tab-section,
-.qld__body--dark+data+.qld__tab-section {
+.qld__body--dark + .qld__tab-section,
+.qld__body--dark + data + .qld__tab-section {
     box-shadow: 0 -49px 0 0 var(--QLD-color-dark__background);
 
     .qld__tab-nav__item-scroll {
-        
         &.tab-overflow-nav-button-left {
             display: none;
             left: 0;
-            background: linear-gradient(to left, rgba(255,255,255,0), var(--QLD-color-dark__background));
+            background: linear-gradient(to left, rgba(255, 255, 255, 0), var(--QLD-color-dark__background));
         }
-    
+
         &.tab-overflow-nav-button-right {
             display: none;
             right: 0;
-            background: linear-gradient(to right, rgba(255,255,255,0), var(--QLD-color-dark__background));
+            background: linear-gradient(to right, rgba(255, 255, 255, 0), var(--QLD-color-dark__background));
         }
     }
     .qld__tab-container {
-
         .qld__tab-button {
             &:not(.active) {
                 background: var(--QLD-color-dark__background--shade);
                 color: var(--QLD-color-dark__link);
-    
+
                 span i {
                     color: var(--QLD-color-dark__action--secondary);
                 }
@@ -813,15 +765,14 @@
                     outline: 3px solid var(--QLD-color-dark__focus);
                 }
             }
-            
-    
+
             &:hover {
                 background: var(--QLD-color-dark__action--primary-hover);
                 color: var(--QLD-color-dark__link--on-action);
                 text-decoration-color: var(--QLD--color-dark__link--on-action);
-    
+
                 span i {
-                    color: var(--QLD-color-dark__link--on-action)
+                    color: var(--QLD-color-dark__link--on-action);
                 }
             }
         }
@@ -834,32 +785,30 @@
     }
 }
 
-.qld__body--dark-alt+.qld__tab-section,
-.qld__body--dark-alt+data+.qld__tab-section {
+.qld__body--dark-alt + .qld__tab-section,
+.qld__body--dark-alt + data + .qld__tab-section {
     box-shadow: 0 -49px 0 0 var(--QLD-color-dark__background--alt);
 
     .qld__tab-nav__item-scroll {
-        
         &.tab-overflow-nav-button-left {
             display: none;
             left: 0;
-            background: linear-gradient(to left, rgba(255,255,255,0), var(--QLD-color-dark__background--alt));
+            background: linear-gradient(to left, rgba(255, 255, 255, 0), var(--QLD-color-dark__background--alt));
         }
-    
+
         &.tab-overflow-nav-button-right {
             display: none;
             right: 0;
-            background: linear-gradient(to right, rgba(255,255,255,0), var(--QLD-color-dark__background--alt));
+            background: linear-gradient(to right, rgba(255, 255, 255, 0), var(--QLD-color-dark__background--alt));
         }
     }
 
     .qld__tab-container {
-
         .qld__tab-button {
             &:not(.active) {
                 background: var(--QLD-color-dark__background--alt-shade);
                 color: var(--QLD-color-dark__link);
-    
+
                 span i {
                     color: var(--QLD-color-dark__action--secondary);
                 }
@@ -868,14 +817,14 @@
                     outline: 3px solid var(--QLD-color-dark__focus);
                 }
             }
-    
+
             &:hover {
                 background: var(--QLD-color-dark__action--primary-hover);
                 color: var(--QLD-color-dark__link--on-action);
                 text-decoration-color: var(--QLD--color-dark__link--on-action);
-    
+
                 span i {
-                    color: var(--QLD-color-dark__link--on-action)
+                    color: var(--QLD-color-dark__link--on-action);
                 }
             }
         }
@@ -904,7 +853,6 @@
         }
     }
 
-    
     .qld__tab {
         &-content {
             border-bottom: none;
@@ -914,24 +862,50 @@
         }
 
         &-container {
-            // &__fixed {
+            .qld__tab-button {
+                span i {
+                    color: var(--QLD-color-dark__action--secondary);
+                }
 
-                .qld__tab-button {
-                    span i {
-                        color: var(--QLD-color-dark__action--secondary);
+                &:not(.active) {
+                    color: var(--QLD-color-dark__link);
+                    background: var(--QLD-color-dark__background--shade);
+
+                    &:hover {
+                        color: var(--QLD-color-dark__link--on-action);
+                        background: var(--QLD-color-dark__action--primary-hover);
+                        text-decoration-color: var(--QLD-color-dark__link--on-action);
+
+                        span i {
+                            color: var(--QLD-color-dark__link--on-action);
+                        }
                     }
+                }
 
+                &.active {
+                    span i {
+                        color: var(--QLD-color-light__heading);
+                    }
+                }
+            }
+
+            &--light {
+                .qld__tab-button {
                     &:not(.active) {
-                        color: var(--QLD-color-dark__link);
-                        background: var(--QLD-color-dark__background--shade);
+                        background: var(--QLD-color-light__background--shade);
+                        color: var(--QLD-color-light__link);
+
+                        span i {
+                            color: var(--QLD-color-light__action--secondary);
+                        }
 
                         &:hover {
-                            color: var(--QLD-color-dark__link--on-action);
-                            background: var(--QLD-color-dark__action--primary-hover);
-                            text-decoration-color: var(--QLD-color-dark__link--on-action);
+                            background: var(--QLD-color-light__action--primary-hover);
+                            color: var(--QLD-color-light__link--on-action);
+                            text-decoration-color: var(--QLD-color-light__link--on-action);
 
                             span i {
-                                color: var(--QLD-color-dark__link--on-action);
+                                color: var(--QLD-color-dark__heading);
                             }
                         }
                     }
@@ -942,91 +916,19 @@
                         }
                     }
                 }
+            }
 
-                &--light {
-                    .qld__tab-button {
-                        &:not(.active) {
-                            background: var(--QLD-color-light__background--shade);
-                            color: var(--QLD-color-light__link);
+            &--alt {
+                .qld__tab-button {
+                    &:not(.active) {
+                        background: var(--QLD-color-light__background--alt-shade);
+                        color: var(--QLD-color-light__link);
 
-                            span i {
-                                color: var(--QLD-color-light__action--secondary);
-                            }
-
-                            &:hover {
-                                background: var(--QLD-color-light__action--primary-hover);
-                                color: var(--QLD-color-light__link--on-action);
-                                text-decoration-color: var(--QLD-color-light__link--on-action);
-
-                                span i {
-                                    color: var(--QLD-color-dark__heading);
-                                }
-                            }
-                        }
-
-                        &.active {
-                            span i {
-                                color: var(--QLD-color-light__heading);
-                            }
-                        }
-                    }
-                }
-
-                &--alt {
-                    .qld__tab-button {
-                        &:not(.active) {
-                            background: var(--QLD-color-light__background--alt-shade);
-                            color: var(--QLD-color-light__link);
-
-                            span i {
-                                color: var(--QLD-color-light__action--secondary);
-                            }
-
-                            &:hover {
-                                background: var(--QLD-color-light__action--primary-hover);
-                                color: var(--QLD-color-light__link--on-action);
-                                text-decoration-color: var(--QLD-color-light__link--on-action);
-
-                                span i {
-                                    color: var(--QLD-color-dark__heading);
-                                }
-                            }
-                        }
-
-                        &.active {
-                            span i {
-                                color: var(--QLD-color-light__heading);
-                            }
-                        }
-                    }
-                }
-
-                &--dark {
-                    .qld__tab-button {
-                        &:not(.active) {
-                            background: var(--QLD-color-light__background--shade);
-                            color: var(--QLD-color-light__link);
-                        }
-                    }
-                }
-
-                &--dark,
-                &--dark-alt {
-                    .qld__tab-button {
                         span i {
                             color: var(--QLD-color-light__action--secondary);
                         }
 
-                        &:not(.active) {
-                            background-color: var(--QLD-color-light__background--alt-shade);
-                            color: var(--QLD-color-light__link);
-                            &:focus {
-                                outline: 3px solid var(--QLD-color-light__focus);
-                                outline-offset: -8px;
-                            }
-                        }
-        
-                        &:not(.active):hover {
+                        &:hover {
                             background: var(--QLD-color-light__action--primary-hover);
                             color: var(--QLD-color-light__link--on-action);
                             text-decoration-color: var(--QLD-color-light__link--on-action);
@@ -1035,15 +937,58 @@
                                 color: var(--QLD-color-dark__heading);
                             }
                         }
+                    }
 
-                        &.active {
-                            span i {
-                                color: var(--QLD-color-dark__heading);
-                            }
+                    &.active {
+                        span i {
+                            color: var(--QLD-color-light__heading);
                         }
                     }
                 }
-            // }
+            }
+
+            &--dark {
+                .qld__tab-button {
+                    &:not(.active) {
+                        background: var(--QLD-color-light__background--shade);
+                        color: var(--QLD-color-light__link);
+                    }
+                }
+            }
+
+            &--dark,
+            &--dark-alt {
+                .qld__tab-button {
+                    span i {
+                        color: var(--QLD-color-light__action--secondary);
+                    }
+
+                    &:not(.active) {
+                        background-color: var(--QLD-color-light__background--alt-shade);
+                        color: var(--QLD-color-light__link);
+                        &:focus {
+                            outline: 3px solid var(--QLD-color-light__focus);
+                            outline-offset: -8px;
+                        }
+                    }
+
+                    &:not(.active):hover {
+                        background: var(--QLD-color-light__action--primary-hover);
+                        color: var(--QLD-color-light__link--on-action);
+                        text-decoration-color: var(--QLD-color-light__link--on-action);
+
+                        span i {
+                            color: var(--QLD-color-dark__heading);
+                        }
+                    }
+
+                    &.active {
+                        span i {
+                            color: var(--QLD-color-dark__heading);
+                        }
+                    }
+                }
+            }
         }
     }
 }

--- a/src/components/tab/html/component.hbs
+++ b/src/components/tab/html/component.hbs
@@ -50,8 +50,12 @@
         {{/if}}
         
         <div class="qld__tab-container{{#if metadata.theme.value}} qld__tab-container--{{metadata.theme.value}}{{/if}} qld__tab-container__fixed" id="tab-{{assetid}}">
-            <button class="qld__tab-nav__item-scroll tab-overflow-nav-button-left" aria-hidden="true" aria-label="Scroll tab buttons left" tabindex="-1"><i class="fa-solid fa-chevron-left"></i></button>
-            <button class="qld__tab-nav__item-scroll tab-overflow-nav-button-right" aria-hidden="true" aria-label="Scroll tab buttons right" tabindex="-1"><i class="fa-solid fa-chevron-right"></i></button>
+            <button class="qld__tab-nav__item-scroll tab-overflow-nav-button-left" aria-hidden="true" aria-label="Scroll tab buttons left" tabindex="-1">
+                <svg class="qld__icon qld__icon--xs" aria-hidden="true" xmlns="http://www.w3.org/2000/svg"><use href="{{@root.site.metadata.coreSiteIcons.value}}#chevron-left"></use></svg>
+            </button>
+            <button class="qld__tab-nav__item-scroll tab-overflow-nav-button-right" aria-hidden="true" aria-label="Scroll tab buttons right" tabindex="-1">
+                <svg class="qld__icon qld__icon--xs" aria-hidden="true" xmlns="http://www.w3.org/2000/svg"><use href="{{@root.site.metadata.coreSiteIcons.value}}#chevron-right"></use></svg>
+            </button>
             <div class="qld__tabs" role="tablist">
                     {{#ifCond metadata.type.value '==' 'wysiwyg'}}
                         {{#if metadata.title_1.value}}


### PR DESCRIPTION
This pull request includes significant changes to the CSS and HTML for tab components, focusing on cleaning up the code and improving the styling of tab navigation buttons. The most important changes include removing redundant and commented-out CSS code, updating the styling for tab navigation buttons, and switching from FontAwesome icons to SVG icons.

Codebase cleanup and simplification:

* [`src/components/_global/css/tabs/component.scss`](diffhunk://#diff-3d4b5f9e560124fce99d13c8c8f0d84a7d7727295987c96b3ec47d0fdebcd661L39-L42): Removed an empty CSS rule for `.qld__tab + .qld__tab`.
* [`src/components/tab/css/component.scss`](diffhunk://#diff-b4dae899d8ac05179fab482cd1f73c64e7a733dd3211385ce3abf21a54b39722L133-R143): Removed multiple instances of redundant and commented-out CSS code. [[1]](diffhunk://#diff-b4dae899d8ac05179fab482cd1f73c64e7a733dd3211385ce3abf21a54b39722L133-R143) [[2]](diffhunk://#diff-b4dae899d8ac05179fab482cd1f73c64e7a733dd3211385ce3abf21a54b39722L298-L302) [[3]](diffhunk://#diff-b4dae899d8ac05179fab482cd1f73c64e7a733dd3211385ce3abf21a54b39722L365-L366) [[4]](diffhunk://#diff-b4dae899d8ac05179fab482cd1f73c64e7a733dd3211385ce3abf21a54b39722L388-L397) [[5]](diffhunk://#diff-b4dae899d8ac05179fab482cd1f73c64e7a733dd3211385ce3abf21a54b39722L431) [[6]](diffhunk://#diff-b4dae899d8ac05179fab482cd1f73c64e7a733dd3211385ce3abf21a54b39722L453) [[7]](diffhunk://#diff-b4dae899d8ac05179fab482cd1f73c64e7a733dd3211385ce3abf21a54b39722L514-L520) [[8]](diffhunk://#diff-b4dae899d8ac05179fab482cd1f73c64e7a733dd3211385ce3abf21a54b39722L549-R519) [[9]](diffhunk://#diff-b4dae899d8ac05179fab482cd1f73c64e7a733dd3211385ce3abf21a54b39722L559-L563) [[10]](diffhunk://#diff-b4dae899d8ac05179fab482cd1f73c64e7a733dd3211385ce3abf21a54b39722L592-L608) [[11]](diffhunk://#diff-b4dae899d8ac05179fab482cd1f73c64e7a733dd3211385ce3abf21a54b39722L638-L652) [[12]](diffhunk://#diff-b4dae899d8ac05179fab482cd1f73c64e7a733dd3211385ce3abf21a54b39722L682-L694) [[13]](diffhunk://#diff-b4dae899d8ac05179fab482cd1f73c64e7a733dd3211385ce3abf21a54b39722L708) [[14]](diffhunk://#diff-b4dae899d8ac05179fab482cd1f73c64e7a733dd3211385ce3abf21a54b39722L724-R681) [[15]](diffhunk://#diff-b4dae899d8ac05179fab482cd1f73c64e7a733dd3211385ce3abf21a54b39722L740) [[16]](diffhunk://#diff-b4dae899d8ac05179fab482cd1f73c64e7a733dd3211385ce3abf21a54b39722L755) [[17]](diffhunk://#diff-b4dae899d8ac05179fab482cd1f73c64e7a733dd3211385ce3abf21a54b39722L771-L779) [[18]](diffhunk://#diff-b4dae899d8ac05179fab482cd1f73c64e7a733dd3211385ce3abf21a54b39722L788) [[19]](diffhunk://#diff-b4dae899d8ac05179fab482cd1f73c64e7a733dd3211385ce3abf21a54b39722L802) [[20]](diffhunk://#diff-b4dae899d8ac05179fab482cd1f73c64e7a733dd3211385ce3abf21a54b39722L817-R775) [[21]](diffhunk://#diff-b4dae899d8ac05179fab482cd1f73c64e7a733dd3211385ce3abf21a54b39722L842) [[22]](diffhunk://#diff-b4dae899d8ac05179fab482cd1f73c64e7a733dd3211385ce3abf21a54b39722L857) [[23]](diffhunk://#diff-b4dae899d8ac05179fab482cd1f73c64e7a733dd3211385ce3abf21a54b39722L878-R827) [[24]](diffhunk://#diff-b4dae899d8ac05179fab482cd1f73c64e7a733dd3211385ce3abf21a54b39722L907) [[25]](diffhunk://#diff-b4dae899d8ac05179fab482cd1f73c64e7a733dd3211385ce3abf21a54b39722L917-L918) [[26]](diffhunk://#diff-b4dae899d8ac05179fab482cd1f73c64e7a733dd3211385ce3abf21a54b39722L1046)

Styling improvements:

* [`src/components/tab/css/component.scss`](diffhunk://#diff-b4dae899d8ac05179fab482cd1f73c64e7a733dd3211385ce3abf21a54b39722R163-R187): Updated the styling for tab navigation buttons to use `.qld__icon` instead of `i` elements, and added hover effects for the new icons. [[1]](diffhunk://#diff-b4dae899d8ac05179fab482cd1f73c64e7a733dd3211385ce3abf21a54b39722R163-R187) [[2]](diffhunk://#diff-b4dae899d8ac05179fab482cd1f73c64e7a733dd3211385ce3abf21a54b39722L549-R519) [[3]](diffhunk://#diff-b4dae899d8ac05179fab482cd1f73c64e7a733dd3211385ce3abf21a54b39722L559-L563) [[4]](diffhunk://#diff-b4dae899d8ac05179fab482cd1f73c64e7a733dd3211385ce3abf21a54b39722L592-L608) [[5]](diffhunk://#diff-b4dae899d8ac05179fab482cd1f73c64e7a733dd3211385ce3abf21a54b39722L638-L652) [[6]](diffhunk://#diff-b4dae899d8ac05179fab482cd1f73c64e7a733dd3211385ce3abf21a54b39722L682-L694) [[7]](diffhunk://#diff-b4dae899d8ac05179fab482cd1f73c64e7a733dd3211385ce3abf21a54b39722L708) [[8]](diffhunk://#diff-b4dae899d8ac05179fab482cd1f73c64e7a733dd3211385ce3abf21a54b39722L724-R681) [[9]](diffhunk://#diff-b4dae899d8ac05179fab482cd1f73c64e7a733dd3211385ce3abf21a54b39722L740) [[10]](diffhunk://#diff-b4dae899d8ac05179fab482cd1f73c64e7a733dd3211385ce3abf21a54b39722L755) [[11]](diffhunk://#diff-b4dae899d8ac05179fab482cd1f73c64e7a733dd3211385ce3abf21a54b39722L771-L779) [[12]](diffhunk://#diff-b4dae899d8ac05179fab482cd1f73c64e7a733dd3211385ce3abf21a54b39722L788) [[13]](diffhunk://#diff-b4dae899d8ac05179fab482cd1f73c64e7a733dd3211385ce3abf21a54b39722L802) [[14]](diffhunk://#diff-b4dae899d8ac05179fab482cd1f73c64e7a733dd3211385ce3abf21a54b39722L817-R775) [[15]](diffhunk://#diff-b4dae899d8ac05179fab482cd1f73c64e7a733dd3211385ce3abf21a54b39722L842) [[16]](diffhunk://#diff-b4dae899d8ac05179fab482cd1f73c64e7a733dd3211385ce3abf21a54b39722L857) [[17]](diffhunk://#diff-b4dae899d8ac05179fab482cd1f73c64e7a733dd3211385ce3abf21a54b39722L878-R827)

Icon updates:

* [`src/components/tab/html/component.hbs`](diffhunk://#diff-9ba15183843b723f0de34cae7e55ef3e0309c8dc41f80d2c71c64a427ab9078aL53-R58): Replaced FontAwesome icons with SVG icons for the tab navigation buttons.