### PR TITLE
QHWT-1325 | New text-columns-2 utility class.

### DIFF
--- a/src/styles/imports/utilities.scss
+++ b/src/styles/imports/utilities.scss
@@ -733,3 +733,31 @@ div.sq-form-question-error {
 .sq-form-error {
   color: $QLD-color-status__error;
 }
+
+.qld__text-columns-2 {
+  /* Margin removed for utility-based spacing */
+
+  @media screen and (min-width: 992px) {
+    column-count: 2;
+    column-gap: 2rem;
+
+    /* Prevent headings from breaking across columns (limited browser support) */
+    .qld__text-columns-2 h1,
+    .qld__text-columns-2 h2,
+    .qld__text-columns-2 h3,
+    .qld__text-columns-2 h4,
+    .qld__text-columns-2 h5,
+    .qld__text-columns-2 h6 {
+        break-after: avoid;
+        break-inside: avoid;
+        page-break-after: avoid;
+    }
+
+    /* Utility to keep block-level content together in one column */
+    .qld__keep-together {
+        break-inside: avoid;
+        display: inline-block;
+        width: 100%;
+    }
+  }
+}


### PR DESCRIPTION
This pull request introduces a new utility class for styling multi-column text layouts in the `src/styles/imports/utilities.scss` file. The changes aim to improve text formatting and ensure better readability across different screen sizes.

### New utility class for multi-column text layout:

* Added `.qld__text-columns-2` class to enable a two-column layout for text on screens wider than 992px. It includes a `column-gap` of `2rem` for spacing between columns.
* Ensured that headings (`h1` through `h6`) within `.qld__text-columns-2` do not break across columns by using `break-after: avoid`, `break-inside: avoid`, and `page-break-after: avoid`.
* Introduced `.qld__keep-together` utility class to keep block-level content within a single column by applying `break-inside: avoid`, `display: inline-block`, and `width: 100%`.