### PR TITLE
fix/QHWT-1296-QHWT-1326 | Promo icon + title spacing

### DIFF
--- a/src/components/promo_panel/css/component.scss
+++ b/src/components/promo_panel/css/component.scss
@@ -12,7 +12,7 @@
         @include QLD-space(margin-top, 20px);
     }
 
-    h2.qld__display-xl {
+    .qld__promo-panel__container-icon + h2.qld__display-xl {
         margin-top: 2rem;
     }
 


### PR DESCRIPTION
This pull request makes a small improvement to the styling in the `src/components/promo_panel/css/component.scss` file. The change updates the CSS selector for the `h2.qld__display-xl` element to apply styles only when it is preceded by an element with the class `qld__promo-panel__container-icon`.