### PR TITLE
QHWT-1352 | Footer | Modify css to ensure footer link cols have proper directions

### DIFF
--- a/src/components/footer/css/component.scss
+++ b/src/components/footer/css/component.scss
@@ -182,32 +182,36 @@
     &__social,
     &__navigation {
         border-top: $QLD-border-width-thin solid $QLD-color-neutral--lighter;
+
         @include QLD-media(lg) {
             border-top: none;
         }
+
         ul.qld__link-list {
             padding: 0;
             margin: 0;
             display: flex;
             flex-wrap: wrap;
-            flex-direction: row;
+            flex-direction: column;
             justify-content: space-between;
             line-height: 1.4;
+
+            @include QLD-media(lg, "down") {
+                flex-direction: row;
+            }
 
             > li {
                 margin: 0;
 
                 @include QLD-space(margin-bottom, 0.5unit);
                 width: 50%;
-                flex-basis: 50%;
 
                 @include QLD-media(md) {
                     width: 33%;
-                    flex-basis: 33%;
                 }
+
                 @include QLD-media(lg) {
                     width: auto;
-                    flex-basis: 100%;
                     @include QLD-space(margin-bottom, 0.75unit);
                 }
 
@@ -284,7 +288,6 @@
         }
         ul.qld__link-list {
             display: flex;
-            align-items: end;
             justify-content: space-between;
 
             @include QLD-media(lg) {


### PR DESCRIPTION
This pull request includes updates to the `src/components/footer/css/component.scss` file to adjust the layout and styling of the footer's link lists. The changes focus on improving responsiveness and simplifying the CSS structure.

### Layout adjustments for responsiveness:
* Updated the `ul.qld__link-list` to use a column layout by default (`flex-direction: column`) and switch back to a row layout for smaller screens using a media query (`QLD-media(lg, "down")`). This improves the footer's adaptability to different screen sizes.

### Simplification of CSS:
* Removed redundant `flex-basis` properties for list items, relying on the `width` property for layout control instead.
* Removed the `align-items: end` property from the `ul.qld__link-list`, simplifying the alignment rules.