### PR TITLE
QHWT-1324 | Horizontal rule | Add colours to horizontal rule for accessible body elements

### DIFF
--- a/src/components/horizontal_rule/css/component.scss
+++ b/src/components/horizontal_rule/css/component.scss
@@ -3,40 +3,78 @@
 //--------------------------------------------------------------------------------------------------------------------------------------------------------------
 
 hr.qld__horizontal-rule {
-	background-color: $QLD-color-neutral--lighter;
-	border: none;
+    background-color: $QLD-color-neutral--lighter;
+    border: none;
 
-	.qld__card .qld__card__footer &{
-		background-color: $QLD-color-neutral--lighter;
-	}
+    .qld__card .qld__card__footer & {
+        background-color: $QLD-color-neutral--lighter;
+    }
 
-	.qld__body--light &,
-	.qld__card--light .qld__card__footer &{
-		background-color: var(--QLD-color-light__border);
-	}
+    .qld__body--light &,
+    .qld__card--light .qld__card__footer & {
+        background-color: var(--QLD-color-light__border);
+    }
 
-	.qld__body--alt &,
-	.qld__card--alt .qld__card__footer &{
-		background-color: var(--QLD-color-light__border--alt);
-	}
-	.qld__body--dark &,
-	.qld__card--dark .qld__card__footer &,
-	.qld__main-nav--dark &{
-		background-color: var(--QLD-color-dark__border);
-	}
-	.qld__body--dark-alt &,
-	.qld__card--dark-alt .qld__card__footer &{
-		background-color: var(--QLD-color-dark__border--alt); 
-	}
+    .qld__body--alt &,
+    .qld__card--alt .qld__card__footer & {
+        background-color: var(--QLD-color-light__border--alt);
+    }
+    .qld__body--dark &,
+    .qld__card--dark .qld__card__footer &,
+    .qld__main-nav--dark & {
+        background-color: var(--QLD-color-dark__border);
+    }
+    .qld__body--dark-alt &,
+    .qld__card--dark-alt .qld__card__footer & {
+        background-color: var(--QLD-color-dark__border--alt);
+    }
 
-	&.qld__horizontal-rule--md{
-		height: 2px;
-		@include QLD-space(margin, 1.438unit 0 1.438unit 0);
-	}
+    &.qld__horizontal-rule--md {
+        height: 2px;
+        @include QLD-space(margin, 1.438unit 0 1.438unit 0);
+    }
 
-	&.qld__horizontal-rule--lg{
-		height: 2px;
-		@include QLD-space(margin, 1.938unit 0 1.938unit 0);
-	}
+    &.qld__horizontal-rule--lg {
+        height: 2px;
+        @include QLD-space(margin, 1.938unit 0 1.938unit 0);
+    }
+}
 
+/* Accessible versions for body sections */
+
+.qld__horizontal-rule,
+hr.qld__horizontal-rule {
+    .qld__body & {
+        background-color: var(--QLD-color-light__border--alt);
+    }
+
+    .qld__body--dark &,
+    .qld__body--dark-alt & {
+        background-color: var(--QLD-color-dark__border--alt);
+    }
+}
+
+/* Decorative versions for body sections */
+
+.qld__horizontal-rule[aria-hidden="true"],
+hr.qld__horizontal-rule[aria-hidden="true"] {
+    .qld__body & {
+        background-color: $QLD-color-neutral--lighter;
+    }
+
+    .qld__body--light & {
+        background-color: var(--QLD-color-light__border);
+    }
+
+    .qld__body--alt & {
+        background-color: var(--QLD-color-light__border--alt);
+    }
+
+    .qld__body--dark & {
+        background-color: var(--QLD-color-dark__border);
+    }
+
+    .qld__body--dark-alt & {
+        background-color: var(--QLD-color-dark__border--alt);
+    }
 }

--- a/src/html/component-horizontal_rule.html
+++ b/src/html/component-horizontal_rule.html
@@ -1,0 +1,253 @@
+<!DOCTYPE html>
+<!--[if lt IE 8]>
+        <html class="no-js lt-ie8 lt-ie9" lang="en">
+    <![endif]-->
+<!--[if IE 8]>
+        <html class="no-js lt-ie9 ie8" lang="en">
+    <![endif]-->
+<!--[if IE 9]>
+        <html class="no-js ie9" lang="en">
+    <![endif]-->
+<!--[if !(IE)]><!-->
+<html class="no-js" lang="en">
+    <!--<![endif]-->
+
+    <head>
+        <title>Queensland Design System</title>
+
+        ${require('../components/_global/html/head.html')}
+        <script>
+            var globals = {
+                site: {
+                    data: {
+                        assetid: "136",
+                        type_code: "site",
+                        version: "0.0.8",
+                        name: "Design System",
+                        short_name: "Design System",
+                        status: "2",
+                        force_secure: "0",
+                        languages: "en",
+                        charset: "utf-8",
+                        created: "2020-12-09 13:11:12",
+                        created_userid: "54",
+                        updated: "2021-01-20 15:08:30",
+                        updated_userid: "312",
+                        published: "Never",
+                        published_userid: "",
+                        status_changed: "2020-12-09 13:11:12",
+                        status_changed_userid: "54",
+                        thumbnail: "",
+                        attributes: {
+                            name: { attrid: "685", type: "text", value: "Design System", is_contextable: true, use_default: true },
+                            not_found_page_cache_globally: { attrid: "686", type: "boolean", value: false, is_contextable: false, use_default: true },
+                            available_conditions: { attrid: "687", type: "serialise", value: [], is_contextable: false, use_default: true },
+                        },
+                        metadata: {
+                            displayInPageNav: { value: "", fieldid: "808", type: "metadata_field_select", is_contextable: true, default_value: true, use_default: true },
+                            inPageNav_heading: { value: "On this page", fieldid: "809", type: "metadata_field_text", is_contextable: true, default_value: true, use_default: true },
+                            inPageNav_headingType: { value: "h2", fieldid: "810", type: "metadata_field_select", is_contextable: true, default_value: true, use_default: true },
+                            siteTitle: { value: "Queensland Health Design System", fieldid: "166", type: "metadata_field_text", is_contextable: true, default_value: false, use_default: true },
+                            siteLogo: { value: "169", fieldid: "127", type: "metadata_field_related_asset", is_contextable: true, default_value: false, use_default: true },
+                            siteFavicon: { value: "106", fieldid: "128", type: "metadata_field_related_asset", is_contextable: true, default_value: false, use_default: true },
+                            siteAppleTouch: { value: "106", fieldid: "129", type: "metadata_field_related_asset", is_contextable: true, default_value: false, use_default: true },
+                            sitePreHeaderLogo: { value: "170", fieldid: "171", type: "metadata_field_related_asset", is_contextable: true, default_value: false, use_default: true },
+                            sitePreHeaderText: { value: "digital.qld.gov.au", fieldid: "167", type: "metadata_field_text", is_contextable: true, default_value: false, use_default: true },
+                            sitePreHeaderURL: { value: "http://www.digital.qld.gov.au", fieldid: "168", type: "metadata_field_text", is_contextable: true, default_value: false, use_default: true },
+                            showHomeIcon: { value: "true", fieldid: "481", type: "metadata_field_select", is_contextable: true, default_value: true, use_default: true },
+                            siteRepository: { value: "164", fieldid: "213", type: "metadata_field_related_asset", is_contextable: true, default_value: false, use_default: true },
+                            footerLinks: { value: '["186","194","198","458","676"]', fieldid: "715", type: "metadata_field_related_asset", is_contextable: true, default_value: false, use_default: true },
+                            footerCopyrightMessage: { value: "© The State of Queensland 2020", fieldid: "722", type: "metadata_field_text", is_contextable: true, default_value: true, use_default: true },
+                            footerCopyrightLink: { value: "206", fieldid: "723", type: "metadata_field_related_asset", is_contextable: true, default_value: false, use_default: true },
+                            footerCTAHeading: { value: "Help us improve", fieldid: "724", type: "metadata_field_text", is_contextable: true, default_value: false, use_default: true },
+                            footerCTALead: { value: "We are always looking for ways to improve our website.", fieldid: "725", type: "metadata_field_text", is_contextable: true, default_value: false, use_default: true },
+                            footerCTALink: { value: "186", fieldid: "726", type: "metadata_field_related_asset", is_contextable: true, default_value: false, use_default: true },
+                        },
+                    },
+                    metadata: {
+                        displayInPageNav: { value: "", fieldid: "808", type: "metadata_field_select", is_contextable: true, default_value: true, use_default: true },
+                        inPageNav_heading: { value: "On this page", fieldid: "809", type: "metadata_field_text", is_contextable: true, default_value: true, use_default: true },
+                        inPageNav_headingType: { value: "h2", fieldid: "810", type: "metadata_field_select", is_contextable: true, default_value: true, use_default: true },
+                        siteTitle: { value: "Queensland Health Design System", fieldid: "166", type: "metadata_field_text", is_contextable: true, default_value: false, use_default: true },
+                        siteLogo: { value: "169", fieldid: "127", type: "metadata_field_related_asset", is_contextable: true, default_value: false, use_default: true },
+                        siteFavicon: { value: "106", fieldid: "128", type: "metadata_field_related_asset", is_contextable: true, default_value: false, use_default: true },
+                        siteAppleTouch: { value: "106", fieldid: "129", type: "metadata_field_related_asset", is_contextable: true, default_value: false, use_default: true },
+                        sitePreHeaderLogo: { value: "170", fieldid: "171", type: "metadata_field_related_asset", is_contextable: true, default_value: false, use_default: true },
+                        sitePreHeaderText: { value: "digital.qld.gov.au", fieldid: "167", type: "metadata_field_text", is_contextable: true, default_value: false, use_default: true },
+                        sitePreHeaderURL: { value: "http://www.digital.qld.gov.au", fieldid: "168", type: "metadata_field_text", is_contextable: true, default_value: false, use_default: true },
+                        showHomeIcon: { value: "true", fieldid: "481", type: "metadata_field_select", is_contextable: true, default_value: true, use_default: true },
+                        siteRepository: { value: "164", fieldid: "213", type: "metadata_field_related_asset", is_contextable: true, default_value: false, use_default: true },
+                        footerLinks: { value: '["186","194","198","458","676"]', fieldid: "715", type: "metadata_field_related_asset", is_contextable: true, default_value: false, use_default: true },
+                        footerCopyrightMessage: { value: "© The State of Queensland 2020", fieldid: "722", type: "metadata_field_text", is_contextable: true, default_value: true, use_default: true },
+                        footerCopyrightLink: { value: "206", fieldid: "723", type: "metadata_field_related_asset", is_contextable: true, default_value: false, use_default: true },
+                        footerCTAHeading: { value: "Help us improve", fieldid: "724", type: "metadata_field_text", is_contextable: true, default_value: false, use_default: true },
+                        footerCTALead: { value: "We are always looking for ways to improve our website.", fieldid: "725", type: "metadata_field_text", is_contextable: true, default_value: false, use_default: true },
+                        footerCTALink: { value: "186", fieldid: "726", type: "metadata_field_related_asset", is_contextable: true, default_value: false, use_default: true },
+                    },
+                    children: [
+                        { asset_name: "Get started", asset_assetid: "186" },
+                        { asset_name: "Brand guidelines", asset_assetid: "190" },
+                        { asset_name: "Content guidelines", asset_assetid: "194" },
+                        { asset_name: "Components", asset_assetid: "198" },
+                        { asset_name: "Examples", asset_assetid: "202" },
+                        { asset_name: "Support", asset_assetid: "206" },
+                    ],
+                },
+                current: {
+                    data: {
+                        assetid: "676",
+                        type_code: "page_standard",
+                        version: "0.0.16",
+                        name: "Links",
+                        short_name: "Links",
+                        status: "2",
+                        force_secure: "0",
+                        languages: "en",
+                        charset: "utf-8",
+                        created: "2021-01-11 11:48:22",
+                        created_userid: "312",
+                        updated: "2021-01-20 15:08:29",
+                        updated_userid: "312",
+                        published: "Never",
+                        published_userid: "",
+                        status_changed: "2021-01-11 11:48:22",
+                        status_changed_userid: "312",
+                        thumbnail: "",
+                        attributes: {
+                            name: { attrid: "631", type: "text", value: "Links", is_contextable: true, use_default: true },
+                            short_name: { attrid: "632", type: "text", value: "Links", is_contextable: true, use_default: true },
+                            available_conditions: { attrid: "633", type: "serialise", value: [], is_contextable: false, use_default: true },
+                            conditions: { attrid: "634", type: "serialise", value: [], is_contextable: true, use_default: true },
+                        },
+                        metadata: {
+                            description: { value: "", fieldid: "132", type: "metadata_field_text", is_contextable: true, default_value: true, use_default: true },
+                            pageType: { value: "landing", fieldid: "680", type: "metadata_field_select", is_contextable: true, default_value: false, use_default: true },
+                            displayBreadcrumbs: { value: "true", fieldid: "681", type: "metadata_field_select", is_contextable: true, default_value: true, use_default: true },
+                            displayBanner: { value: "true", fieldid: "682", type: "metadata_field_select", is_contextable: true, default_value: true, use_default: true },
+                            displayInPageNav: { value: "true", fieldid: "808", type: "metadata_field_select", is_contextable: true, default_value: true, use_default: true },
+                            inPageNav_heading: { value: "On this page", fieldid: "809", type: "metadata_field_text", is_contextable: true, default_value: true, use_default: true },
+                            inPageNav_headingType: { value: "h2", fieldid: "810", type: "metadata_field_select", is_contextable: true, default_value: true, use_default: true },
+                        },
+                    },
+                    home: 0,
+                    children: [
+                        { asset_assetid: "458", asset_url: "https://qhscb.squiz.cloud/components/accordion", asset_name: "Accordion", children: [] },
+                        { asset_assetid: "325", asset_url: "https://qhscb.squiz.cloud/components/callout", asset_name: "Callout", children: [] },
+                        { asset_assetid: "659", asset_url: "https://qhscb.squiz.cloud/components/card-listing", asset_name: "Card Listing", children: [] },
+                        { asset_assetid: "676", asset_url: "https://qhscb.squiz.cloud/components/links", asset_name: "Links", children: [] },
+                        { asset_assetid: "683", asset_url: "https://qhscb.squiz.cloud/components/search-box", asset_name: "Search Box", children: [] },
+                        { asset_assetid: "785", asset_url: "https://qhscb.squiz.cloud/components/page-alert", asset_name: "Page Alert", children: [] },
+                    ],
+                    lineage: [
+                        { asset_assetid: "136", asset_name: "Design System", asset_url: "https://qhscb.squiz.cloud" },
+                        { asset_assetid: "198", asset_name: "Components", asset_url: "https://qhscb.squiz.cloud/components" },
+                        { asset_assetid: "676", asset_name: "Links", asset_url: "https://qhscb.squiz.cloud/components/links" },
+                    ],
+                    top: { asset_assetid: "198", asset_name: "Components", asset_url: "https://qhscb.squiz.cloud/components" },
+                },
+            };
+        </script>
+    </head>
+
+    <body class="qld__grid">
+        <!--noindex-->
+        ${require('../components/header/html/component.hbs')({ "site":require('/src/data/site.json') })}
+        <!--endnoindex-->
+        ${require('../components/main_navigation/html/component.hbs')({ "site":require('/src/data/site.json') })}
+        <!-- MAIN BODY -->
+        <main class="main" role="main">
+            <section class="qld__body qld__body--breadcrumb">
+                <div class="container-fluid">${require('../components/breadcrumbs/html/component.hbs')({ "site":require('/src/data/site.json'), "current":require('/src/data/current.json'), })}</div>
+            </section>
+            <!--CONTENT-->
+            <div class="qld__body">
+                <div class="container-fluid">
+                    <div class="row">
+                        <div class="col-xs-12 col-lg-4 col-xl-3">
+                            <!-- INTERNAL NAVIGATION -->
+                            ${require('../components/internal_navigation/html/component.hbs')({ "site":require('/src/data/site.json'), "current":require('/src/data/current.json') })}
+                        </div>
+                        <div class="col-xs-12 col-lg-8 col-xl-8" id="content">
+                            <h1>Horizontal rule</h1>
+
+                            <div class="qld__body">
+                                <div class="container-fluid">
+                                    <h2>White</h2>
+                                    <h3>Decorative</h3>
+                                    <hr class="qld__horizontal-rule" aria-hidden="true" />
+                                    <hr class="qld__horizontal-rule qld__horizontal-rule--md" aria-hidden="true" />
+                                    <hr class="qld__horizontal-rule qld__horizontal-rule--lg" aria-hidden="true" />
+                                    <h3>Accessible</h3>
+                                    <hr class="qld__horizontal-rule" />
+                                    <hr class="qld__horizontal-rule qld__horizontal-rule--md" />
+                                    <hr class="qld__horizontal-rule qld__horizontal-rule--lg" />
+                                </div>
+                            </div>
+                            <div class="qld__body qld__body--light">
+                                <div class="container-fluid">
+                                    <h2>White</h2>
+                                    <h3>Decorative</h3>
+                                    <hr class="qld__horizontal-rule" aria-hidden="true" />
+                                    <hr class="qld__horizontal-rule qld__horizontal-rule--md" aria-hidden="true" />
+                                    <hr class="qld__horizontal-rule qld__horizontal-rule--lg" aria-hidden="true" />
+                                    <h3>Accessible</h3>
+                                    <hr class="qld__horizontal-rule" />
+                                    <hr class="qld__horizontal-rule qld__horizontal-rule--md" />
+                                    <hr class="qld__horizontal-rule qld__horizontal-rule--lg" />
+                                </div>
+                            </div>
+                            <div class="qld__body qld__body--alt">
+                                <div class="container-fluid">
+                                    <h2>Alt</h2>
+                                    <h3>Decorative</h3>
+                                    <hr class="qld__horizontal-rule" aria-hidden="true" />
+                                    <hr class="qld__horizontal-rule qld__horizontal-rule--md" aria-hidden="true" />
+                                    <hr class="qld__horizontal-rule qld__horizontal-rule--lg" aria-hidden="true" />
+                                    <h3>Accessible</h3>
+                                    <hr class="qld__horizontal-rule" />
+                                    <hr class="qld__horizontal-rule qld__horizontal-rule--md" />
+                                    <hr class="qld__horizontal-rule qld__horizontal-rule--lg" />
+                                </div>
+                            </div>
+                            <div class="qld__body qld__body--dark">
+                                <div class="container-fluid">
+                                    <h2>Dark</h2>
+                                    <h3>Decorative</h3>
+                                    <hr class="qld__horizontal-rule" aria-hidden="true" />
+                                    <hr class="qld__horizontal-rule qld__horizontal-rule--md" aria-hidden="true" />
+                                    <hr class="qld__horizontal-rule qld__horizontal-rule--lg" aria-hidden="true" />
+                                    <h3>Accessible</h3>
+                                    <hr class="qld__horizontal-rule" />
+                                    <hr class="qld__horizontal-rule qld__horizontal-rule--md" />
+                                    <hr class="qld__horizontal-rule qld__horizontal-rule--lg" />
+                                </div>
+                            </div>
+                            <div class="qld__body qld__body--dark-alt">
+                                <div class="container-fluid">
+                                    <h2>Dark Alternative</h2>
+                                    <h3>Decorative</h3>
+                                    <hr class="qld__horizontal-rule" aria-hidden="true" />
+                                    <hr class="qld__horizontal-rule qld__horizontal-rule--md" aria-hidden="true" />
+                                    <hr class="qld__horizontal-rule qld__horizontal-rule--lg" aria-hidden="true" />
+                                    <h3>Accessible</h3>
+                                    <hr class="qld__horizontal-rule" />
+                                    <hr class="qld__horizontal-rule qld__horizontal-rule--md" />
+                                    <hr class="qld__horizontal-rule qld__horizontal-rule--lg" />
+                                </div>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+            </div>
+        </main>
+        <!-- END MAIN BODY -->
+
+        <!-- WIDGETS -->
+        ${require('../components/widgets/html/component.hbs')({ "site":require('/src/data/site.json'), "current":require('/src/data/current.json') })}
+
+        <!-- FOOTER-->
+        ${require('../components/footer/html/component.hbs')({ "site":require('/src/data/site.json') })}
+
+        <div class="footer-scripts" id="footer_js" style="display: none !important">${require('../components/_global/html/scripts.html')}</div>
+    </body>
+</html>


### PR DESCRIPTION
This pull request introduces enhancements to the styling and accessibility of horizontal rules in the Queensland Design System, as well as a new HTML template for the `horizontal_rule` component. The changes improve visual consistency across themes and provide accessible and decorative variations for different body sections.

### Styling Enhancements for Horizontal Rules:
* Added accessible and decorative versions of the `qld__horizontal-rule` class for different body themes (e.g., light, dark, alt) with appropriate background colors. These styles ensure better visual contrast and accessibility. (`src/components/horizontal_rule/css/component.scss`)

### New HTML Template for Component:
* Introduced a new `horizontal_rule` HTML template that demonstrates the usage of accessible and decorative horizontal rules across various themes. This includes examples for different sizes (`--md`, `--lg`) and states (`aria-hidden="true"` for decorative). (`src/html/component-horizontal_rule.html`)