### PR TITLE
Add video item alignment

### DIFF
--- a/src/components/video_player/css/component.scss
+++ b/src/components/video_player/css/component.scss
@@ -4,7 +4,8 @@
     .qld__video__player__transcript-link,
     .qld__accordion__body-wrapper {
         background-color: $QLD-color-neutral--lightest;
-        border-top: var(--QLD-border-width-thin) solid $QLD-color-neutral--lighter;
+        border-top: var(--QLD-border-width-thin) solid
+            $QLD-color-neutral--lighter;
     }
     .qld__video__player__transcript {
         &-link,
@@ -23,7 +24,9 @@
 
             &:hover {
                 span {
-                    text-decoration-thickness: var(--QLD-underline__thickness-thick);
+                    text-decoration-thickness: var(
+                        --QLD-underline__thickness-thick
+                    );
                 }
             }
         }
@@ -31,7 +34,8 @@
 
     .qld__video__player {
         &--summary {
-            border: var(--QLD-border-width-thin) solid $QLD-color-neutral--lighter;
+            border: var(--QLD-border-width-thin) solid
+                $QLD-color-neutral--lighter;
             border-top: none;
             border-radius: 0 0 $QLD-border-radius-xs $QLD-border-radius-xs;
         }
@@ -48,11 +52,13 @@
         .qld__accordion__body-wrapper {
             color: $QLD-color-neutral--white;
             background-color: var(--QLD-color-dark__background--alt-shade);
-            border-top: var(--QLD-border-width-thin) solid var(--QLD-color-dark__border--alt);
+            border-top: var(--QLD-border-width-thin) solid
+                var(--QLD-color-dark__border--alt);
         }
         .qld__video__player {
             &--summary {
-                border: var(--QLD-border-width-thin) solid var(--QLD-color-dark__border--alt);
+                border: var(--QLD-border-width-thin) solid
+                    var(--QLD-color-dark__border--alt);
                 border-top: none;
             }
         }
@@ -64,11 +70,13 @@
         .qld__accordion__body-wrapper {
             color: $QLD-color-neutral--white;
             background-color: var(--QLD-color-dark__background--shade);
-            border-top: var(--QLD-border-width-thin) solid var(--QLD-color-dark__border);
+            border-top: var(--QLD-border-width-thin) solid
+                var(--QLD-color-dark__border);
         }
         .qld__video__player {
             &--summary {
-                border: var(--QLD-border-width-thin) solid var(--QLD-color-dark__border);
+                border: var(--QLD-border-width-thin) solid
+                    var(--QLD-color-dark__border);
                 border-top: none;
             }
         }
@@ -80,11 +88,13 @@
         .qld__video__player__transcript-link,
         .qld__accordion__body-wrapper {
             background-color: var(--QLD-color-light__background--alt-shade);
-            border-top: var(--QLD-border-width-thin) solid var(--QLD-color-light__border--alt);
+            border-top: var(--QLD-border-width-thin) solid
+                var(--QLD-color-light__border--alt);
         }
         .qld__video__player {
             &--summary {
-                border: var(--QLD-border-width-thin) solid var(--QLD-color-light__border--alt);
+                border: var(--QLD-border-width-thin) solid
+                    var(--QLD-color-light__border--alt);
                 border-top: none;
             }
         }
@@ -95,11 +105,13 @@
         .qld__video__player__transcript-link,
         .qld__accordion__body-wrapper {
             background-color: var(--QLD-color-light__background--shade);
-            border-top: var(--QLD-border-width-thin) solid var(--QLD-color-light__border);
+            border-top: var(--QLD-border-width-thin) solid
+                var(--QLD-color-light__border);
         }
         .qld__video__player {
             &--summary {
-                border: var(--QLD-border-width-thin) solid var(--QLD-color-light__border);
+                border: var(--QLD-border-width-thin) solid
+                    var(--QLD-color-light__border);
                 border-top: none;
             }
         }
@@ -113,7 +125,9 @@
                     color: var(--QLD-color-dark__link);
 
                     &::after {
-                        background-color: var(--QLD-color-dark__action--secondary);
+                        background-color: var(
+                            --QLD-color-dark__action--secondary
+                        );
                     }
                 }
 
@@ -132,7 +146,10 @@
         }
     }
 
-    &--align {
+    &--align-top {
+        align-items: flex-start;
+    }
+    &--align-centered_vertically {
         align-items: center;
     }
     &--embed--container {

--- a/src/components/video_player/html/component.hbs
+++ b/src/components/video_player/html/component.hbs
@@ -1,8 +1,8 @@
 {{#with component.data}}
-<section class="qld__body qld__video__player--wrapper 
+<section class="qld__body qld__video__player--wrapper
   {{#if metadata.body_background.value}}qld__body--{{metadata.body_background.value}}{{/if}}" id="{{#if metadata.id_field.value}}{{{metadata.id_field.value}}}{{else}}video_player-{{assetid}}{{/if}}">
   <div class="container-fluid">
-    <div class="row qld__row-gap-component {{#ifCond metadata.video_layout.value '==' 'two_column'}}qld__video__player--align{{/ifCond}}">
+    <div class="row qld__row-gap-component {{#ifCond metadata.video_layout.value '==' 'two_column'}}qld__video__player--align-{{metadata.video_align_items.value}}{{/ifCond}}">
 
 
       <!-- Check for 'stack' video layout option -->
@@ -10,14 +10,14 @@
 
       <!-- If video description exists, display it -->
         {{#if metadata.video_description.value}}
-          <div class="col-xs-12 
+          <div class="col-xs-12
             {{#ifCond metadata.stack_options.value '==' 'centered'}}qld__video__copy--centered text-center{{/ifCond}}">
             {{{metadata.video_description.value}}}
           </div>
         {{/if}}
 
         <!-- Embed video based on selected video size and layout -->
-        <div class="{{#ifCond metadata.video_size.value '==' 'eight_col'}}col-xs-12 col-lg-8{{else}}col-xs-12{{/ifCond}} 
+        <div class="{{#ifCond metadata.video_size.value '==' 'eight_col'}}col-xs-12 col-lg-8{{else}}col-xs-12{{/ifCond}}
           {{#ifCond metadata.stack_options.value '==' 'centered'}}qld__video__centered{{/ifCond}}">
 
           <!-- Only embed the video if a video ID is provided -->
@@ -31,7 +31,7 @@
                     allow="fullscreen"
                     allowfullscreen
                     title="{{metadata.video_caption.value}} - Video"
-                    aria-label="Video: {{metadata.video_caption.value}}" 
+                    aria-label="Video: {{metadata.video_caption.value}}"
                     class="qld__video__player--iframe">
                     </iframe>
               </div>
@@ -105,7 +105,7 @@
                 allow="fullscreen"
                 allowfullscreen
                 title="{{metadata.video_caption.value}} - Video"
-                aria-label="Video: {{metadata.video_caption.value}}" 
+                aria-label="Video: {{metadata.video_caption.value}}"
                 class="qld__video__player--iframe">
                 </iframe>
               </div>

--- a/src/components/video_player/js/manifest.json
+++ b/src/components/video_player/js/manifest.json
@@ -23,7 +23,7 @@
                     "type": "metadata_field_select",
                     "description": "Select the layout",
                     "friendly_name": "Layout",
-                    "value": "two_column",
+                    "value": "stack",
                     "options": {
                         "stack": "Stacked",
                         "two_column": "2 Columns"
@@ -50,6 +50,29 @@
                                 "field": "video_layout",
                                 "operator": "equals",
                                 "value": "stack"
+                            }
+                        ]
+                    }
+                },
+                "video_align_items": {
+                    "type": "metadata_field_select",
+                    "description": "Select the align items of video",
+                    "friendly_name": "Align items",
+                    "value": "top",
+                    "options": {
+                        "top": "Top",
+                        "centered_vertically": "Centered vertically"
+                    },
+                    "required": false,
+                    "editable": true,
+                    "display_if": {
+                        "show": true,
+                        "operator": "AND",
+                        "rules": [
+                            {
+                                "field": "video_layout",
+                                "operator": "equals",
+                                "value": "two_column"
                             }
                         ]
                     }


### PR DESCRIPTION
This pull request refactors the `video_player` component by improving its CSS structure, introducing new alignment options for layouts, and updating metadata configuration. The main changes focus on enhancing maintainability and flexibility in styling and layout customization.

### CSS Refactoring and Improvements:
* Reformatted CSS properties for better readability by breaking long property values into multiple lines. This affects various selectors, including `.qld__video__player--summary` and `.qld__accordion__body-wrapper`. [[1]](diffhunk://#diff-379d678e7f90a26f7de6bfabd06e424e4d28041c852aab1efd12ff2cb6420f97L7-R8) [[2]](diffhunk://#diff-379d678e7f90a26f7de6bfabd06e424e4d28041c852aab1efd12ff2cb6420f97L26-R38) [[3]](diffhunk://#diff-379d678e7f90a26f7de6bfabd06e424e4d28041c852aab1efd12ff2cb6420f97L51-R61) [[4]](diffhunk://#diff-379d678e7f90a26f7de6bfabd06e424e4d28041c852aab1efd12ff2cb6420f97L67-R79) [[5]](diffhunk://#diff-379d678e7f90a26f7de6bfabd06e424e4d28041c852aab1efd12ff2cb6420f97L83-R97) [[6]](diffhunk://#diff-379d678e7f90a26f7de6bfabd06e424e4d28041c852aab1efd12ff2cb6420f97L98-R114) [[7]](diffhunk://#diff-379d678e7f90a26f7de6bfabd06e424e4d28041c852aab1efd12ff2cb6420f97L116-R130)
* Added a new CSS class `&--align-top` for top alignment and renamed `&--align` to `&--align-centered_vertically` for clarity.

### HTML Updates:
* Updated the `video_player` layout logic in the Handlebars template to dynamically apply the new alignment classes (`qld__video__player--align-top` or `qld__video__player--align-centered_vertically`) based on metadata.

### Metadata Configuration Enhancements:
* Changed the default layout option in `manifest.json` from `two_column` to `stack` for better default behavior. (F00de2fbL2R2)
* Introduced a new metadata field `video_align_items` to allow users to specify alignment options (`top` or `centered_vertically`) when the `two_column` layout is selected. This field is editable and conditionally displayed based on the selected layout.