### PR TITLE
fix/QHWT-1328-QHWT-1274: Content id for search page - Back to top

### DIFF
--- a/src/components/basic_search/html/component.hbs
+++ b/src/components/basic_search/html/component.hbs
@@ -116,7 +116,7 @@
     </div>
 </section>
 
-<section class="qld__body qld__search"> 
+<section class="qld__body qld__search" id="content">
     <div class="container-fluid">
         <div class="row">
             <div class="col-xs-12 col-md-12">


### PR DESCRIPTION
This pull request makes a small but meaningful change to the `src/components/basic_search/html/component.hbs` file. The change adds an `id` attribute with the value `content` to the `<section>` element.