### PR TITLE
fix/QHWT-1357-1311: Bug: Dark main nav active and hover colours are incorrect

### DIFF
--- a/src/components/main_navigation/css/component.scss
+++ b/src/components/main_navigation/css/component.scss
@@ -602,6 +602,10 @@ $QLD-header-md: 72px;
                 background-color: var(--QLD-color-dark__border);
             }
             .qld__main-nav__item {
+                &.active:hover .qld__main-nav__item-link {
+                    border-color: var(--QLD-color-dark__action--primary-hover);
+                }
+
                 a {
                     @include QLD-underline("dark", "noUnderline", "default", "noVisited");
                     color: var(--QLD-color-dark__text);

--- a/src/components/main_navigation/css/component.scss
+++ b/src/components/main_navigation/css/component.scss
@@ -613,8 +613,8 @@ $QLD-header-md: 72px;
                 border-color: var(--QLD-color-dark__design-accent);
 
                 &:hover {
-                    background-color: var(--QLD-color-dark__background);
-                    border-color: var(--QLD-color-dark__action--secondary-hover);
+                    background-color: var(--QLD-color-dark__background--alt);
+                    border-color: var(--QLD-color-dark__action--primary-hover);
 
                     .qld__icon {
                         color: var(--QLD-color-dark__action--secondary-hover);
@@ -626,7 +626,7 @@ $QLD-header-md: 72px;
                 color: var(--QLD-color-dark__heading);
 
                 @include QLD-media(lg) {
-                    border-color: var(--QLD-color-dark__background);
+                    border-color: var(--QLD-color-dark__background--shade);
                 }
             }
 

--- a/src/components/mega_main_navigation/css/component.scss
+++ b/src/components/mega_main_navigation/css/component.scss
@@ -455,7 +455,7 @@
                     }
 
                     &:hover {
-                        border-bottom-color: var(--QLD-color-dark__action--secondary-hover);
+                        border-bottom-color: var(--QLD-color-dark__action--primary-hover);
                         background-color: var(--QLD-color-dark__background--shade);
                     }
                 }

--- a/src/components/mega_main_navigation/css/component.scss
+++ b/src/components/mega_main_navigation/css/component.scss
@@ -456,7 +456,7 @@
 
                     &:hover {
                         border-bottom-color: var(--QLD-color-dark__action--primary-hover);
-                        background-color: var(--QLD-color-dark__background--shade);
+                        background-color: var(--QLD-color-dark__background--alt);
                     }
                 }
                 .qld__main-nav__item-link {


### PR DESCRIPTION
[QHWT-1311](https://squizgroup.atlassian.net/browse/QHWT-1311)


This pull request updates the styling for navigation components in the `src/components/main_navigation/css/component.scss` and `src/components/mega_main_navigation/css/component.scss` files. The changes primarily focus on improving hover states and adjusting border and background colors for better visual consistency.

### Navigation Styling Updates:

#### Main Navigation (`src/components/main_navigation/css/component.scss`):
* Updated the hover state for active navigation items to use `var(--QLD-color-dark__action--primary-hover)` for border color.
* Adjusted hover background and border colors to `var(--QLD-color-dark__background--alt)` and `var(--QLD-color-dark__action--primary-hover)`, respectively, for improved visual hierarchy.
* Changed the border color for large screen sizes to `var(--QLD-color-dark__background--shade)` for enhanced contrast.

#### Mega Main Navigation (`src/components/mega_main_navigation/css/component.scss`):
* Modified hover styles to use `var(--QLD-color-dark__action--primary-hover)` for border-bottom color and `var(--QLD-color-dark__background--alt)` for background color, aligning with the main navigation updates.