### PR TITLE
fix/QHWT-1357-1318: Multi action cards have incorrect and missing focus colours in various scenarios

### DIFF
--- a/src/components/card_multi_action/css/component.scss
+++ b/src/components/card_multi_action/css/component.scss
@@ -171,7 +171,8 @@
             }
         }
 
-        a.qld__card--clickable__link:focus {
+        a.qld__card--clickable__link:focus,
+        a.qld__card__footer-link:focus {
             outline: 3px solid var(--QLD-color-dark__focus);
         }
 
@@ -179,11 +180,12 @@
             color: var(--QLD-color-dark__action--secondary);
         }
 
-        .qld__card__footer-link{  
+        .qld__card__footer-link {
             color: var(--QLD-color-dark__link);
+
             span {
                 @include QLD-underline('dark');
-            }  
+            }
 
             &:visited{
                 span {
@@ -191,6 +193,7 @@
                     text-decoration-color: var(--QLD-color-dark__underline--visited);
                 }
             }
+
             &:hover:visited {
                 span{
                     color: var(--QLD-color-dark__underline--hover-visited);
@@ -198,9 +201,9 @@
                     text-decoration-thickness: var(--QLD-underline__thickness-thick);
                 }
             }
-            &:hover{
 
-                .qld__card__footer-link-icon{
+            &:hover {
+                .qld__card__footer-link-icon {
                     color: var(--QLD-color-dark__action--secondary-hover);
                 }
             }

--- a/src/components/card_multi_action/css/component.scss
+++ b/src/components/card_multi_action/css/component.scss
@@ -67,8 +67,6 @@
         }
     }
 
-    
-
     a.qld__card--clickable__link{
         //remove hit area entire card
         
@@ -80,7 +78,7 @@
             outline: 3px solid var(--QLD-color-light__focus);
         }
     }
-   
+
     .qld__card__footer-inner{
         display: flex;
         flex-direction: column;
@@ -153,7 +151,7 @@
     }
 
     &.qld__card--dark,
-    &.qld__card--dark-alt{
+    &.qld__card--dark-alt {
 
         //Card Icon
         &.qld__card--icon {
@@ -171,6 +169,10 @@
                     }
                 }    
             }
+        }
+
+        a.qld__card--clickable__link:focus {
+            outline: 3px solid var(--QLD-color-dark__focus);
         }
 
         .qld__card__footer-link-icon{

--- a/src/components/card_multi_action/css/component.scss
+++ b/src/components/card_multi_action/css/component.scss
@@ -67,9 +67,10 @@
         }
     }
 
-    a.qld__card--clickable__link{
+    a.qld__card--clickable__link,
+    a.qld__card__footer-link {
         //remove hit area entire card
-        
+
         &:after {
             content: none;
         }
@@ -124,6 +125,7 @@
             @include QLD-underline('light');
 
         }
+
         &:visited{
             span {
                 color: var(--QLD-color-light__underline--hover-visited);

--- a/src/components/card_no_action/css/component.scss
+++ b/src/components/card_no_action/css/component.scss
@@ -377,13 +377,14 @@
         a.qld__card--clickable__link {
             @include QLD-underline('light');
             color: var(--QLD-color-light__link);
+
             &:visited, &:hover:visited {
                 color: var(--QLD-color-light__link--visited);
             }
     
-            &:focus {
-                outline: none;
-            }
+            // &:focus {
+            //     outline: none;
+            // }
         }
 
         &.qld__card--dark, &.qld__card--dark-alt{
@@ -395,9 +396,9 @@
                     color: var(--QLD-color-dark__link--visited);
                 }
         
-                &:focus {
-                    outline: none;
-                }
+                // &:focus {
+                //     outline: none;
+                // }
     
             }
         }


### PR DESCRIPTION
[QHWT-1318](https://squizgroup.atlassian.net/browse/QHWT-1318)

This pull request introduces accessibility improvements and minor styling adjustments to the `card_multi_action` and `card_no_action` components by refining focus states and hover behaviors. The changes ensure better visual feedback for users interacting with links and buttons.

### Accessibility Improvements:

* Added focus outlines for `a.qld__card--clickable__link` and `a.qld__card__footer-link` in `card_multi_action` to enhance keyboard navigation visibility.
* Commented out the removal of focus outlines in `card_no_action` to preserve accessibility for focused elements. [[1]](diffhunk://#diff-65ad3987205948c7aacc1b41d7993936fc3aac721901a4ac6ab05db0506bc01cR380-R387) [[2]](diffhunk://#diff-65ad3987205948c7aacc1b41d7993936fc3aac721901a4ac6ab05db0506bc01cL398-R401)

### Styling Adjustments:

* Unified styling for `a.qld__card--clickable__link` and `a.qld__card__footer-link` in `card_multi_action` by combining their rules.
* Fixed spacing inconsistencies and adjusted hover styles in `card_multi_action` for better visual consistency. [[1]](diffhunk://#diff-60cbc29913d39ebab1645599ea14916040233e635fb96eb061ddc68e0580497bR128) [[2]](diffhunk://#diff-60cbc29913d39ebab1645599ea14916040233e635fb96eb061ddc68e0580497bR198-R207)