### PR TITLE
QHWT-1397 | Back to top | Fix interactive and visited colours

### DIFF
--- a/src/components/widgets/css/component.scss
+++ b/src/components/widgets/css/component.scss
@@ -38,7 +38,7 @@
 // Back to top
 //--------------------------------------------------------------------------------------------------------------------------------------------------------------
 
-@mixin BTT-arrow-colours($interact-colour) {
+@mixin QLD-BTT-arrow-colours($interact-colour) {
     &:hover,
     &:focus,
     &:active {
@@ -56,7 +56,7 @@
             text-decoration: var(--QLD-color-light__underline);
         }
 
-        @include BTT-arrow-colours(var(--QLD-color-light__action--secondary-hover));
+        @include QLD-BTT-arrow-colours(var(--QLD-color-light__action--secondary-hover));
     }
 }
 
@@ -68,7 +68,7 @@
             text-decoration: var(--QLD-color-dark__underline);
         }
 
-        @include BTT-arrow-colours(var(--QLD-color-dark__action--secondary-hover));
+        @include QLD-BTT-arrow-colours(var(--QLD-color-dark__action--secondary-hover));
     }
 }
 

--- a/src/components/widgets/css/component.scss
+++ b/src/components/widgets/css/component.scss
@@ -38,6 +38,37 @@
 // Back to top
 //--------------------------------------------------------------------------------------------------------------------------------------------------------------
 
+@mixin BTT-arrow-colours($interact-colour, $visited-colour) {
+    &:hover,
+    &:focus,
+    &:active {
+        &::after,
+        &::before {
+            border-color: $interact-colour;
+        }
+    }
+
+    &:visited {
+        &::after,
+        &::before {
+            border-color: $visited-colour;
+        }
+    }
+}
+
+.qld__body {
+    .qld__widgets__back_to_top > .qld__direction-link {
+        @include BTT-arrow-colours(var(--QLD-color-light__action--secondary-hover), var(--QLD-color-light__link--visited));
+    }
+}
+
+.qld__body.qld__body--dark,
+.qld__body.qld__body--dark-alt {
+    .qld__widgets__back_to_top > .qld__direction-link {
+        @include BTT-arrow-colours(var(--QLD-color-dark__action--secondary-hover), var(--QLD-color-dark__link--visited));
+    }
+}
+
 body a.qld__btn.qld__btn--floating.qld__btn--back-to-top {
     @include QLD-space(margin-top, 0.5unit);
     background-color: $QLD-color-neutral--lightest;

--- a/src/components/widgets/css/component.scss
+++ b/src/components/widgets/css/component.scss
@@ -38,7 +38,7 @@
 // Back to top
 //--------------------------------------------------------------------------------------------------------------------------------------------------------------
 
-@mixin BTT-arrow-colours($interact-colour, $visited-colour) {
+@mixin BTT-arrow-colours($interact-colour) {
     &:hover,
     &:focus,
     &:active {
@@ -47,25 +47,28 @@
             border-color: $interact-colour;
         }
     }
-
-    &:visited {
-        &::after,
-        &::before {
-            border-color: $visited-colour;
-        }
-    }
 }
 
 .qld__body {
     .qld__widgets__back_to_top > .qld__direction-link {
-        @include BTT-arrow-colours(var(--QLD-color-light__action--secondary-hover), var(--QLD-color-light__link--visited));
+        &:visited {
+            color: var(--QLD-color-light__link);
+            text-decoration: var(--QLD-color-light__underline);
+        }
+
+        @include BTT-arrow-colours(var(--QLD-color-light__action--secondary-hover));
     }
 }
 
 .qld__body.qld__body--dark,
 .qld__body.qld__body--dark-alt {
     .qld__widgets__back_to_top > .qld__direction-link {
-        @include BTT-arrow-colours(var(--QLD-color-dark__action--secondary-hover), var(--QLD-color-dark__link--visited));
+        &:visited {
+            color: var(--QLD-color-dark__link);
+            text-decoration: var(--QLD-color-dark__underline);
+        }
+
+        @include BTT-arrow-colours(var(--QLD-color-dark__action--secondary-hover));
     }
 }
 


### PR DESCRIPTION
This pull request introduces a new mixin and updates the styles for the "Back to Top" widget in both light and dark themes to improve hover, focus, and active state visuals.

### Styling Enhancements:

* Added a new SCSS mixin `QLD-BTT-arrow-colours` to handle the arrow color changes on hover, focus, and active states for the "Back to Top" widget.
* Updated `.qld__widgets__back_to_top` styles for light and dark themes to ensure visited links have appropriate colors and underline styles, and applied the new mixin for consistent interaction feedback.