### PR TITLE
 QHWT-1358 | Footer | Update fa icons

### DIFF
--- a/src/components/footer/css/component.scss
+++ b/src/components/footer/css/component.scss
@@ -407,11 +407,9 @@
             }
         }
 
-        .qld__footer__cta__icon {
+        svg.qld__icon {
             color: var(--QLD-color-dark__action--secondary);
-            text-align: middle;
-            line-height: 1;
-            height: 0.875rem;
+            font-size: 1.25rem;
         }
 
         a.qld__footer__clickable__link {

--- a/src/components/footer/html/component.hbs
+++ b/src/components/footer/html/component.hbs
@@ -30,9 +30,12 @@
                             {{/if}}
                            {{#if footerCTAContact.value}}
                             <p class="qld__footer__cta-content">
-                                {{#if footerCTAContactIcon.value}}
-                                <i class="qld__footer__cta__icon {{footerCTAContactIcon.value}}"></i>
-                                {{/if}}
+                                {{#ifCond footerCTAContactIcon.value '==' 'phone'}}
+                                <svg class="qld__icon" xmlns="http://www.w3.org/2000/svg"><use href="{{@root.site.metadata.coreSiteIcons.value}}#phone"></use></svg>
+                                {{/ifCond}}
+                                {{#ifCond footerCTAContactIcon.value '==' 'email'}}
+                                <svg class="qld__icon" xmlns="http://www.w3.org/2000/svg"><use href="{{@root.site.metadata.coreSiteIcons.value}}#Email"></use></svg>
+                                {{/ifCond}}
                                 {{{footerCTAContact.value}}}
                             </p>
                             {{/if}}

--- a/src/components/footer/html/component.hbs
+++ b/src/components/footer/html/component.hbs
@@ -31,10 +31,10 @@
                            {{#if footerCTAContact.value}}
                             <p class="qld__footer__cta-content">
                                 {{#ifCond footerCTAContactIcon.value '==' 'phone'}}
-                                <svg class="qld__icon" xmlns="http://www.w3.org/2000/svg"><use href="{{@root.site.metadata.coreSiteIcons.value}}#phone"></use></svg>
+                                <svg class="qld__icon qld__icon--lead" xmlns="http://www.w3.org/2000/svg"><use href="{{@root.site.metadata.coreSiteIcons.value}}#phone"></use></svg>
                                 {{/ifCond}}
                                 {{#ifCond footerCTAContactIcon.value '==' 'email'}}
-                                <svg class="qld__icon" xmlns="http://www.w3.org/2000/svg"><use href="{{@root.site.metadata.coreSiteIcons.value}}#Email"></use></svg>
+                                <svg class="qld__icon qld__icon--lead" xmlns="http://www.w3.org/2000/svg"><use href="{{@root.site.metadata.coreSiteIcons.value}}#Email"></use></svg>
                                 {{/ifCond}}
                                 {{{footerCTAContact.value}}}
                             </p>
@@ -116,19 +116,19 @@
                             <a class="qld__footer__clickable__link" href="{{urldecode (lookup this 'asset_url^urlencode')}}">
                             {{/ifCond}}
                                 {{#ifCond (lookup this 'asset_short_name^escapequotes') 'contains' 'facebook'}}
-                                    <svg class="qld__icon qld__icon--md" aria-hidden="true" xmlns="http://www.w3.org/2000/svg" ><use href="{{@root.site.metadata.coreSiteIcons.value}}#Facebook"></use></svg>
+                                    <svg class="qld__icon qld__icon--md" aria-hidden="true" xmlns="http://www.w3.org/2000/svg"><use href="{{@root.site.metadata.coreSiteIcons.value}}#Facebook"></use></svg>
                                 {{/ifCond}}
                                 {{#ifCond (lookup this 'asset_short_name^escapequotes') 'contains' 'linkedin'}}
-                                    <svg class="qld__icon qld__icon--md" aria-hidden="true" xmlns="http://www.w3.org/2000/svg" ><use href="{{@root.site.metadata.coreSiteIcons.value}}#LinkedIn"></use></svg>
+                                    <svg class="qld__icon qld__icon--md" aria-hidden="true" xmlns="http://www.w3.org/2000/svg"><use href="{{@root.site.metadata.coreSiteIcons.value}}#LinkedIn"></use></svg>
                                 {{/ifCond}}
                                 {{#ifCond (lookup this 'asset_short_name^escapequotes') 'contains' 'youtube'}}
-                                    <svg class="qld__icon qld__icon--md" aria-hidden="true" xmlns="http://www.w3.org/2000/svg" ><use href="{{@root.site.metadata.coreSiteIcons.value}}#YouTube"></use></svg>
+                                    <svg class="qld__icon qld__icon--md" aria-hidden="true" xmlns="http://www.w3.org/2000/svg"><use href="{{@root.site.metadata.coreSiteIcons.value}}#YouTube"></use></svg>
                                 {{/ifCond}}
                                 {{#ifCond (lookup this 'asset_short_name^escapequotes') 'contains' 'instagram'}}
-                                    <svg class="qld__icon qld__icon--md" aria-hidden="true" xmlns="http://www.w3.org/2000/svg" ><use href="{{@root.site.metadata.coreSiteIcons.value}}#Instagram"></use></svg>
+                                    <svg class="qld__icon qld__icon--md" aria-hidden="true" xmlns="http://www.w3.org/2000/svg"><use href="{{@root.site.metadata.coreSiteIcons.value}}#Instagram"></use></svg>
                                 {{/ifCond}}
                                 {{#ifCond (lookup this 'asset_short_name^escapequotes') 'contains' 'twitter'}}
-                                    <svg class="qld__icon qld__icon--md" aria-hidden="true" xmlns="http://www.w3.org/2000/svg" ><use href="{{@root.site.metadata.coreSiteIcons.value}}#X"></use></svg>
+                                    <svg class="qld__icon qld__icon--md" aria-hidden="true" xmlns="http://www.w3.org/2000/svg"><use href="{{@root.site.metadata.coreSiteIcons.value}}#X"></use></svg>
                                 {{/ifCond}}
                                 <span class="qld__footer__social__label">{{lookup this 'asset_short_name^escapequotes'}}</span>
                             </a>

--- a/src/data/site.json
+++ b/src/data/site.json
@@ -755,7 +755,7 @@
             "use_default": true
         },
         "footerCTAContactIcon": {
-            "value": "",
+            "value": "email",
             "fieldid": "72414",
             "type": "metadata_field_text",
             "is_contextable": true,


### PR DESCRIPTION
This pull request updates how contact icons are rendered in the footer component, switching from font-based icons to SVG icons for improved accessibility and consistency. The changes also set the default contact icon to "email" in the site metadata.

**Footer contact icon rendering:**
* Replaced font-based icon markup with conditional SVG rendering for "phone" and "email" icons in `component.hbs`, using core site icons for improved accessibility and visual consistency.

**Styling updates:**
* Updated the CSS selector and styling in `component.scss` to target SVG icons (`svg.qld__icon`) instead of the previous font icon class, adjusting size and removing unnecessary styles.

**Configuration update:**
* Set the default value of `footerCTAContactIcon` to "email" in `site.json`, ensuring the email icon is shown by default in the footer.