### PR TITLE
QHWT-1424 | Cards | Update card arrows

### DIFF
--- a/src/components/banner_advanced/html/component.hbs
+++ b/src/components/banner_advanced/html/component.hbs
@@ -221,7 +221,7 @@
                                                     {{/if}}
                                                 </h2> 
                                             </div>
-                                            <div class="qld__card__arrow"></div>
+                                            <svg aria-hidden="true" xmlns="http://www.w3.org/2000/svg" class="qld__card--arrow-icon qld__icon qld__icon--md"><use href="{{@root.site.metadata.coreSiteIcons.value}}#arrow-right"></use></svg>
                                         </div>
                                     </div>
                                 </div>

--- a/src/components/card_feature/html/component.hbs
+++ b/src/components/card_feature/html/component.hbs
@@ -62,7 +62,7 @@
                                     {{/if}}
                                 </div>
                                 {{#ifCond metadata.show_arrow.value '==' 'true'}}
-                                <div class="qld__card__arrow"></div>
+                                    <svg aria-hidden="true" xmlns="http://www.w3.org/2000/svg" class="qld__card--arrow-icon qld__icon qld__icon--md"><use href="{{@root.site.metadata.coreSiteIcons.value}}#arrow-right"></use></svg>
                                 {{/ifCond}}
                             </div>
                             {{#ifCond metadata.show_card_footer.value '==' 'true'}}

--- a/src/components/card_multi_action/html/component.hbs
+++ b/src/components/card_multi_action/html/component.hbs
@@ -126,7 +126,7 @@
                                         {{/if}}
                                     </div>
                                     {{#ifCond ../component.data.metadata.show_arrow.value '==' 'true'}}
-                                    <div class="qld__card__arrow"></div>
+                                        <svg aria-hidden="true" xmlns="http://www.w3.org/2000/svg" class="qld__card--arrow-icon qld__icon qld__icon--md"><use href="{{@root.site.metadata.coreSiteIcons.value}}#arrow-right"></use></svg>
                                     {{/ifCond}}
                                 </div>
                                 {{#ifCond metadata.cardDisplayFooter.value '==' 'true'}}

--- a/src/components/card_single_action/css/component.scss
+++ b/src/components/card_single_action/css/component.scss
@@ -10,27 +10,26 @@
         outline: 3px solid var(--QLD-color-light__focus);
         outline-offset: 2px;
     }
-        
-    &:hover{
+
+    &:hover {
         box-shadow: none;
     }
 
     @include QLD-media(lg) {
         box-shadow: none;
 
-        &:hover{
+        &:hover {
             @include QLD-box-shadow(4);
         }
     }
-    
-    //Card image 
-    &.qld__card--image{
 
-        &:hover{
-            .qld__responsive-media-img--bg::before{
-                content: '';
+    //Card image
+    &.qld__card--image {
+        &:hover {
+            .qld__responsive-media-img--bg::before {
+                content: "";
                 background-color: var(--QLD-color-dark__background);
-                opacity: .1;
+                opacity: 0.1;
                 position: absolute;
                 left: 0;
                 right: 0;
@@ -41,86 +40,78 @@
                 border-bottom-right-radius: 6.0882800608828% 10.81081081081081%;
                 border-bottom-left-radius: 0px;
             }
-        } 
+        }
     }
 
     //Card Icon
     &.qld__card--icon {
-        .qld__card__icon{
+        .qld__card__icon {
             i,
-            svg{
+            svg {
                 color: var(--QLD-color-light__action--secondary);
             }
-        }  
-        &:hover{
-            .qld__card__icon{
+        }
+        &:hover {
+            .qld__card__icon {
                 i,
-                svg{
+                svg {
                     color: var(--QLD-color-light__action--secondary-hover);
                 }
-            }    
+            }
         }
     }
 
     &.qld__card--dark,
-    &.qld__card--dark-alt{
-
+    &.qld__card--dark-alt {
         &.qld__card--icon {
-            .qld__card__icon{
+            .qld__card__icon {
                 i,
-                svg{
+                svg {
                     color: var(--QLD-color-dark__action--secondary);
                 }
-            } 
-            &:hover{
-                .qld__card__icon{
+            }
+            &:hover {
+                .qld__card__icon {
                     i,
-                    svg{
+                    svg {
                         color: var(--QLD-color-dark__action--secondary-hover);
                     }
-                }    
+                }
             }
         }
     }
- 
 }
 
 .qld__card.qld__card--arrow {
-    .qld__card__content{
+    .qld__card__content {
         display: flex;
         justify-content: space-between;
 
-        .qld__card__arrow{
-            @include QLD-space(width, 1.375unit);
-            @include QLD-space(height, 1.5unit);
+        .qld__card--arrow-icon {
             flex: 0 0 auto;
             transition: margin 0.2s ease;
             color: var(--QLD-color-light__action--secondary);
             display: inline-block;
-            mask-image: QLD-svguri($QLD-icon-arrow-right);
-            mask-repeat: no-repeat;
-            mask-position: center;
-            background-color: var(--QLD-color-light__action--secondary);
             @include QLD-space(margin, auto 0 auto 1unit);
         }
 
-        &:hover{
-            .qld__card__arrow{
-                background-color: var(--QLD-color-light__action--secondary-hover);
-                @include QLD-space(margin-right, -.25unit);
+        &:hover {
+            .qld__card--arrow-icon {
+                color: var(--QLD-color-light__action--secondary-hover);
+                @include QLD-space(margin-right, -0.25unit);
                 @include QLD-space(margin-left, 1.25unit);
             }
         }
     }
 
     &.qld__card--dark,
-    &.qld__card--dark-alt{
-        .qld__card__arrow{
-            background-color: var(--QLD-color-dark__action--secondary);
+    &.qld__card--dark-alt {
+        .qld__card--arrow-icon {
+            color: var(--QLD-color-dark__action--secondary);
         }
-        &:hover{
-            .qld__card__arrow{
-                background-color: var(--QLD-color-dark__action--secondary-hover);
+        &:hover {
+            .qld__card--arrow-icon {
+                color: var(--QLD-color-dark__action--secondary-hover);
             }
         }
     }

--- a/src/components/card_single_action/html/component.hbs
+++ b/src/components/card_single_action/html/component.hbs
@@ -125,7 +125,7 @@
                                         {{/if}}
                                     </div>
                                     {{#ifCond ../component.data.metadata.show_arrow.value '==' 'true'}}
-                                    <div class="qld__card__arrow"></div>
+                                        <svg aria-hidden="true" xmlns="http://www.w3.org/2000/svg" class="qld__card--arrow-icon qld__icon qld__icon--md"><use href="{{@root.site.metadata.coreSiteIcons.value}}#arrow-right"></use></svg>
                                     {{/ifCond}}
                                 </div>
                                 {{#ifCond metadata.cardDisplayFooter.value '==' 'true'}}

--- a/src/components/page_alert/css/component.scss
+++ b/src/components/page_alert/css/component.scss
@@ -106,6 +106,67 @@
     }
 }
 
+/**
+* This section can be removed in the future once all WYSIWYG codes are updated to use SVG instead of pseudo. 
+*/
+.qld__page-alerts:not(.qld__page-alerts--svg) {
+    &::before {
+        content: " ";
+        @include QLD-space(width, 1.25unit);
+        @include QLD-space(height, 1.25unit);
+        display: inline-block;
+        vertical-align: text-top;
+        mask-image: QLD-svguri($QLD-icon-info);
+        mask-repeat: no-repeat;
+        mask-position: center;
+        background-color: $QLD-color-neutral--white;
+        position: absolute;
+        @include QLD-space(left, -1.5unit);
+        top: 50%;
+        transform: translate(-50%, -50%);
+    }
+
+    /**
+	* Page alert success
+	*/
+    &.qld__page-alerts--success {
+        border-color: $QLD-color-status__success;
+
+        &::before {
+            background-color: $QLD-color-neutral--white;
+            mask-image: QLD-svguri($QLD-icon-success);
+        }
+    }
+
+    /**
+	* Page alert warning.
+	*/
+    &.qld__page-alerts--warning {
+        border-color: $QLD-color-status__caution;
+
+        &::before {
+            background-color: $QLD-color-neutral--black;
+            mask-image: QLD-svguri($QLD-icon-warning);
+        }
+    }
+
+    /**
+	* Page alert error.
+	*/
+    &.qld__page-alerts--error {
+        border-color: $QLD-color-status__error;
+
+        &::before {
+            background-color: $QLD-color-neutral--white;
+            mask-image: QLD-svguri($QLD-icon-error);
+        }
+    }
+}
+
+/**
+* Remove up to here
+*/
+
 .qld__body #content > * + .qld__page-alerts {
     @include QLD-space(margin-top, 2unit);
 }

--- a/src/components/page_alert/css/component.scss
+++ b/src/components/page_alert/css/component.scss
@@ -2,230 +2,131 @@
 // Page alerts
 //--------------------------------------------------------------------------------------------------------------------------------------------------------------
 .qld__page-alerts {
-	@include QLD-space( padding, 1unit );
-	@include QLD-fontgrid( sm );
-	position: relative;
-	border: solid $QLD-border-width-default $QLD-color-status__info;
-	@include QLD-space( border-left-width, 3unit );
-	border-radius: $QLD-border-radius-xs;
-	word-wrap: break-word;
-	background-color: $QLD-color-neutral--white;
-	max-width: 48rem;
+    @include QLD-space(padding, 1unit);
+    @include QLD-fontgrid(sm);
+    position: relative;
+    border: solid $QLD-border-width-default $QLD-color-status__info;
+    @include QLD-space(border-left-width, 3unit);
+    border-radius: $QLD-border-radius-xs;
+    word-wrap: break-word;
+    background-color: $QLD-color-neutral--white;
+    max-width: 48rem;
 
-	&.qld__page-alerts--svg {
-		.qld__page-alerts--heading {
-			@include QLD-space( margin-top, 0unit );
-		}
-		.qld__page-alerts__icon {
-			position: absolute;
-			@include QLD-space( left, -1.5unit );
-			top: 50%;
-			transform: translate(-50%, -50%);
-			vertical-align: text-top;
-		}
+    &.qld__page-alerts--svg {
+        .qld__page-alerts--heading {
+            @include QLD-space(margin-top, 0unit);
+        }
+        .qld__page-alerts__icon {
+            position: absolute;
+            @include QLD-space(left, -1.5unit);
+            top: 50%;
+            transform: translate(-50%, -50%);
+            vertical-align: text-top;
+        }
 
-		.qld__icon {
-			color: $QLD-color-neutral--white;
-		}
+        .qld__icon {
+            color: $QLD-color-neutral--white;
+        }
 
-		/**
+        /**
 		* Page alert success
 		*/
-		&.qld__page-alerts--success {
-			border-color: $QLD-color-status__success;
+        &.qld__page-alerts--success {
+            border-color: $QLD-color-status__success;
 
-			.qld__icon {
-				color: $QLD-color-neutral--white;
-			}
-		}
+            .qld__icon {
+                color: $QLD-color-neutral--white;
+            }
+        }
 
-		/**
+        /**
 		* Page alert warning.
 		*/
-		&.qld__page-alerts--warning {
-			border-color: $QLD-color-status__caution;
+        &.qld__page-alerts--warning {
+            border-color: $QLD-color-status__caution;
 
-			.qld__icon {
-				color: $QLD-color-neutral--black;
-			}
-		}
+            .qld__icon {
+                color: $QLD-color-neutral--black;
+            }
+        }
 
-		/**
+        /**
 		* Page alert error.
 		*/
-		&.qld__page-alerts--error {
-			border-color: $QLD-color-status__error;
+        &.qld__page-alerts--error {
+            border-color: $QLD-color-status__error;
 
-			.qld__icon {
-				color: $QLD-color-neutral--white;
-			}
-		}
-	}
-	
-	& .qld__page-alerts--heading.qld__display-lg {
-		color: var(--QLD-color-light__heading);
-		@include QLD-space(margin-bottom, 1unit);
-		line-height: 2.25rem;
-	}
+            .qld__icon {
+                color: $QLD-color-neutral--white;
+            }
+        }
+    }
 
-	& a{
-		color: var(--QLD-color-light__link);
-		@include QLD-underline('light');
-	}
+    & .qld__page-alerts--heading.qld__display-lg {
+        color: var(--QLD-color-light__heading);
+        @include QLD-space(margin-bottom, 1unit);
+        line-height: 2.25rem;
+    }
 
+    & a {
+        color: var(--QLD-color-light__link);
+        @include QLD-underline("light");
+    }
 
-
-	/**
+    /**
 	* Page alert warning.
 	*/
-	&.qld__page-alerts--warning {
-		border-color: $QLD-color-status__caution;
+    &.qld__page-alerts--warning {
+        border-color: $QLD-color-status__caution;
+    }
 
-		&::before{
-			background-color: $QLD-color-neutral--black;
-			mask-image: QLD-svguri($QLD-icon-warning);
-		}
-	}
-
-	/**
+    /**
 	* Page alert error.
 	*/
-	&.qld__page-alerts--error {
-		border-color: $QLD-color-status__error;
+    &.qld__page-alerts--error {
+        border-color: $QLD-color-status__error;
+    }
 
-		&::before{
-			background-color: $QLD-color-neutral--white;
-			mask-image: QLD-svguri($QLD-icon-error);
-		}
-	}
+    // dark and dark alt
+    .qld__body--dark &,
+    .qld__body--dark-alt & {
+        color: var(--QLD-color-light__text);
 
-	// // dark and dark alt
-	.qld__body--dark &,
-	.qld__body--dark-alt &{
-		color: var(--QLD-color-light__text);
-		
-		h3{
-			color: var(--QLD-color-light__heading);
-		}
+        h3 {
+            color: var(--QLD-color-light__heading);
+        }
 
-		& a{
-			color: var(--QLD-color-light__link);
-			@include QLD-underline('light');
-			&:hover{
-				color: var(--QLD-color-light__link);
-			}
-		}
-	}
+        & a {
+            color: var(--QLD-color-light__link);
+            @include QLD-underline("light");
+            &:hover {
+                color: var(--QLD-color-light__link);
+            }
+        }
+    }
 }
 
-/**
-* This section can be removed in the future once all WYSIWYG codes are updated to use SVG instead of pseudo. 
-*/
-.qld__page-alerts:not(.qld__page-alerts--svg) {
-	&::before{
-		content: ' ';
-		@include QLD-space( width, 1.25unit );
-		@include QLD-space( height, 1.25unit );
-		display: inline-block;
-		vertical-align: text-top;
-		mask-image: QLD-svguri($QLD-icon-info);
-		mask-repeat: no-repeat;
-		mask-position: center;
-		background-color: $QLD-color-neutral--white;
-		position: absolute;
-		@include QLD-space( left, -1.5unit );
-		top: 50%;
-		transform: translate(-50%, -50%);
-	}
-
-	/**
-	* Page alert success
-	*/
-	&.qld__page-alerts--success {
-		border-color: $QLD-color-status__success;
-
-		&::before{
-			background-color: $QLD-color-neutral--white;
-			mask-image: QLD-svguri($QLD-icon-success);
-		}
-	}
-
-	/**
-	* Page alert warning.
-	*/
-	&.qld__page-alerts--warning {
-		border-color: $QLD-color-status__caution;
-
-		&::before{
-			background-color: $QLD-color-neutral--black;
-			mask-image: QLD-svguri($QLD-icon-warning);
-		}
-	}
-
-	/**
-	* Page alert error.
-	*/
-	&.qld__page-alerts--error {
-		border-color: $QLD-color-status__error;
-
-		&::before{
-			background-color: $QLD-color-neutral--white;
-			mask-image: QLD-svguri($QLD-icon-error);
-		}
-	}
+.qld__body #content > * + .qld__page-alerts {
+    @include QLD-space(margin-top, 2unit);
 }
-
-/**
-* Remove up to here
-*/
-
-
-.qld__body #content > * + .qld__page-alerts  {
-	@include QLD-space( margin-top, 2unit );
-}
-
 
 /**
  * Screen-reader only class for interlinking error messages and corresponding form elements.
  */
 .qld__page-alerts__sronly {
-	@include QLD-sronly;
+    @include QLD-sronly;
 }
-
 
 // Print styles
 @media print {
-	.qld__page-alerts {
-		border-color: #000 !important;
-		background-color: #fff !important;
-		border-left: 2px solid #000 !important;
-		padding-top: 3em !important;
+    .qld__page-alerts {
+        border-color: #000 !important;
+        background-color: #fff !important;
+        border-left: 2px solid #000 !important;
+        padding-top: 3em !important;
+    }
 
-		&:after {
-			background: none !important;
-			content: 'info' !important;
-			top: 1em !important;
-			left: 0 !important;
-			font-size: 12px !important;
-			border-right: 1px solid #000 !important;
-			border-bottom: 1px solid #000 !important;
-			padding: 0.5em !important;
-			width: auto !important;
-		}
-	}
-
-	.qld__page-alerts--success:after {
-		content: 'success' !important;
-	}
-
-	.qld__page-alerts--warning:after {
-		content: 'warning' !important;
-	}
-
-	.qld__page-alerts--error:after {
-		content: 'error' !important;
-	}
-	.qld__page-alerts__icon {
-		display: none;
-	}
+    .qld__page-alerts__icon {
+        display: none;
+    }
 }

--- a/src/html/component-card_feature.html
+++ b/src/html/component-card_feature.html
@@ -14,31 +14,150 @@
 
     <head>
         <title>Queensland Design System</title>
-        
+
         ${require('../components/_global/html/head.html')}
         <script>
-            var globals = {"site":{"data":{"assetid":"136","type_code":"site","version":"0.0.8","name":"Design System","short_name":"Design System","status":"2","force_secure":"0","languages":"en","charset":"utf-8","created":"2020-12-09 13:11:12","created_userid":"54","updated":"2021-01-20 15:08:30","updated_userid":"312","published":"Never","published_userid":"","status_changed":"2020-12-09 13:11:12","status_changed_userid":"54","thumbnail":"","attributes":{"name":{"attrid":"685","type":"text","value":"Design System","is_contextable":true,"use_default":true},"not_found_page_cache_globally":{"attrid":"686","type":"boolean","value":false,"is_contextable":false,"use_default":true},"available_conditions":{"attrid":"687","type":"serialise","value":[],"is_contextable":false,"use_default":true}},"metadata":{"displayInPageNav":{"value":"","fieldid":"808","type":"metadata_field_select","is_contextable":true,"default_value":true,"use_default":true},"inPageNav_heading":{"value":"On this page","fieldid":"809","type":"metadata_field_text","is_contextable":true,"default_value":true,"use_default":true},"inPageNav_headingType":{"value":"h2","fieldid":"810","type":"metadata_field_select","is_contextable":true,"default_value":true,"use_default":true},"siteTitle":{"value":"Queensland Health Design System","fieldid":"166","type":"metadata_field_text","is_contextable":true,"default_value":false,"use_default":true},"siteLogo":{"value":"169","fieldid":"127","type":"metadata_field_related_asset","is_contextable":true,"default_value":false,"use_default":true},"siteFavicon":{"value":"106","fieldid":"128","type":"metadata_field_related_asset","is_contextable":true,"default_value":false,"use_default":true},"siteAppleTouch":{"value":"106","fieldid":"129","type":"metadata_field_related_asset","is_contextable":true,"default_value":false,"use_default":true},"sitePreHeaderLogo":{"value":"170","fieldid":"171","type":"metadata_field_related_asset","is_contextable":true,"default_value":false,"use_default":true},"sitePreHeaderText":{"value":"digital.qld.gov.au","fieldid":"167","type":"metadata_field_text","is_contextable":true,"default_value":false,"use_default":true},"sitePreHeaderURL":{"value":"http://www.digital.qld.gov.au","fieldid":"168","type":"metadata_field_text","is_contextable":true,"default_value":false,"use_default":true},"showHomeIcon":{"value":"true","fieldid":"481","type":"metadata_field_select","is_contextable":true,"default_value":true,"use_default":true},"siteRepository":{"value":"164","fieldid":"213","type":"metadata_field_related_asset","is_contextable":true,"default_value":false,"use_default":true},"footerLinks":{"value":"[\"186\",\"194\",\"198\",\"458\",\"676\"]","fieldid":"715","type":"metadata_field_related_asset","is_contextable":true,"default_value":false,"use_default":true},"footerCopyrightMessage":{"value":"© The State of Queensland 2020","fieldid":"722","type":"metadata_field_text","is_contextable":true,"default_value":true,"use_default":true},"footerCopyrightLink":{"value":"206","fieldid":"723","type":"metadata_field_related_asset","is_contextable":true,"default_value":false,"use_default":true},"footerCTAHeading":{"value":"Help us improve","fieldid":"724","type":"metadata_field_text","is_contextable":true,"default_value":false,"use_default":true},"footerCTALead":{"value":"We are always looking for ways to improve our website.","fieldid":"725","type":"metadata_field_text","is_contextable":true,"default_value":false,"use_default":true},"footerCTALink":{"value":"186","fieldid":"726","type":"metadata_field_related_asset","is_contextable":true,"default_value":false,"use_default":true}}},"metadata":{"displayInPageNav":{"value":"","fieldid":"808","type":"metadata_field_select","is_contextable":true,"default_value":true,"use_default":true},"inPageNav_heading":{"value":"On this page","fieldid":"809","type":"metadata_field_text","is_contextable":true,"default_value":true,"use_default":true},"inPageNav_headingType":{"value":"h2","fieldid":"810","type":"metadata_field_select","is_contextable":true,"default_value":true,"use_default":true},"siteTitle":{"value":"Queensland Health Design System","fieldid":"166","type":"metadata_field_text","is_contextable":true,"default_value":false,"use_default":true},"siteLogo":{"value":"169","fieldid":"127","type":"metadata_field_related_asset","is_contextable":true,"default_value":false,"use_default":true},"siteFavicon":{"value":"106","fieldid":"128","type":"metadata_field_related_asset","is_contextable":true,"default_value":false,"use_default":true},"siteAppleTouch":{"value":"106","fieldid":"129","type":"metadata_field_related_asset","is_contextable":true,"default_value":false,"use_default":true},"sitePreHeaderLogo":{"value":"170","fieldid":"171","type":"metadata_field_related_asset","is_contextable":true,"default_value":false,"use_default":true},"sitePreHeaderText":{"value":"digital.qld.gov.au","fieldid":"167","type":"metadata_field_text","is_contextable":true,"default_value":false,"use_default":true},"sitePreHeaderURL":{"value":"http://www.digital.qld.gov.au","fieldid":"168","type":"metadata_field_text","is_contextable":true,"default_value":false,"use_default":true},"showHomeIcon":{"value":"true","fieldid":"481","type":"metadata_field_select","is_contextable":true,"default_value":true,"use_default":true},"siteRepository":{"value":"164","fieldid":"213","type":"metadata_field_related_asset","is_contextable":true,"default_value":false,"use_default":true},"footerLinks":{"value":"[\"186\",\"194\",\"198\",\"458\",\"676\"]","fieldid":"715","type":"metadata_field_related_asset","is_contextable":true,"default_value":false,"use_default":true},"footerCopyrightMessage":{"value":"© The State of Queensland 2020","fieldid":"722","type":"metadata_field_text","is_contextable":true,"default_value":true,"use_default":true},"footerCopyrightLink":{"value":"206","fieldid":"723","type":"metadata_field_related_asset","is_contextable":true,"default_value":false,"use_default":true},"footerCTAHeading":{"value":"Help us improve","fieldid":"724","type":"metadata_field_text","is_contextable":true,"default_value":false,"use_default":true},"footerCTALead":{"value":"We are always looking for ways to improve our website.","fieldid":"725","type":"metadata_field_text","is_contextable":true,"default_value":false,"use_default":true},"footerCTALink":{"value":"186","fieldid":"726","type":"metadata_field_related_asset","is_contextable":true,"default_value":false,"use_default":true}},"children":[{"asset_name":"Get started","asset_assetid":"186"},{"asset_name":"Brand guidelines","asset_assetid":"190"},{"asset_name":"Content guidelines","asset_assetid":"194"},{"asset_name":"Components","asset_assetid":"198"},{"asset_name":"Examples","asset_assetid":"202"},{"asset_name":"Support","asset_assetid":"206"}]},"current":{"data":{"assetid":"676","type_code":"page_standard","version":"0.0.16","name":"Links","short_name":"Links","status":"2","force_secure":"0","languages":"en","charset":"utf-8","created":"2021-01-11 11:48:22","created_userid":"312","updated":"2021-01-20 15:08:29","updated_userid":"312","published":"Never","published_userid":"","status_changed":"2021-01-11 11:48:22","status_changed_userid":"312","thumbnail":"","attributes":{"name":{"attrid":"631","type":"text","value":"Links","is_contextable":true,"use_default":true},"short_name":{"attrid":"632","type":"text","value":"Links","is_contextable":true,"use_default":true},"available_conditions":{"attrid":"633","type":"serialise","value":[],"is_contextable":false,"use_default":true},"conditions":{"attrid":"634","type":"serialise","value":[],"is_contextable":true,"use_default":true}},"metadata":{"description":{"value":"","fieldid":"132","type":"metadata_field_text","is_contextable":true,"default_value":true,"use_default":true},"pageType":{"value":"landing","fieldid":"680","type":"metadata_field_select","is_contextable":true,"default_value":false,"use_default":true},"displayBreadcrumbs":{"value":"true","fieldid":"681","type":"metadata_field_select","is_contextable":true,"default_value":true,"use_default":true},"displayBanner":{"value":"true","fieldid":"682","type":"metadata_field_select","is_contextable":true,"default_value":true,"use_default":true},"displayInPageNav":{"value":"true","fieldid":"808","type":"metadata_field_select","is_contextable":true,"default_value":true,"use_default":true},"inPageNav_heading":{"value":"On this page","fieldid":"809","type":"metadata_field_text","is_contextable":true,"default_value":true,"use_default":true},"inPageNav_headingType":{"value":"h2","fieldid":"810","type":"metadata_field_select","is_contextable":true,"default_value":true,"use_default":true}}},"home":0,"children":[{"asset_assetid":"458","asset_url":"https://qhscb.squiz.cloud/components/accordion","asset_name":"Accordion","children":[]},{"asset_assetid":"325","asset_url":"https://qhscb.squiz.cloud/components/callout","asset_name":"Callout","children":[]},{"asset_assetid":"659","asset_url":"https://qhscb.squiz.cloud/components/card-listing","asset_name":"Card Listing","children":[]},{"asset_assetid":"676","asset_url":"https://qhscb.squiz.cloud/components/links","asset_name":"Links","children":[]},{"asset_assetid":"683","asset_url":"https://qhscb.squiz.cloud/components/search-box","asset_name":"Search Box","children":[]},{"asset_assetid":"785","asset_url":"https://qhscb.squiz.cloud/components/page-alert","asset_name":"Page Alert","children":[]}],"lineage":[{"asset_assetid":"136","asset_name":"Design System","asset_url":"https://qhscb.squiz.cloud"},{"asset_assetid":"198","asset_name":"Components","asset_url":"https://qhscb.squiz.cloud/components"},{"asset_assetid":"676","asset_name":"Links","asset_url":"https://qhscb.squiz.cloud/components/links"}],"top":{"asset_assetid":"198","asset_name":"Components","asset_url":"https://qhscb.squiz.cloud/components"}}};
+            var globals = {
+                site: {
+                    data: {
+                        assetid: "136",
+                        type_code: "site",
+                        version: "0.0.8",
+                        name: "Design System",
+                        short_name: "Design System",
+                        status: "2",
+                        force_secure: "0",
+                        languages: "en",
+                        charset: "utf-8",
+                        created: "2020-12-09 13:11:12",
+                        created_userid: "54",
+                        updated: "2021-01-20 15:08:30",
+                        updated_userid: "312",
+                        published: "Never",
+                        published_userid: "",
+                        status_changed: "2020-12-09 13:11:12",
+                        status_changed_userid: "54",
+                        thumbnail: "",
+                        attributes: {
+                            name: { attrid: "685", type: "text", value: "Design System", is_contextable: true, use_default: true },
+                            not_found_page_cache_globally: { attrid: "686", type: "boolean", value: false, is_contextable: false, use_default: true },
+                            available_conditions: { attrid: "687", type: "serialise", value: [], is_contextable: false, use_default: true },
+                        },
+                        metadata: {
+                            displayInPageNav: { value: "", fieldid: "808", type: "metadata_field_select", is_contextable: true, default_value: true, use_default: true },
+                            inPageNav_heading: { value: "On this page", fieldid: "809", type: "metadata_field_text", is_contextable: true, default_value: true, use_default: true },
+                            inPageNav_headingType: { value: "h2", fieldid: "810", type: "metadata_field_select", is_contextable: true, default_value: true, use_default: true },
+                            siteTitle: { value: "Queensland Health Design System", fieldid: "166", type: "metadata_field_text", is_contextable: true, default_value: false, use_default: true },
+                            siteLogo: { value: "169", fieldid: "127", type: "metadata_field_related_asset", is_contextable: true, default_value: false, use_default: true },
+                            siteFavicon: { value: "106", fieldid: "128", type: "metadata_field_related_asset", is_contextable: true, default_value: false, use_default: true },
+                            siteAppleTouch: { value: "106", fieldid: "129", type: "metadata_field_related_asset", is_contextable: true, default_value: false, use_default: true },
+                            sitePreHeaderLogo: { value: "170", fieldid: "171", type: "metadata_field_related_asset", is_contextable: true, default_value: false, use_default: true },
+                            sitePreHeaderText: { value: "digital.qld.gov.au", fieldid: "167", type: "metadata_field_text", is_contextable: true, default_value: false, use_default: true },
+                            sitePreHeaderURL: { value: "http://www.digital.qld.gov.au", fieldid: "168", type: "metadata_field_text", is_contextable: true, default_value: false, use_default: true },
+                            showHomeIcon: { value: "true", fieldid: "481", type: "metadata_field_select", is_contextable: true, default_value: true, use_default: true },
+                            siteRepository: { value: "164", fieldid: "213", type: "metadata_field_related_asset", is_contextable: true, default_value: false, use_default: true },
+                            footerLinks: { value: '["186","194","198","458","676"]', fieldid: "715", type: "metadata_field_related_asset", is_contextable: true, default_value: false, use_default: true },
+                            footerCopyrightMessage: { value: "© The State of Queensland 2020", fieldid: "722", type: "metadata_field_text", is_contextable: true, default_value: true, use_default: true },
+                            footerCopyrightLink: { value: "206", fieldid: "723", type: "metadata_field_related_asset", is_contextable: true, default_value: false, use_default: true },
+                            footerCTAHeading: { value: "Help us improve", fieldid: "724", type: "metadata_field_text", is_contextable: true, default_value: false, use_default: true },
+                            footerCTALead: { value: "We are always looking for ways to improve our website.", fieldid: "725", type: "metadata_field_text", is_contextable: true, default_value: false, use_default: true },
+                            footerCTALink: { value: "186", fieldid: "726", type: "metadata_field_related_asset", is_contextable: true, default_value: false, use_default: true },
+                        },
+                    },
+                    metadata: {
+                        displayInPageNav: { value: "", fieldid: "808", type: "metadata_field_select", is_contextable: true, default_value: true, use_default: true },
+                        inPageNav_heading: { value: "On this page", fieldid: "809", type: "metadata_field_text", is_contextable: true, default_value: true, use_default: true },
+                        inPageNav_headingType: { value: "h2", fieldid: "810", type: "metadata_field_select", is_contextable: true, default_value: true, use_default: true },
+                        siteTitle: { value: "Queensland Health Design System", fieldid: "166", type: "metadata_field_text", is_contextable: true, default_value: false, use_default: true },
+                        siteLogo: { value: "169", fieldid: "127", type: "metadata_field_related_asset", is_contextable: true, default_value: false, use_default: true },
+                        siteFavicon: { value: "106", fieldid: "128", type: "metadata_field_related_asset", is_contextable: true, default_value: false, use_default: true },
+                        siteAppleTouch: { value: "106", fieldid: "129", type: "metadata_field_related_asset", is_contextable: true, default_value: false, use_default: true },
+                        sitePreHeaderLogo: { value: "170", fieldid: "171", type: "metadata_field_related_asset", is_contextable: true, default_value: false, use_default: true },
+                        sitePreHeaderText: { value: "digital.qld.gov.au", fieldid: "167", type: "metadata_field_text", is_contextable: true, default_value: false, use_default: true },
+                        sitePreHeaderURL: { value: "http://www.digital.qld.gov.au", fieldid: "168", type: "metadata_field_text", is_contextable: true, default_value: false, use_default: true },
+                        showHomeIcon: { value: "true", fieldid: "481", type: "metadata_field_select", is_contextable: true, default_value: true, use_default: true },
+                        siteRepository: { value: "164", fieldid: "213", type: "metadata_field_related_asset", is_contextable: true, default_value: false, use_default: true },
+                        footerLinks: { value: '["186","194","198","458","676"]', fieldid: "715", type: "metadata_field_related_asset", is_contextable: true, default_value: false, use_default: true },
+                        footerCopyrightMessage: { value: "© The State of Queensland 2020", fieldid: "722", type: "metadata_field_text", is_contextable: true, default_value: true, use_default: true },
+                        footerCopyrightLink: { value: "206", fieldid: "723", type: "metadata_field_related_asset", is_contextable: true, default_value: false, use_default: true },
+                        footerCTAHeading: { value: "Help us improve", fieldid: "724", type: "metadata_field_text", is_contextable: true, default_value: false, use_default: true },
+                        footerCTALead: { value: "We are always looking for ways to improve our website.", fieldid: "725", type: "metadata_field_text", is_contextable: true, default_value: false, use_default: true },
+                        footerCTALink: { value: "186", fieldid: "726", type: "metadata_field_related_asset", is_contextable: true, default_value: false, use_default: true },
+                    },
+                    children: [
+                        { asset_name: "Get started", asset_assetid: "186" },
+                        { asset_name: "Brand guidelines", asset_assetid: "190" },
+                        { asset_name: "Content guidelines", asset_assetid: "194" },
+                        { asset_name: "Components", asset_assetid: "198" },
+                        { asset_name: "Examples", asset_assetid: "202" },
+                        { asset_name: "Support", asset_assetid: "206" },
+                    ],
+                },
+                current: {
+                    data: {
+                        assetid: "676",
+                        type_code: "page_standard",
+                        version: "0.0.16",
+                        name: "Links",
+                        short_name: "Links",
+                        status: "2",
+                        force_secure: "0",
+                        languages: "en",
+                        charset: "utf-8",
+                        created: "2021-01-11 11:48:22",
+                        created_userid: "312",
+                        updated: "2021-01-20 15:08:29",
+                        updated_userid: "312",
+                        published: "Never",
+                        published_userid: "",
+                        status_changed: "2021-01-11 11:48:22",
+                        status_changed_userid: "312",
+                        thumbnail: "",
+                        attributes: {
+                            name: { attrid: "631", type: "text", value: "Links", is_contextable: true, use_default: true },
+                            short_name: { attrid: "632", type: "text", value: "Links", is_contextable: true, use_default: true },
+                            available_conditions: { attrid: "633", type: "serialise", value: [], is_contextable: false, use_default: true },
+                            conditions: { attrid: "634", type: "serialise", value: [], is_contextable: true, use_default: true },
+                        },
+                        metadata: {
+                            description: { value: "", fieldid: "132", type: "metadata_field_text", is_contextable: true, default_value: true, use_default: true },
+                            pageType: { value: "landing", fieldid: "680", type: "metadata_field_select", is_contextable: true, default_value: false, use_default: true },
+                            displayBreadcrumbs: { value: "true", fieldid: "681", type: "metadata_field_select", is_contextable: true, default_value: true, use_default: true },
+                            displayBanner: { value: "true", fieldid: "682", type: "metadata_field_select", is_contextable: true, default_value: true, use_default: true },
+                            displayInPageNav: { value: "true", fieldid: "808", type: "metadata_field_select", is_contextable: true, default_value: true, use_default: true },
+                            inPageNav_heading: { value: "On this page", fieldid: "809", type: "metadata_field_text", is_contextable: true, default_value: true, use_default: true },
+                            inPageNav_headingType: { value: "h2", fieldid: "810", type: "metadata_field_select", is_contextable: true, default_value: true, use_default: true },
+                        },
+                    },
+                    home: 0,
+                    children: [
+                        { asset_assetid: "458", asset_url: "https://qhscb.squiz.cloud/components/accordion", asset_name: "Accordion", children: [] },
+                        { asset_assetid: "325", asset_url: "https://qhscb.squiz.cloud/components/callout", asset_name: "Callout", children: [] },
+                        { asset_assetid: "659", asset_url: "https://qhscb.squiz.cloud/components/card-listing", asset_name: "Card Listing", children: [] },
+                        { asset_assetid: "676", asset_url: "https://qhscb.squiz.cloud/components/links", asset_name: "Links", children: [] },
+                        { asset_assetid: "683", asset_url: "https://qhscb.squiz.cloud/components/search-box", asset_name: "Search Box", children: [] },
+                        { asset_assetid: "785", asset_url: "https://qhscb.squiz.cloud/components/page-alert", asset_name: "Page Alert", children: [] },
+                    ],
+                    lineage: [
+                        { asset_assetid: "136", asset_name: "Design System", asset_url: "https://qhscb.squiz.cloud" },
+                        { asset_assetid: "198", asset_name: "Components", asset_url: "https://qhscb.squiz.cloud/components" },
+                        { asset_assetid: "676", asset_name: "Links", asset_url: "https://qhscb.squiz.cloud/components/links" },
+                    ],
+                    top: { asset_assetid: "198", asset_name: "Components", asset_url: "https://qhscb.squiz.cloud/components" },
+                },
+            };
         </script>
     </head>
 
     <body class="qld__grid">
         <!--noindex-->
-        ${require('../components/header/html/component.hbs')({
-            "site":require('/src/data/site.json')
-        })}
+        ${require('../components/header/html/component.hbs')({ "site":require('/src/data/site.json') })}
         <!--endnoindex-->
-        ${require('../components/mega_main_navigation/html/component.hbs')({
-            "site":require('/src/data/site.json')
-        })}
+        ${require('../components/mega_main_navigation/html/component.hbs')({ "site":require('/src/data/site.json') })}
         <!-- MAIN BODY -->
         <main class="main" role="main">
             <section class="qld__body qld__body--breadcrumb">
-                <div class="container-fluid">
-                    ${require('../components/breadcrumbs/html/component.hbs')({
-                        "site":require('/src/data/site.json'),
-                        "current":require('/src/data/current.json'),
-                    })}
-                </div>
+                <div class="container-fluid">${require('../components/breadcrumbs/html/component.hbs')({ "site":require('/src/data/site.json'), "current":require('/src/data/current.json'), })}</div>
             </section>
             <!--CONTENT-->
             <div class="qld__body">
@@ -46,99 +165,67 @@
                     <div class="row">
                         <div class="col-xs-12 col-lg-4 col-xl-3">
                             <!-- INTERNAL NAVIGATION -->
-                            ${require('../components/internal_navigation/html/component.hbs')({
-                                "site":require('/src/data/site.json'),
-                                "current":require('/src/data/current.json')
-                            })}
+                            ${require('../components/internal_navigation/html/component.hbs')({ "site":require('/src/data/site.json'), "current":require('/src/data/current.json') })}
                         </div>
                         <div class="col-xs-12 col-lg-8 col-xl-8" id="content">
-                            
-                            ${require('../components/_global/html/component.hbs')({
-                                "manifest":require('../components/card_feature/js/manifest.json'),
-                                "component":require('!url-loader!../components/card_feature/html/component.hbs'),
-                                "component_output":require('../components/card_feature/html/component.hbs')({
-                                    "component":require('../components/card_feature/js/manifest.json').component,
-                                    "content":"Lorem Ipsum"
-                                })
-                            })}
+                            ${require('../components/_global/html/component.hbs')({ "manifest":require('../components/card_feature/js/manifest.json'), "component":require('!url-loader!../components/card_feature/html/component.hbs'),
+                            "component_output":require('../components/card_feature/html/component.hbs')({ "component":require('../components/card_feature/js/manifest.json').component, "content":"Lorem Ipsum" }) })}
 
                             <h2>Single action - base</h2>
                             <ul class="qld__card-list qld__card-list--matchheight">
+                                <li class="col-xs-12 col-md-6 col-xs-12">
+                                    <div class="qld__card qld__card__action">
+                                        <div class="qld__card__inner">
+                                            <div class="qld__card__content">
+                                                <div class="qld__card__content-inner">
+                                                    <h3 class="qld__card__title">
+                                                        <a aria-label="Brand" aria-describedby="card-22724" class="qld__card--clickable__link" href="#">Light</a>
+                                                    </h3>
+                                                    <p id="card-22724" class="qld__card__description">Additional text about the card</p>
+                                                </div>
+                                            </div>
+                                        </div>
+                                    </div>
+                                </li>
 
+                                <li class="col-xs-12 col-md-6 col-xs-12">
+                                    <div class="qld__card qld__card__action qld__card--alt">
+                                        <div class="qld__card__inner">
+                                            <div class="qld__card__content">
+                                                <div class="qld__card__content-inner">
+                                                    <h3 class="qld__card__title">
+                                                        <a aria-label="Content" aria-describedby="card-22725" class="qld__card--clickable__link" href="#">Alternative</a>
+                                                    </h3>
+                                                    <p id="card-22725" class="qld__card__description">Additional text about the card</p>
+                                                </div>
+                                            </div>
+                                        </div>
+                                    </div>
+                                </li>
 
-                                <li class="col-xs-12 col-md-6 col-xs-12"> 
-                                    
-                                    <div class="qld__card qld__card__action     ">
-            
-            
+                                <li class="col-xs-12 col-md-6 col-xs-12">
+                                    <div class="qld__card qld__card__action qld__card--dark">
                                         <div class="qld__card__inner">
                                             <div class="qld__card__content">
                                                 <div class="qld__card__content-inner">
                                                     <h3 class="qld__card__title">
-                                                            <a aria-label="Brand" aria-describedby="card-22724" class="qld__card--clickable__link" href="#">Light</a>   
+                                                        <a aria-label="Components" aria-describedby="card-22726" class="qld__card--clickable__link" href="#">Dark</a>
                                                     </h3>
-                                                    <p id="card-22724" class="qld__card__description">
-                                                        Additional text about the card
-                                                    </p>
+                                                    <p id="card-22726" class="qld__card__description">Additional text about the card</p>
                                                 </div>
                                             </div>
                                         </div>
                                     </div>
                                 </li>
-            
-                                <li class="col-xs-12 col-md-6 col-xs-12"> 
-                                    
-                                    <div class="qld__card qld__card__action  qld__card--alt ">
-            
-            
+                                <li class="col-xs-12 col-md-6 col-xs-12">
+                                    <div class="qld__card qld__card__action qld__card--dark-alt">
                                         <div class="qld__card__inner">
                                             <div class="qld__card__content">
                                                 <div class="qld__card__content-inner">
                                                     <h3 class="qld__card__title">
-                                                            <a aria-label="Content" aria-describedby="card-22725" class="qld__card--clickable__link" href="#">Alternative</a>   
+                                                        <a aria-label="Components" aria-describedby="card-22726" class="qld__card--clickable__link" href="#">Dark Alternative</a>
                                                     </h3>
-                                                    <p id="card-22725" class="qld__card__description">
-                                                        Additional text about the card
-                                                    </p>
-                                                </div>
-                                            </div>
-                                        </div>
-                                    </div>
-                                </li>
-            
-                                <li class="col-xs-12 col-md-6 col-xs-12"> 
-                                    
-                                    <div class="qld__card qld__card__action qld__card--dark ">
-            
-            
-                                        <div class="qld__card__inner">
-                                            <div class="qld__card__content">
-                                                <div class="qld__card__content-inner">
-                                                    <h3 class="qld__card__title">
-                                                            <a aria-label="Components" aria-describedby="card-22726" class="qld__card--clickable__link" href="#">Dark</a>   
-                                                    </h3>
-                                                    <p id="card-22726" class="qld__card__description">
-                                                        Additional text about the card
-                                                    </p>
-                                                </div>
-                                            </div>
-                                        </div>
-                                    </div>
-                                </li>
-                                <li class="col-xs-12 col-md-6 col-xs-12"> 
-                                    
-                                    <div class="qld__card qld__card__action qld__card--dark-alt ">
-            
-            
-                                        <div class="qld__card__inner">
-                                            <div class="qld__card__content">
-                                                <div class="qld__card__content-inner">
-                                                    <h3 class="qld__card__title">
-                                                            <a aria-label="Components" aria-describedby="card-22726" class="qld__card--clickable__link" href="#">Dark Alternative</a>   
-                                                    </h3>
-                                                    <p id="card-22726" class="qld__card__description">
-                                                        Additional text about the card
-                                                    </p>
+                                                    <p id="card-22726" class="qld__card__description">Additional text about the card</p>
                                                 </div>
                                             </div>
                                         </div>
@@ -148,106 +235,76 @@
 
                             <h2>Single Action - with footer</h2>
                             <ul class="qld__card-list qld__card-list--matchheight">
+                                <li class="col-xs-12 col-md-6 col-xs-12">
+                                    <div class="qld__card qld__card__action">
+                                        <div class="qld__card__inner">
+                                            <div class="qld__card__content">
+                                                <div class="qld__card__content-inner">
+                                                    <h3 class="qld__card__title">
+                                                        <a aria-label="Brand" aria-describedby="card-22724" class="qld__card--clickable__link" href="#">Light</a>
+                                                    </h3>
+                                                    <p id="card-22724" class="qld__card__description">Additional text about the card</p>
+                                                </div>
+                                            </div>
+                                            <div class="qld__card__footer">
+                                                <hr class="qld__horizontal-rule" />
+                                                <div class="qld__card__footer-inner">Footer text</div>
+                                            </div>
+                                        </div>
+                                    </div>
+                                </li>
 
+                                <li class="col-xs-12 col-md-6 col-xs-12">
+                                    <div class="qld__card qld__card__action qld__card--alt">
+                                        <div class="qld__card__inner">
+                                            <div class="qld__card__content">
+                                                <div class="qld__card__content-inner">
+                                                    <h3 class="qld__card__title">
+                                                        <a aria-label="Content" aria-describedby="card-22725" class="qld__card--clickable__link" href="#">Alternative</a>
+                                                    </h3>
+                                                    <p id="card-22725" class="qld__card__description">Additional text about the card</p>
+                                                </div>
+                                            </div>
+                                            <div class="qld__card__footer">
+                                                <hr class="qld__horizontal-rule" />
+                                                <div class="qld__card__footer-inner">Footer text</div>
+                                            </div>
+                                        </div>
+                                    </div>
+                                </li>
 
-                                <li class="col-xs-12 col-md-6 col-xs-12"> 
-                                    
-                                    <div class="qld__card qld__card__action     ">
-            
-            
+                                <li class="col-xs-12 col-md-6 col-xs-12">
+                                    <div class="qld__card qld__card__action qld__card--dark">
                                         <div class="qld__card__inner">
                                             <div class="qld__card__content">
                                                 <div class="qld__card__content-inner">
                                                     <h3 class="qld__card__title">
-                                                            <a aria-label="Brand" aria-describedby="card-22724" class="qld__card--clickable__link" href="#">Light</a>   
+                                                        <a aria-label="Components" aria-describedby="card-22726" class="qld__card--clickable__link" href="#">Dark</a>
                                                     </h3>
-                                                    <p id="card-22724" class="qld__card__description">
-                                                        Additional text about the card
-                                                    </p>
+                                                    <p id="card-22726" class="qld__card__description">Additional text about the card</p>
                                                 </div>
                                             </div>
                                             <div class="qld__card__footer">
-                                                <hr class="qld__horizontal-rule">
-                                                <div class="qld__card__footer-inner">
-                                                    Footer text
-                                                </div>
+                                                <hr class="qld__horizontal-rule" />
+                                                <div class="qld__card__footer-inner">Footer text</div>
                                             </div>
                                         </div>
                                     </div>
                                 </li>
-            
-                                <li class="col-xs-12 col-md-6 col-xs-12"> 
-                                    
-                                    <div class="qld__card qld__card__action  qld__card--alt ">
-            
-            
+                                <li class="col-xs-12 col-md-6 col-xs-12">
+                                    <div class="qld__card qld__card__action qld__card--dark-alt">
                                         <div class="qld__card__inner">
                                             <div class="qld__card__content">
                                                 <div class="qld__card__content-inner">
                                                     <h3 class="qld__card__title">
-                                                            <a aria-label="Content" aria-describedby="card-22725" class="qld__card--clickable__link" href="#">Alternative</a>   
+                                                        <a aria-label="Components" aria-describedby="card-22726" class="qld__card--clickable__link" href="#">Dark Alternative</a>
                                                     </h3>
-                                                    <p id="card-22725" class="qld__card__description">
-                                                        Additional text about the card
-                                                    </p>
+                                                    <p id="card-22726" class="qld__card__description">Additional text about the card</p>
                                                 </div>
                                             </div>
                                             <div class="qld__card__footer">
-                                                <hr class="qld__horizontal-rule">
-                                                <div class="qld__card__footer-inner">
-                                                    Footer text
-                                                </div>
-                                            </div>
-                                        </div>
-                                    </div>
-                                </li>
-            
-                                <li class="col-xs-12 col-md-6 col-xs-12"> 
-                                    
-                                    <div class="qld__card qld__card__action qld__card--dark ">
-            
-            
-                                        <div class="qld__card__inner">
-                                            <div class="qld__card__content">
-                                                <div class="qld__card__content-inner">
-                                                    <h3 class="qld__card__title">
-                                                            <a aria-label="Components" aria-describedby="card-22726" class="qld__card--clickable__link" href="#">Dark</a>   
-                                                    </h3>
-                                                    <p id="card-22726" class="qld__card__description">
-                                                        Additional text about the card
-                                                    </p>
-                                                </div>
-                                            </div>
-                                            <div class="qld__card__footer">
-                                                <hr class="qld__horizontal-rule">
-                                                <div class="qld__card__footer-inner">
-                                                    Footer text
-                                                </div>
-                                            </div>
-                                        </div>
-                                    </div>
-                                </li>
-                                <li class="col-xs-12 col-md-6 col-xs-12"> 
-                                    
-                                    <div class="qld__card qld__card__action qld__card--dark-alt ">
-            
-            
-                                        <div class="qld__card__inner">
-                                            <div class="qld__card__content">
-                                                <div class="qld__card__content-inner">
-                                                    <h3 class="qld__card__title">
-                                                            <a aria-label="Components" aria-describedby="card-22726" class="qld__card--clickable__link" href="#">Dark Alternative</a>   
-                                                    </h3>
-                                                    <p id="card-22726" class="qld__card__description">
-                                                        Additional text about the card
-                                                    </p>
-                                                </div>
-                                            </div>
-                                            <div class="qld__card__footer">
-                                                <hr class="qld__horizontal-rule">
-                                                <div class="qld__card__footer-inner">
-                                                    Footer text
-                                                </div>
+                                                <hr class="qld__horizontal-rule" />
+                                                <div class="qld__card__footer-inner">Footer text</div>
                                             </div>
                                         </div>
                                     </div>
@@ -256,85 +313,67 @@
 
                             <h2>Single Click - Image</h2>
                             <ul class="qld__card-list qld__card-list--matchheight">
+                                <li class="col-xs-12 col-md-6 col-xs-12">
+                                    <div class="qld__card qld__card__action qld__card--image">
+                                        <div class="qld__responsive-media-img--bg" style="background-image: url('/mysource_files/img/card--content.png')"></div>
 
+                                        <div class="qld__card__inner">
+                                            <div class="qld__card__content">
+                                                <div class="qld__card__content-inner">
+                                                    <h3 class="qld__card__title">
+                                                        <a aria-label="Brand" aria-describedby="card-22724" class="qld__card--clickable__link" href="#">Light</a>
+                                                    </h3>
+                                                    <p id="card-22724" class="qld__card__description">Additional text about the card</p>
+                                                </div>
+                                            </div>
+                                        </div>
+                                    </div>
+                                </li>
 
-                                <li class="col-xs-12 col-md-6 col-xs-12"> 
-                                    
-                                    <div class="qld__card qld__card__action   qld__card--image  ">
-            
-                                        <div class="qld__responsive-media-img--bg" style="background-image: url('/mysource_files/img/card--content.png');"></div>          
-            
+                                <li class="col-xs-12 col-md-6 col-xs-12">
+                                    <div class="qld__card qld__card__action qld__card--alt qld__card--image">
+                                        <div class="qld__responsive-media-img--bg" style="background-image: url('/mysource_files/img/card--content.png')"></div>
+
                                         <div class="qld__card__inner">
                                             <div class="qld__card__content">
                                                 <div class="qld__card__content-inner">
                                                     <h3 class="qld__card__title">
-                                                            <a aria-label="Brand" aria-describedby="card-22724" class="qld__card--clickable__link" href="#">Light</a>   
+                                                        <a aria-label="Content" aria-describedby="card-22725" class="qld__card--clickable__link" href="#">Alternative</a>
                                                     </h3>
-                                                    <p id="card-22724" class="qld__card__description">
-                                                        Additional text about the card
-                                                    </p>
+                                                    <p id="card-22725" class="qld__card__description">Additional text about the card</p>
                                                 </div>
                                             </div>
                                         </div>
                                     </div>
                                 </li>
-            
-                                <li class="col-xs-12 col-md-6 col-xs-12"> 
-                                    
-                                    <div class="qld__card qld__card__action qld__card--alt qld__card--image  ">
-            
-                                        <div class="qld__responsive-media-img--bg" style="background-image: url('/mysource_files/img/card--content.png');"></div>          
-            
+
+                                <li class="col-xs-12 col-md-6 col-xs-12">
+                                    <div class="qld__card qld__card__action qld__card--dark qld__card--image">
+                                        <div class="qld__responsive-media-img--bg" style="background-image: url('/mysource_files/img/card--content.png')"></div>
+
                                         <div class="qld__card__inner">
                                             <div class="qld__card__content">
                                                 <div class="qld__card__content-inner">
                                                     <h3 class="qld__card__title">
-                                                            <a aria-label="Content" aria-describedby="card-22725" class="qld__card--clickable__link" href="#">Alternative</a>   
+                                                        <a aria-label="Components" aria-describedby="card-22726" class="qld__card--clickable__link" href="#">Dark</a>
                                                     </h3>
-                                                    <p id="card-22725" class="qld__card__description">
-                                                        Additional text about the card
-                                                    </p>
+                                                    <p id="card-22726" class="qld__card__description">Additional text about the card</p>
                                                 </div>
                                             </div>
                                         </div>
                                     </div>
                                 </li>
-            
-                                <li class="col-xs-12 col-md-6 col-xs-12"> 
-                                    
-                                    <div class="qld__card qld__card__action qld__card--dark  qld__card--image  ">
-            
-                                        <div class="qld__responsive-media-img--bg" style="background-image: url('/mysource_files/img/card--content.png');"></div>          
-            
+                                <li class="col-xs-12 col-md-6 col-xs-12">
+                                    <div class="qld__card qld__card__action qld__card--dark-alt qld__card--image">
+                                        <div class="qld__responsive-media-img--bg" style="background-image: url('/mysource_files/img/card--content.png')"></div>
+
                                         <div class="qld__card__inner">
                                             <div class="qld__card__content">
                                                 <div class="qld__card__content-inner">
                                                     <h3 class="qld__card__title">
-                                                            <a aria-label="Components" aria-describedby="card-22726" class="qld__card--clickable__link" href="#">Dark</a>   
+                                                        <a aria-label="Components" aria-describedby="card-22726" class="qld__card--clickable__link" href="#">Dark Alternative</a>
                                                     </h3>
-                                                    <p id="card-22726" class="qld__card__description">
-                                                        Additional text about the card
-                                                    </p>
-                                                </div>
-                                            </div>
-                                        </div>
-                                    </div>
-                                </li>
-                                <li class="col-xs-12 col-md-6 col-xs-12"> 
-                                    
-                                    <div class="qld__card qld__card__action qld__card--dark-alt  qld__card--image  ">
-            
-                                        <div class="qld__responsive-media-img--bg" style="background-image: url('/mysource_files/img/card--content.png');"></div>          
-            
-                                        <div class="qld__card__inner">
-                                            <div class="qld__card__content">
-                                                <div class="qld__card__content-inner">
-                                                    <h3 class="qld__card__title">
-                                                            <a aria-label="Components" aria-describedby="card-22726" class="qld__card--clickable__link" href="#">Dark Alternative</a>   
-                                                    </h3>
-                                                    <p id="card-22726" class="qld__card__description">
-                                                        Additional text about the card
-                                                    </p>
+                                                    <p id="card-22726" class="qld__card__description">Additional text about the card</p>
                                                 </div>
                                             </div>
                                         </div>
@@ -345,172 +384,136 @@
                             <h2>Single action - Icon</h2>
 
                             <ul class="qld__card-list qld__card-list--matchheight">
+                                <li class="col-xs-12 col-md-6 col-xs-12">
+                                    <div class="qld__card qld__card__action qld__card--icon">
+                                        <div class="qld__card__icon"><i class="fal fa-question-circle" aria-hidden="true"></i></div>
 
+                                        <div class="qld__card__inner">
+                                            <div class="qld__card__content">
+                                                <div class="qld__card__content-inner">
+                                                    <h3 class="qld__card__title">
+                                                        <a aria-label="Brand" aria-describedby="card-22724" class="qld__card--clickable__link" href="#">Light</a>
+                                                    </h3>
+                                                    <p id="card-22724" class="qld__card__description">Additional text about the card</p>
+                                                </div>
+                                            </div>
+                                        </div>
+                                    </div>
+                                </li>
 
-                                <li class="col-xs-12 col-md-6 col-xs-12"> 
-                                    
-                                    <div class="qld__card qld__card__action  qld__card--icon   ">
-            
-                                            <div class="qld__card__icon"><i class="fal fa-question-circle" aria-hidden="true"></i></div>
-            
+                                <li class="col-xs-12 col-md-6 col-xs-12">
+                                    <div class="qld__card qld__card__action qld__card--alt qld__card--icon">
+                                        <div class="qld__card__icon"><i class="fal fa-stethoscope" aria-hidden="true"></i></div>
+
                                         <div class="qld__card__inner">
                                             <div class="qld__card__content">
                                                 <div class="qld__card__content-inner">
                                                     <h3 class="qld__card__title">
-                                                            <a aria-label="Brand" aria-describedby="card-22724" class="qld__card--clickable__link" href="#">Light</a>   
+                                                        <a aria-label="Content" aria-describedby="card-22725" class="qld__card--clickable__link" href="#">Alternative</a>
                                                     </h3>
-                                                    <p id="card-22724" class="qld__card__description">
-                                                        Additional text about the card
-                                                    </p>
+                                                    <p id="card-22725" class="qld__card__description">Additional text about the card</p>
                                                 </div>
                                             </div>
                                         </div>
                                     </div>
                                 </li>
-            
-                                <li class="col-xs-12 col-md-6 col-xs-12"> 
-                                    
-                                    <div class="qld__card qld__card__action qld__card--alt qld__card--icon   ">
-            
-                                            <div class="qld__card__icon"><i class="fal fa-stethoscope" aria-hidden="true"></i></div>
-            
+
+                                <li class="col-xs-12 col-md-6 col-xs-12">
+                                    <div class="qld__card qld__card__action qld__card--dark qld__card--icon">
+                                        <div class="qld__card__icon"><i class="fal fa-heart" aria-hidden="true"></i></div>
+
                                         <div class="qld__card__inner">
                                             <div class="qld__card__content">
                                                 <div class="qld__card__content-inner">
                                                     <h3 class="qld__card__title">
-                                                            <a aria-label="Content" aria-describedby="card-22725" class="qld__card--clickable__link" href="#">Alternative</a>   
+                                                        <a aria-label="Components" aria-describedby="card-22726" class="qld__card--clickable__link" href="#">Dark</a>
                                                     </h3>
-                                                    <p id="card-22725" class="qld__card__description">
-                                                        Additional text about the card
-                                                    </p>
+                                                    <p id="card-22726" class="qld__card__description">Additional text about the card</p>
                                                 </div>
                                             </div>
                                         </div>
                                     </div>
                                 </li>
-            
-                                <li class="col-xs-12 col-md-6 col-xs-12"> 
-                                    
-                                    <div class="qld__card qld__card__action qld__card--dark qld__card--icon   ">
-            
-                                            <div class="qld__card__icon"><i class="fal fa-heart" aria-hidden="true"></i></div>
-            
+                                <li class="col-xs-12 col-md-6 col-xs-12">
+                                    <div class="qld__card qld__card__action qld__card--dark-alt qld__card--icon">
+                                        <div class="qld__card__icon"><i class="fal fa-heart" aria-hidden="true"></i></div>
+
                                         <div class="qld__card__inner">
                                             <div class="qld__card__content">
                                                 <div class="qld__card__content-inner">
                                                     <h3 class="qld__card__title">
-                                                            <a aria-label="Components" aria-describedby="card-22726" class="qld__card--clickable__link" href="#">Dark</a>   
+                                                        <a aria-label="Components" aria-describedby="card-22726" class="qld__card--clickable__link" href="#">Dark Alternative</a>
                                                     </h3>
-                                                    <p id="card-22726" class="qld__card__description">
-                                                        Additional text about the card
-                                                    </p>
+                                                    <p id="card-22726" class="qld__card__description">Additional text about the card</p>
                                                 </div>
                                             </div>
                                         </div>
                                     </div>
                                 </li>
-                                <li class="col-xs-12 col-md-6 col-xs-12"> 
-                                    
-                                    <div class="qld__card qld__card__action qld__card--dark-alt  qld__card--icon   ">
-            
-                                            <div class="qld__card__icon"><i class="fal fa-heart" aria-hidden="true"></i></div>
-            
-                                        <div class="qld__card__inner">
-                                            <div class="qld__card__content">
-                                                <div class="qld__card__content-inner">
-                                                    <h3 class="qld__card__title">
-                                                            <a aria-label="Components" aria-describedby="card-22726" class="qld__card--clickable__link" href="#">Dark Alternative</a>   
-                                                    </h3>
-                                                    <p id="card-22726" class="qld__card__description">
-                                                        Additional text about the card
-                                                    </p>
-                                                </div>
-                                            </div>
-                                        </div>
-                                    </div>
-                                </li>
-                        </ul>
+                            </ul>
                             <h2>Single action - Icon left</h2>
                             <ul class="qld__card-list qld__card-list--matchheight">
+                                <li class="col-xs-12 col-md-6 col-xs-12">
+                                    <div class="qld__card qld__card__action qld__card--icon qld__card--icon-left">
+                                        <div class="qld__card__icon"><i class="fal fa-question-circle" aria-hidden="true"></i></div>
 
+                                        <div class="qld__card__inner">
+                                            <div class="qld__card__content">
+                                                <div class="qld__card__content-inner">
+                                                    <h3 class="qld__card__title">
+                                                        <a aria-label="Brand" aria-describedby="card-22724" class="qld__card--clickable__link" href="#">Light</a>
+                                                    </h3>
+                                                    <p id="card-22724" class="qld__card__description">Additional text about the card</p>
+                                                </div>
+                                            </div>
+                                        </div>
+                                    </div>
+                                </li>
 
-                                <li class="col-xs-12 col-md-6 col-xs-12"> 
-                                    
-                                    <div class="qld__card qld__card__action  qld__card--icon  qld__card--icon-left ">
-            
-                                            <div class="qld__card__icon"><i class="fal fa-question-circle" aria-hidden="true"></i></div>
-            
+                                <li class="col-xs-12 col-md-6 col-xs-12">
+                                    <div class="qld__card qld__card__action qld__card--alt qld__card--icon qld__card--icon-left">
+                                        <div class="qld__card__icon"><i class="fal fa-stethoscope" aria-hidden="true"></i></div>
+
                                         <div class="qld__card__inner">
                                             <div class="qld__card__content">
                                                 <div class="qld__card__content-inner">
                                                     <h3 class="qld__card__title">
-                                                            <a aria-label="Brand" aria-describedby="card-22724" class="qld__card--clickable__link" href="#">Light</a>   
+                                                        <a aria-label="Content" aria-describedby="card-22725" class="qld__card--clickable__link" href="#">Alternative</a>
                                                     </h3>
-                                                    <p id="card-22724" class="qld__card__description">
-                                                        Additional text about the card
-                                                    </p>
+                                                    <p id="card-22725" class="qld__card__description">Additional text about the card</p>
                                                 </div>
                                             </div>
                                         </div>
                                     </div>
                                 </li>
-            
-                                <li class="col-xs-12 col-md-6 col-xs-12"> 
-                                    
-                                    <div class="qld__card qld__card__action qld__card--alt qld__card--icon qld__card--icon-left  ">
-            
-                                            <div class="qld__card__icon"><i class="fal fa-stethoscope" aria-hidden="true"></i></div>
-            
+
+                                <li class="col-xs-12 col-md-6 col-xs-12">
+                                    <div class="qld__card qld__card__action qld__card--dark qld__card--icon qld__card--icon-left">
+                                        <div class="qld__card__icon"><i class="fal fa-heart" aria-hidden="true"></i></div>
+
                                         <div class="qld__card__inner">
                                             <div class="qld__card__content">
                                                 <div class="qld__card__content-inner">
                                                     <h3 class="qld__card__title">
-                                                            <a aria-label="Content" aria-describedby="card-22725" class="qld__card--clickable__link" href="#">Alternative</a>   
+                                                        <a aria-label="Components" aria-describedby="card-22726" class="qld__card--clickable__link" href="#">Dark</a>
                                                     </h3>
-                                                    <p id="card-22725" class="qld__card__description">
-                                                        Additional text about the card
-                                                    </p>
+                                                    <p id="card-22726" class="qld__card__description">Additional text about the card</p>
                                                 </div>
                                             </div>
                                         </div>
                                     </div>
                                 </li>
-            
-                                <li class="col-xs-12 col-md-6 col-xs-12"> 
-                                    
-                                    <div class="qld__card qld__card__action qld__card--dark qld__card--icon qld__card--icon-left  ">
-            
-                                            <div class="qld__card__icon"><i class="fal fa-heart" aria-hidden="true"></i></div>
-            
+                                <li class="col-xs-12 col-md-6 col-xs-12">
+                                    <div class="qld__card qld__card__action qld__card--dark-alt qld__card--icon qld__card--icon-left">
+                                        <div class="qld__card__icon"><i class="fal fa-heart" aria-hidden="true"></i></div>
+
                                         <div class="qld__card__inner">
                                             <div class="qld__card__content">
                                                 <div class="qld__card__content-inner">
                                                     <h3 class="qld__card__title">
-                                                            <a aria-label="Components" aria-describedby="card-22726" class="qld__card--clickable__link" href="#">Dark</a>   
+                                                        <a aria-label="Components" aria-describedby="card-22726" class="qld__card--clickable__link" href="#">Dark Alternative</a>
                                                     </h3>
-                                                    <p id="card-22726" class="qld__card__description">
-                                                        Additional text about the card
-                                                    </p>
-                                                </div>
-                                            </div>
-                                        </div>
-                                    </div>
-                                </li>
-                                <li class="col-xs-12 col-md-6 col-xs-12"> 
-                                    
-                                    <div class="qld__card qld__card__action qld__card--dark-alt  qld__card--icon qld__card--icon-left  ">
-            
-                                            <div class="qld__card__icon"><i class="fal fa-heart" aria-hidden="true"></i></div>
-            
-                                        <div class="qld__card__inner">
-                                            <div class="qld__card__content">
-                                                <div class="qld__card__content-inner">
-                                                    <h3 class="qld__card__title">
-                                                            <a aria-label="Components" aria-describedby="card-22726" class="qld__card--clickable__link" href="#">Dark Alternative</a>   
-                                                    </h3>
-                                                    <p id="card-22726" class="qld__card__description">
-                                                        Additional text about the card
-                                                    </p>
+                                                    <p id="card-22726" class="qld__card__description">Additional text about the card</p>
                                                 </div>
                                             </div>
                                         </div>
@@ -520,112 +523,82 @@
 
                             <h2>Single Action - Arrow</h2>
                             <ul class="qld__card-list qld__card-list--matchheight">
+                                <li class="col-xs-12 col-md-6 col-xs-12">
+                                    <div class="qld__card qld__card__action qld__card--arrow">
+                                        <div class="qld__card__inner">
+                                            <div class="qld__card__content">
+                                                <div class="qld__card__content-inner">
+                                                    <h3 class="qld__card__title">
+                                                        <a aria-label="Brand" aria-describedby="card-22724" class="qld__card--clickable__link" href="#">Light</a>
+                                                    </h3>
+                                                    <p id="card-22724" class="qld__card__description">Additional text about the card</p>
+                                                </div>
+                                                <svg aria-hidden="true" xmlns="http://www.w3.org/2000/svg" class="qld__card--arrow-icon qld__icon qld__icon--md"><use href="/mysource_files/img/QLD-icons.svg#arrow-right"></use></svg>
+                                            </div>
+                                        </div>
+                                    </div>
+                                </li>
 
+                                <li class="col-xs-12 col-md-6 col-xs-12">
+                                    <div class="qld__card qld__card__action qld__card--arrow qld__card--alt">
+                                        <div class="qld__card__inner">
+                                            <div class="qld__card__content">
+                                                <div class="qld__card__content-inner">
+                                                    <h3 class="qld__card__title">
+                                                        <a aria-label="Content" aria-describedby="card-22725" class="qld__card--clickable__link" href="#">Alternative</a>
+                                                    </h3>
+                                                    <p id="card-22725" class="qld__card__description">Additional text about the card</p>
+                                                </div>
+                                                <svg aria-hidden="true" xmlns="http://www.w3.org/2000/svg" class="qld__card--arrow-icon qld__icon qld__icon--md"><use href="/mysource_files/img/QLD-icons.svg#arrow-right"></use></svg>
+                                            </div>
+                                        </div>
+                                    </div>
+                                </li>
 
-                                <li class="col-xs-12 col-md-6 col-xs-12"> 
-                                    
-                                    <div class="qld__card qld__card__action qld__card--arrow    ">
-            
-            
+                                <li class="col-xs-12 col-md-6 col-xs-12">
+                                    <div class="qld__card qld__card__action qld__card--arrow qld__card--dark">
                                         <div class="qld__card__inner">
                                             <div class="qld__card__content">
                                                 <div class="qld__card__content-inner">
                                                     <h3 class="qld__card__title">
-                                                            <a aria-label="Brand" aria-describedby="card-22724" class="qld__card--clickable__link" href="#">Light</a>   
+                                                        <a aria-label="Components" aria-describedby="card-22726" class="qld__card--clickable__link" href="#">Dark</a>
                                                     </h3>
-                                                    <p id="card-22724" class="qld__card__description">
-                                                        Additional text about the card
-                                                    </p>
+                                                    <p id="card-22726" class="qld__card__description">Additional text about the card</p>
                                                 </div>
-                                                <div class="qld__card__arrow"></div>
+                                                <svg aria-hidden="true" xmlns="http://www.w3.org/2000/svg" class="qld__card--arrow-icon qld__icon qld__icon--md"><use href="/mysource_files/img/QLD-icons.svg#arrow-right"></use></svg>
                                             </div>
-                                            
                                         </div>
                                     </div>
                                 </li>
-            
-                                <li class="col-xs-12 col-md-6 col-xs-12"> 
-                                    
-                                    <div class="qld__card qld__card__action qld__card--arrow qld__card--alt   ">
-            
-            
+                                <li class="col-xs-12 col-md-6 col-xs-12">
+                                    <div class="qld__card qld__card__action qld__card--arrow qld__card--dark-alt">
                                         <div class="qld__card__inner">
                                             <div class="qld__card__content">
                                                 <div class="qld__card__content-inner">
                                                     <h3 class="qld__card__title">
-                                                            <a aria-label="Content" aria-describedby="card-22725" class="qld__card--clickable__link" href="#">Alternative</a>   
+                                                        <a aria-label="Components" aria-describedby="card-22726" class="qld__card--clickable__link" href="#">Dark Alternative</a>
                                                     </h3>
-                                                    <p id="card-22725" class="qld__card__description">
-                                                        Additional text about the card
-                                                    </p>
+                                                    <p id="card-22726" class="qld__card__description">Additional text about the card</p>
                                                 </div>
-                                                <div class="qld__card__arrow"></div>
+                                                <svg aria-hidden="true" xmlns="http://www.w3.org/2000/svg" class="qld__card--arrow-icon qld__icon qld__icon--md"><use href="/mysource_files/img/QLD-icons.svg#arrow-right"></use></svg>
                                             </div>
                                         </div>
                                     </div>
                                 </li>
-            
-                                <li class="col-xs-12 col-md-6 col-xs-12"> 
-                                    
-                                    <div class="qld__card qld__card__action qld__card--arrow qld__card--dark   ">
-            
-            
-                                        <div class="qld__card__inner">
-                                            <div class="qld__card__content">
-                                                <div class="qld__card__content-inner">
-                                                    <h3 class="qld__card__title">
-                                                            <a aria-label="Components" aria-describedby="card-22726" class="qld__card--clickable__link" href="#">Dark</a>   
-                                                    </h3>
-                                                    <p id="card-22726" class="qld__card__description">
-                                                        Additional text about the card
-                                                    </p>
-                                                </div>
-                                                <div class="qld__card__arrow"></div>
-                                            </div>
-                                        </div>
-                                    </div>
-                                </li>
-                                <li class="col-xs-12 col-md-6 col-xs-12"> 
-                                    
-                                    <div class="qld__card qld__card__action qld__card--arrow qld__card--dark-alt   ">
-            
-            
-                                        <div class="qld__card__inner">
-                                            <div class="qld__card__content">
-                                                <div class="qld__card__content-inner">
-                                                    <h3 class="qld__card__title">
-                                                            <a aria-label="Components" aria-describedby="card-22726" class="qld__card--clickable__link" href="#">Dark Alternative</a>   
-                                                    </h3>
-                                                    <p id="card-22726" class="qld__card__description">
-                                                        Additional text about the card
-                                                    </p>
-                                                </div>
-                                                <div class="qld__card__arrow"></div>
-                                            </div>
-                                        </div>
-                                    </div>
-                                </li>
-                        </ul>
+                            </ul>
                         </div>
                     </div>
                 </div>
-            </div>  
+            </div>
         </main>
         <!-- END MAIN BODY -->
 
         <!-- WIDGETS -->
-        ${require('../components/widgets/html/component.hbs')({
-            "site":require('/src/data/site.json'),
-            "current":require('/src/data/current.json')
-        })}
-        
-        <!-- FOOTER-->
-        ${require('../components/footer/html/component.hbs')({
-            "site":require('/src/data/site.json')
-        })}
+        ${require('../components/widgets/html/component.hbs')({ "site":require('/src/data/site.json'), "current":require('/src/data/current.json') })}
 
-        <div class="footer-scripts" id="footer_js" style="display: none !important;">
-            ${require('../components/_global/html/scripts.html')}
-        </div>
+        <!-- FOOTER-->
+        ${require('../components/footer/html/component.hbs')({ "site":require('/src/data/site.json') })}
+
+        <div class="footer-scripts" id="footer_js" style="display: none !important">${require('../components/_global/html/scripts.html')}</div>
     </body>
 </html>

--- a/src/html/component-card_single_action.html
+++ b/src/html/component-card_single_action.html
@@ -14,31 +14,150 @@
 
     <head>
         <title>Queensland Design System</title>
-        
+
         ${require('../components/_global/html/head.html')}
         <script>
-            var globals = {"site":{"data":{"assetid":"136","type_code":"site","version":"0.0.8","name":"Design System","short_name":"Design System","status":"2","force_secure":"0","languages":"en","charset":"utf-8","created":"2020-12-09 13:11:12","created_userid":"54","updated":"2021-01-20 15:08:30","updated_userid":"312","published":"Never","published_userid":"","status_changed":"2020-12-09 13:11:12","status_changed_userid":"54","thumbnail":"","attributes":{"name":{"attrid":"685","type":"text","value":"Design System","is_contextable":true,"use_default":true},"not_found_page_cache_globally":{"attrid":"686","type":"boolean","value":false,"is_contextable":false,"use_default":true},"available_conditions":{"attrid":"687","type":"serialise","value":[],"is_contextable":false,"use_default":true}},"metadata":{"displayInPageNav":{"value":"","fieldid":"808","type":"metadata_field_select","is_contextable":true,"default_value":true,"use_default":true},"inPageNav_heading":{"value":"On this page","fieldid":"809","type":"metadata_field_text","is_contextable":true,"default_value":true,"use_default":true},"inPageNav_headingType":{"value":"h2","fieldid":"810","type":"metadata_field_select","is_contextable":true,"default_value":true,"use_default":true},"siteTitle":{"value":"Queensland Health Design System","fieldid":"166","type":"metadata_field_text","is_contextable":true,"default_value":false,"use_default":true},"siteLogo":{"value":"169","fieldid":"127","type":"metadata_field_related_asset","is_contextable":true,"default_value":false,"use_default":true},"siteFavicon":{"value":"106","fieldid":"128","type":"metadata_field_related_asset","is_contextable":true,"default_value":false,"use_default":true},"siteAppleTouch":{"value":"106","fieldid":"129","type":"metadata_field_related_asset","is_contextable":true,"default_value":false,"use_default":true},"sitePreHeaderLogo":{"value":"170","fieldid":"171","type":"metadata_field_related_asset","is_contextable":true,"default_value":false,"use_default":true},"sitePreHeaderText":{"value":"digital.qld.gov.au","fieldid":"167","type":"metadata_field_text","is_contextable":true,"default_value":false,"use_default":true},"sitePreHeaderURL":{"value":"http://www.digital.qld.gov.au","fieldid":"168","type":"metadata_field_text","is_contextable":true,"default_value":false,"use_default":true},"showHomeIcon":{"value":"true","fieldid":"481","type":"metadata_field_select","is_contextable":true,"default_value":true,"use_default":true},"siteRepository":{"value":"164","fieldid":"213","type":"metadata_field_related_asset","is_contextable":true,"default_value":false,"use_default":true},"footerLinks":{"value":"[\"186\",\"194\",\"198\",\"458\",\"676\"]","fieldid":"715","type":"metadata_field_related_asset","is_contextable":true,"default_value":false,"use_default":true},"footerCopyrightMessage":{"value":"© The State of Queensland 2020","fieldid":"722","type":"metadata_field_text","is_contextable":true,"default_value":true,"use_default":true},"footerCopyrightLink":{"value":"206","fieldid":"723","type":"metadata_field_related_asset","is_contextable":true,"default_value":false,"use_default":true},"footerCTAHeading":{"value":"Help us improve","fieldid":"724","type":"metadata_field_text","is_contextable":true,"default_value":false,"use_default":true},"footerCTALead":{"value":"We are always looking for ways to improve our website.","fieldid":"725","type":"metadata_field_text","is_contextable":true,"default_value":false,"use_default":true},"footerCTALink":{"value":"186","fieldid":"726","type":"metadata_field_related_asset","is_contextable":true,"default_value":false,"use_default":true}}},"metadata":{"displayInPageNav":{"value":"","fieldid":"808","type":"metadata_field_select","is_contextable":true,"default_value":true,"use_default":true},"inPageNav_heading":{"value":"On this page","fieldid":"809","type":"metadata_field_text","is_contextable":true,"default_value":true,"use_default":true},"inPageNav_headingType":{"value":"h2","fieldid":"810","type":"metadata_field_select","is_contextable":true,"default_value":true,"use_default":true},"siteTitle":{"value":"Queensland Health Design System","fieldid":"166","type":"metadata_field_text","is_contextable":true,"default_value":false,"use_default":true},"siteLogo":{"value":"169","fieldid":"127","type":"metadata_field_related_asset","is_contextable":true,"default_value":false,"use_default":true},"siteFavicon":{"value":"106","fieldid":"128","type":"metadata_field_related_asset","is_contextable":true,"default_value":false,"use_default":true},"siteAppleTouch":{"value":"106","fieldid":"129","type":"metadata_field_related_asset","is_contextable":true,"default_value":false,"use_default":true},"sitePreHeaderLogo":{"value":"170","fieldid":"171","type":"metadata_field_related_asset","is_contextable":true,"default_value":false,"use_default":true},"sitePreHeaderText":{"value":"digital.qld.gov.au","fieldid":"167","type":"metadata_field_text","is_contextable":true,"default_value":false,"use_default":true},"sitePreHeaderURL":{"value":"http://www.digital.qld.gov.au","fieldid":"168","type":"metadata_field_text","is_contextable":true,"default_value":false,"use_default":true},"showHomeIcon":{"value":"true","fieldid":"481","type":"metadata_field_select","is_contextable":true,"default_value":true,"use_default":true},"siteRepository":{"value":"164","fieldid":"213","type":"metadata_field_related_asset","is_contextable":true,"default_value":false,"use_default":true},"footerLinks":{"value":"[\"186\",\"194\",\"198\",\"458\",\"676\"]","fieldid":"715","type":"metadata_field_related_asset","is_contextable":true,"default_value":false,"use_default":true},"footerCopyrightMessage":{"value":"© The State of Queensland 2020","fieldid":"722","type":"metadata_field_text","is_contextable":true,"default_value":true,"use_default":true},"footerCopyrightLink":{"value":"206","fieldid":"723","type":"metadata_field_related_asset","is_contextable":true,"default_value":false,"use_default":true},"footerCTAHeading":{"value":"Help us improve","fieldid":"724","type":"metadata_field_text","is_contextable":true,"default_value":false,"use_default":true},"footerCTALead":{"value":"We are always looking for ways to improve our website.","fieldid":"725","type":"metadata_field_text","is_contextable":true,"default_value":false,"use_default":true},"footerCTALink":{"value":"186","fieldid":"726","type":"metadata_field_related_asset","is_contextable":true,"default_value":false,"use_default":true}},"children":[{"asset_name":"Get started","asset_assetid":"186"},{"asset_name":"Brand guidelines","asset_assetid":"190"},{"asset_name":"Content guidelines","asset_assetid":"194"},{"asset_name":"Components","asset_assetid":"198"},{"asset_name":"Examples","asset_assetid":"202"},{"asset_name":"Support","asset_assetid":"206"}]},"current":{"data":{"assetid":"676","type_code":"page_standard","version":"0.0.16","name":"Links","short_name":"Links","status":"2","force_secure":"0","languages":"en","charset":"utf-8","created":"2021-01-11 11:48:22","created_userid":"312","updated":"2021-01-20 15:08:29","updated_userid":"312","published":"Never","published_userid":"","status_changed":"2021-01-11 11:48:22","status_changed_userid":"312","thumbnail":"","attributes":{"name":{"attrid":"631","type":"text","value":"Links","is_contextable":true,"use_default":true},"short_name":{"attrid":"632","type":"text","value":"Links","is_contextable":true,"use_default":true},"available_conditions":{"attrid":"633","type":"serialise","value":[],"is_contextable":false,"use_default":true},"conditions":{"attrid":"634","type":"serialise","value":[],"is_contextable":true,"use_default":true}},"metadata":{"description":{"value":"","fieldid":"132","type":"metadata_field_text","is_contextable":true,"default_value":true,"use_default":true},"pageType":{"value":"landing","fieldid":"680","type":"metadata_field_select","is_contextable":true,"default_value":false,"use_default":true},"displayBreadcrumbs":{"value":"true","fieldid":"681","type":"metadata_field_select","is_contextable":true,"default_value":true,"use_default":true},"displayBanner":{"value":"true","fieldid":"682","type":"metadata_field_select","is_contextable":true,"default_value":true,"use_default":true},"displayInPageNav":{"value":"true","fieldid":"808","type":"metadata_field_select","is_contextable":true,"default_value":true,"use_default":true},"inPageNav_heading":{"value":"On this page","fieldid":"809","type":"metadata_field_text","is_contextable":true,"default_value":true,"use_default":true},"inPageNav_headingType":{"value":"h2","fieldid":"810","type":"metadata_field_select","is_contextable":true,"default_value":true,"use_default":true}}},"home":0,"children":[{"asset_assetid":"458","asset_url":"https://qhscb.squiz.cloud/components/accordion","asset_name":"Accordion","children":[]},{"asset_assetid":"325","asset_url":"https://qhscb.squiz.cloud/components/callout","asset_name":"Callout","children":[]},{"asset_assetid":"659","asset_url":"https://qhscb.squiz.cloud/components/card-listing","asset_name":"Card Listing","children":[]},{"asset_assetid":"676","asset_url":"https://qhscb.squiz.cloud/components/links","asset_name":"Links","children":[]},{"asset_assetid":"683","asset_url":"https://qhscb.squiz.cloud/components/search-box","asset_name":"Search Box","children":[]},{"asset_assetid":"785","asset_url":"https://qhscb.squiz.cloud/components/page-alert","asset_name":"Page Alert","children":[]}],"lineage":[{"asset_assetid":"136","asset_name":"Design System","asset_url":"https://qhscb.squiz.cloud"},{"asset_assetid":"198","asset_name":"Components","asset_url":"https://qhscb.squiz.cloud/components"},{"asset_assetid":"676","asset_name":"Links","asset_url":"https://qhscb.squiz.cloud/components/links"}],"top":{"asset_assetid":"198","asset_name":"Components","asset_url":"https://qhscb.squiz.cloud/components"}}};
+            var globals = {
+                site: {
+                    data: {
+                        assetid: "136",
+                        type_code: "site",
+                        version: "0.0.8",
+                        name: "Design System",
+                        short_name: "Design System",
+                        status: "2",
+                        force_secure: "0",
+                        languages: "en",
+                        charset: "utf-8",
+                        created: "2020-12-09 13:11:12",
+                        created_userid: "54",
+                        updated: "2021-01-20 15:08:30",
+                        updated_userid: "312",
+                        published: "Never",
+                        published_userid: "",
+                        status_changed: "2020-12-09 13:11:12",
+                        status_changed_userid: "54",
+                        thumbnail: "",
+                        attributes: {
+                            name: { attrid: "685", type: "text", value: "Design System", is_contextable: true, use_default: true },
+                            not_found_page_cache_globally: { attrid: "686", type: "boolean", value: false, is_contextable: false, use_default: true },
+                            available_conditions: { attrid: "687", type: "serialise", value: [], is_contextable: false, use_default: true },
+                        },
+                        metadata: {
+                            displayInPageNav: { value: "", fieldid: "808", type: "metadata_field_select", is_contextable: true, default_value: true, use_default: true },
+                            inPageNav_heading: { value: "On this page", fieldid: "809", type: "metadata_field_text", is_contextable: true, default_value: true, use_default: true },
+                            inPageNav_headingType: { value: "h2", fieldid: "810", type: "metadata_field_select", is_contextable: true, default_value: true, use_default: true },
+                            siteTitle: { value: "Queensland Health Design System", fieldid: "166", type: "metadata_field_text", is_contextable: true, default_value: false, use_default: true },
+                            siteLogo: { value: "169", fieldid: "127", type: "metadata_field_related_asset", is_contextable: true, default_value: false, use_default: true },
+                            siteFavicon: { value: "106", fieldid: "128", type: "metadata_field_related_asset", is_contextable: true, default_value: false, use_default: true },
+                            siteAppleTouch: { value: "106", fieldid: "129", type: "metadata_field_related_asset", is_contextable: true, default_value: false, use_default: true },
+                            sitePreHeaderLogo: { value: "170", fieldid: "171", type: "metadata_field_related_asset", is_contextable: true, default_value: false, use_default: true },
+                            sitePreHeaderText: { value: "digital.qld.gov.au", fieldid: "167", type: "metadata_field_text", is_contextable: true, default_value: false, use_default: true },
+                            sitePreHeaderURL: { value: "http://www.digital.qld.gov.au", fieldid: "168", type: "metadata_field_text", is_contextable: true, default_value: false, use_default: true },
+                            showHomeIcon: { value: "true", fieldid: "481", type: "metadata_field_select", is_contextable: true, default_value: true, use_default: true },
+                            siteRepository: { value: "164", fieldid: "213", type: "metadata_field_related_asset", is_contextable: true, default_value: false, use_default: true },
+                            footerLinks: { value: '["186","194","198","458","676"]', fieldid: "715", type: "metadata_field_related_asset", is_contextable: true, default_value: false, use_default: true },
+                            footerCopyrightMessage: { value: "© The State of Queensland 2020", fieldid: "722", type: "metadata_field_text", is_contextable: true, default_value: true, use_default: true },
+                            footerCopyrightLink: { value: "206", fieldid: "723", type: "metadata_field_related_asset", is_contextable: true, default_value: false, use_default: true },
+                            footerCTAHeading: { value: "Help us improve", fieldid: "724", type: "metadata_field_text", is_contextable: true, default_value: false, use_default: true },
+                            footerCTALead: { value: "We are always looking for ways to improve our website.", fieldid: "725", type: "metadata_field_text", is_contextable: true, default_value: false, use_default: true },
+                            footerCTALink: { value: "186", fieldid: "726", type: "metadata_field_related_asset", is_contextable: true, default_value: false, use_default: true },
+                        },
+                    },
+                    metadata: {
+                        displayInPageNav: { value: "", fieldid: "808", type: "metadata_field_select", is_contextable: true, default_value: true, use_default: true },
+                        inPageNav_heading: { value: "On this page", fieldid: "809", type: "metadata_field_text", is_contextable: true, default_value: true, use_default: true },
+                        inPageNav_headingType: { value: "h2", fieldid: "810", type: "metadata_field_select", is_contextable: true, default_value: true, use_default: true },
+                        siteTitle: { value: "Queensland Health Design System", fieldid: "166", type: "metadata_field_text", is_contextable: true, default_value: false, use_default: true },
+                        siteLogo: { value: "169", fieldid: "127", type: "metadata_field_related_asset", is_contextable: true, default_value: false, use_default: true },
+                        siteFavicon: { value: "106", fieldid: "128", type: "metadata_field_related_asset", is_contextable: true, default_value: false, use_default: true },
+                        siteAppleTouch: { value: "106", fieldid: "129", type: "metadata_field_related_asset", is_contextable: true, default_value: false, use_default: true },
+                        sitePreHeaderLogo: { value: "170", fieldid: "171", type: "metadata_field_related_asset", is_contextable: true, default_value: false, use_default: true },
+                        sitePreHeaderText: { value: "digital.qld.gov.au", fieldid: "167", type: "metadata_field_text", is_contextable: true, default_value: false, use_default: true },
+                        sitePreHeaderURL: { value: "http://www.digital.qld.gov.au", fieldid: "168", type: "metadata_field_text", is_contextable: true, default_value: false, use_default: true },
+                        showHomeIcon: { value: "true", fieldid: "481", type: "metadata_field_select", is_contextable: true, default_value: true, use_default: true },
+                        siteRepository: { value: "164", fieldid: "213", type: "metadata_field_related_asset", is_contextable: true, default_value: false, use_default: true },
+                        footerLinks: { value: '["186","194","198","458","676"]', fieldid: "715", type: "metadata_field_related_asset", is_contextable: true, default_value: false, use_default: true },
+                        footerCopyrightMessage: { value: "© The State of Queensland 2020", fieldid: "722", type: "metadata_field_text", is_contextable: true, default_value: true, use_default: true },
+                        footerCopyrightLink: { value: "206", fieldid: "723", type: "metadata_field_related_asset", is_contextable: true, default_value: false, use_default: true },
+                        footerCTAHeading: { value: "Help us improve", fieldid: "724", type: "metadata_field_text", is_contextable: true, default_value: false, use_default: true },
+                        footerCTALead: { value: "We are always looking for ways to improve our website.", fieldid: "725", type: "metadata_field_text", is_contextable: true, default_value: false, use_default: true },
+                        footerCTALink: { value: "186", fieldid: "726", type: "metadata_field_related_asset", is_contextable: true, default_value: false, use_default: true },
+                    },
+                    children: [
+                        { asset_name: "Get started", asset_assetid: "186" },
+                        { asset_name: "Brand guidelines", asset_assetid: "190" },
+                        { asset_name: "Content guidelines", asset_assetid: "194" },
+                        { asset_name: "Components", asset_assetid: "198" },
+                        { asset_name: "Examples", asset_assetid: "202" },
+                        { asset_name: "Support", asset_assetid: "206" },
+                    ],
+                },
+                current: {
+                    data: {
+                        assetid: "676",
+                        type_code: "page_standard",
+                        version: "0.0.16",
+                        name: "Links",
+                        short_name: "Links",
+                        status: "2",
+                        force_secure: "0",
+                        languages: "en",
+                        charset: "utf-8",
+                        created: "2021-01-11 11:48:22",
+                        created_userid: "312",
+                        updated: "2021-01-20 15:08:29",
+                        updated_userid: "312",
+                        published: "Never",
+                        published_userid: "",
+                        status_changed: "2021-01-11 11:48:22",
+                        status_changed_userid: "312",
+                        thumbnail: "",
+                        attributes: {
+                            name: { attrid: "631", type: "text", value: "Links", is_contextable: true, use_default: true },
+                            short_name: { attrid: "632", type: "text", value: "Links", is_contextable: true, use_default: true },
+                            available_conditions: { attrid: "633", type: "serialise", value: [], is_contextable: false, use_default: true },
+                            conditions: { attrid: "634", type: "serialise", value: [], is_contextable: true, use_default: true },
+                        },
+                        metadata: {
+                            description: { value: "", fieldid: "132", type: "metadata_field_text", is_contextable: true, default_value: true, use_default: true },
+                            pageType: { value: "landing", fieldid: "680", type: "metadata_field_select", is_contextable: true, default_value: false, use_default: true },
+                            displayBreadcrumbs: { value: "true", fieldid: "681", type: "metadata_field_select", is_contextable: true, default_value: true, use_default: true },
+                            displayBanner: { value: "true", fieldid: "682", type: "metadata_field_select", is_contextable: true, default_value: true, use_default: true },
+                            displayInPageNav: { value: "true", fieldid: "808", type: "metadata_field_select", is_contextable: true, default_value: true, use_default: true },
+                            inPageNav_heading: { value: "On this page", fieldid: "809", type: "metadata_field_text", is_contextable: true, default_value: true, use_default: true },
+                            inPageNav_headingType: { value: "h2", fieldid: "810", type: "metadata_field_select", is_contextable: true, default_value: true, use_default: true },
+                        },
+                    },
+                    home: 0,
+                    children: [
+                        { asset_assetid: "458", asset_url: "https://qhscb.squiz.cloud/components/accordion", asset_name: "Accordion", children: [] },
+                        { asset_assetid: "325", asset_url: "https://qhscb.squiz.cloud/components/callout", asset_name: "Callout", children: [] },
+                        { asset_assetid: "659", asset_url: "https://qhscb.squiz.cloud/components/card-listing", asset_name: "Card Listing", children: [] },
+                        { asset_assetid: "676", asset_url: "https://qhscb.squiz.cloud/components/links", asset_name: "Links", children: [] },
+                        { asset_assetid: "683", asset_url: "https://qhscb.squiz.cloud/components/search-box", asset_name: "Search Box", children: [] },
+                        { asset_assetid: "785", asset_url: "https://qhscb.squiz.cloud/components/page-alert", asset_name: "Page Alert", children: [] },
+                    ],
+                    lineage: [
+                        { asset_assetid: "136", asset_name: "Design System", asset_url: "https://qhscb.squiz.cloud" },
+                        { asset_assetid: "198", asset_name: "Components", asset_url: "https://qhscb.squiz.cloud/components" },
+                        { asset_assetid: "676", asset_name: "Links", asset_url: "https://qhscb.squiz.cloud/components/links" },
+                    ],
+                    top: { asset_assetid: "198", asset_name: "Components", asset_url: "https://qhscb.squiz.cloud/components" },
+                },
+            };
         </script>
     </head>
 
     <body class="qld__grid">
         <!--noindex-->
-        ${require('../components/header/html/component.hbs')({
-            "site":require('/src/data/site.json')
-        })}
+        ${require('../components/header/html/component.hbs')({ "site":require('/src/data/site.json') })}
         <!--endnoindex-->
-        ${require('../components/mega_main_navigation/html/component.hbs')({
-            "site":require('/src/data/site.json')
-        })}
+        ${require('../components/mega_main_navigation/html/component.hbs')({ "site":require('/src/data/site.json') })}
         <!-- MAIN BODY -->
         <main class="main" role="main">
             <section class="qld__body qld__body--breadcrumb">
-                <div class="container-fluid">
-                    ${require('../components/breadcrumbs/html/component.hbs')({
-                        "site":require('/src/data/site.json'),
-                        "current":require('/src/data/current.json'),
-                    })}
-                </div>
+                <div class="container-fluid">${require('../components/breadcrumbs/html/component.hbs')({ "site":require('/src/data/site.json'), "current":require('/src/data/current.json'), })}</div>
             </section>
             <!--CONTENT-->
             <div class="qld__body">
@@ -46,99 +165,68 @@
                     <div class="row">
                         <div class="col-xs-12 col-lg-4 col-xl-3">
                             <!-- INTERNAL NAVIGATION -->
-                            ${require('../components/internal_navigation/html/component.hbs')({
-                                "site":require('/src/data/site.json'),
-                                "current":require('/src/data/current.json')
-                            })}
+                            ${require('../components/internal_navigation/html/component.hbs')({ "site":require('/src/data/site.json'), "current":require('/src/data/current.json') })}
                         </div>
                         <div class="col-xs-12 col-lg-8 col-xl-8" id="content">
-                            
-                            ${require('../components/_global/html/component.hbs')({
-                                "manifest":require('../components/card_single_action/js/manifest.json'),
-                                "component":require('!url-loader!../components/card_single_action/html/component.hbs'),
-                                "component_output":require('../components/card_single_action/html/component.hbs')({
-                                    "component":require('../components/card_single_action/js/manifest.json').component,
-                                    "content":"Lorem Ipsum"
-                                })
-                            })}
+                            ${require('../components/_global/html/component.hbs')({ "manifest":require('../components/card_single_action/js/manifest.json'),
+                            "component":require('!url-loader!../components/card_single_action/html/component.hbs'), "component_output":require('../components/card_single_action/html/component.hbs')({
+                            "component":require('../components/card_single_action/js/manifest.json').component, "content":"Lorem Ipsum" }) })}
 
                             <h2>Single action - base</h2>
                             <ul class="qld__card-list qld__card-list--matchheight">
+                                <li class="col-xs-12 col-md-6 col-xs-12">
+                                    <div class="qld__card qld__card__action">
+                                        <div class="qld__card__inner">
+                                            <div class="qld__card__content">
+                                                <div class="qld__card__content-inner">
+                                                    <h3 class="qld__card__title">
+                                                        <a aria-label="Brand" aria-describedby="card-22724" class="qld__card--clickable__link" href="#">Light</a>
+                                                    </h3>
+                                                    <p id="card-22724" class="qld__card__description">Additional text about the card</p>
+                                                </div>
+                                            </div>
+                                        </div>
+                                    </div>
+                                </li>
 
+                                <li class="col-xs-12 col-md-6 col-xs-12">
+                                    <div class="qld__card qld__card__action qld__card--alt">
+                                        <div class="qld__card__inner">
+                                            <div class="qld__card__content">
+                                                <div class="qld__card__content-inner">
+                                                    <h3 class="qld__card__title">
+                                                        <a aria-label="Content" aria-describedby="card-22725" class="qld__card--clickable__link" href="#">Alternative</a>
+                                                    </h3>
+                                                    <p id="card-22725" class="qld__card__description">Additional text about the card</p>
+                                                </div>
+                                            </div>
+                                        </div>
+                                    </div>
+                                </li>
 
-                                <li class="col-xs-12 col-md-6 col-xs-12"> 
-                                    
-                                    <div class="qld__card qld__card__action     ">
-            
-            
+                                <li class="col-xs-12 col-md-6 col-xs-12">
+                                    <div class="qld__card qld__card__action qld__card--dark">
                                         <div class="qld__card__inner">
                                             <div class="qld__card__content">
                                                 <div class="qld__card__content-inner">
                                                     <h3 class="qld__card__title">
-                                                            <a aria-label="Brand" aria-describedby="card-22724" class="qld__card--clickable__link" href="#">Light</a>   
+                                                        <a aria-label="Components" aria-describedby="card-22726" class="qld__card--clickable__link" href="#">Dark</a>
                                                     </h3>
-                                                    <p id="card-22724" class="qld__card__description">
-                                                        Additional text about the card
-                                                    </p>
+                                                    <p id="card-22726" class="qld__card__description">Additional text about the card</p>
                                                 </div>
                                             </div>
                                         </div>
                                     </div>
                                 </li>
-            
-                                <li class="col-xs-12 col-md-6 col-xs-12"> 
-                                    
-                                    <div class="qld__card qld__card__action  qld__card--alt ">
-            
-            
+                                <li class="col-xs-12 col-md-6 col-xs-12">
+                                    <div class="qld__card qld__card__action qld__card--dark-alt">
                                         <div class="qld__card__inner">
                                             <div class="qld__card__content">
                                                 <div class="qld__card__content-inner">
                                                     <h3 class="qld__card__title">
-                                                            <a aria-label="Content" aria-describedby="card-22725" class="qld__card--clickable__link" href="#">Alternative</a>   
+                                                        <a aria-label="Components" aria-describedby="card-22726" class="qld__card--clickable__link" href="#">Dark Alternative</a>
                                                     </h3>
-                                                    <p id="card-22725" class="qld__card__description">
-                                                        Additional text about the card
-                                                    </p>
-                                                </div>
-                                            </div>
-                                        </div>
-                                    </div>
-                                </li>
-            
-                                <li class="col-xs-12 col-md-6 col-xs-12"> 
-                                    
-                                    <div class="qld__card qld__card__action qld__card--dark ">
-            
-            
-                                        <div class="qld__card__inner">
-                                            <div class="qld__card__content">
-                                                <div class="qld__card__content-inner">
-                                                    <h3 class="qld__card__title">
-                                                            <a aria-label="Components" aria-describedby="card-22726" class="qld__card--clickable__link" href="#">Dark</a>   
-                                                    </h3>
-                                                    <p id="card-22726" class="qld__card__description">
-                                                        Additional text about the card
-                                                    </p>
-                                                </div>
-                                            </div>
-                                        </div>
-                                    </div>
-                                </li>
-                                <li class="col-xs-12 col-md-6 col-xs-12"> 
-                                    
-                                    <div class="qld__card qld__card__action qld__card--dark-alt ">
-            
-            
-                                        <div class="qld__card__inner">
-                                            <div class="qld__card__content">
-                                                <div class="qld__card__content-inner">
-                                                    <h3 class="qld__card__title">
-                                                            <a aria-label="Components" aria-describedby="card-22726" class="qld__card--clickable__link" href="#">Dark Alternative</a>   
-                                                    </h3>
-                                                    <p id="card-22726" class="qld__card__description">
-                                                        Additional text about the card
-                                                    </p>
+                                                    <p id="card-22726" class="qld__card__description">Additional text about the card</p>
                                                 </div>
                                             </div>
                                         </div>
@@ -148,106 +236,76 @@
 
                             <h2>Single Action - with footer</h2>
                             <ul class="qld__card-list qld__card-list--matchheight">
+                                <li class="col-xs-12 col-md-6 col-xs-12">
+                                    <div class="qld__card qld__card__action">
+                                        <div class="qld__card__inner">
+                                            <div class="qld__card__content">
+                                                <div class="qld__card__content-inner">
+                                                    <h3 class="qld__card__title">
+                                                        <a aria-label="Brand" aria-describedby="card-22724" class="qld__card--clickable__link" href="#">Light</a>
+                                                    </h3>
+                                                    <p id="card-22724" class="qld__card__description">Additional text about the card</p>
+                                                </div>
+                                            </div>
+                                            <div class="qld__card__footer">
+                                                <hr class="qld__horizontal-rule" />
+                                                <div class="qld__card__footer-inner">Footer text</div>
+                                            </div>
+                                        </div>
+                                    </div>
+                                </li>
 
+                                <li class="col-xs-12 col-md-6 col-xs-12">
+                                    <div class="qld__card qld__card__action qld__card--alt">
+                                        <div class="qld__card__inner">
+                                            <div class="qld__card__content">
+                                                <div class="qld__card__content-inner">
+                                                    <h3 class="qld__card__title">
+                                                        <a aria-label="Content" aria-describedby="card-22725" class="qld__card--clickable__link" href="#">Alternative</a>
+                                                    </h3>
+                                                    <p id="card-22725" class="qld__card__description">Additional text about the card</p>
+                                                </div>
+                                            </div>
+                                            <div class="qld__card__footer">
+                                                <hr class="qld__horizontal-rule" />
+                                                <div class="qld__card__footer-inner">Footer text</div>
+                                            </div>
+                                        </div>
+                                    </div>
+                                </li>
 
-                                <li class="col-xs-12 col-md-6 col-xs-12"> 
-                                    
-                                    <div class="qld__card qld__card__action     ">
-            
-            
+                                <li class="col-xs-12 col-md-6 col-xs-12">
+                                    <div class="qld__card qld__card__action qld__card--dark">
                                         <div class="qld__card__inner">
                                             <div class="qld__card__content">
                                                 <div class="qld__card__content-inner">
                                                     <h3 class="qld__card__title">
-                                                            <a aria-label="Brand" aria-describedby="card-22724" class="qld__card--clickable__link" href="#">Light</a>   
+                                                        <a aria-label="Components" aria-describedby="card-22726" class="qld__card--clickable__link" href="#">Dark</a>
                                                     </h3>
-                                                    <p id="card-22724" class="qld__card__description">
-                                                        Additional text about the card
-                                                    </p>
+                                                    <p id="card-22726" class="qld__card__description">Additional text about the card</p>
                                                 </div>
                                             </div>
                                             <div class="qld__card__footer">
-                                                <hr class="qld__horizontal-rule">
-                                                <div class="qld__card__footer-inner">
-                                                    Footer text
-                                                </div>
+                                                <hr class="qld__horizontal-rule" />
+                                                <div class="qld__card__footer-inner">Footer text</div>
                                             </div>
                                         </div>
                                     </div>
                                 </li>
-            
-                                <li class="col-xs-12 col-md-6 col-xs-12"> 
-                                    
-                                    <div class="qld__card qld__card__action  qld__card--alt ">
-            
-            
+                                <li class="col-xs-12 col-md-6 col-xs-12">
+                                    <div class="qld__card qld__card__action qld__card--dark-alt">
                                         <div class="qld__card__inner">
                                             <div class="qld__card__content">
                                                 <div class="qld__card__content-inner">
                                                     <h3 class="qld__card__title">
-                                                            <a aria-label="Content" aria-describedby="card-22725" class="qld__card--clickable__link" href="#">Alternative</a>   
+                                                        <a aria-label="Components" aria-describedby="card-22726" class="qld__card--clickable__link" href="#">Dark Alternative</a>
                                                     </h3>
-                                                    <p id="card-22725" class="qld__card__description">
-                                                        Additional text about the card
-                                                    </p>
+                                                    <p id="card-22726" class="qld__card__description">Additional text about the card</p>
                                                 </div>
                                             </div>
                                             <div class="qld__card__footer">
-                                                <hr class="qld__horizontal-rule">
-                                                <div class="qld__card__footer-inner">
-                                                    Footer text
-                                                </div>
-                                            </div>
-                                        </div>
-                                    </div>
-                                </li>
-            
-                                <li class="col-xs-12 col-md-6 col-xs-12"> 
-                                    
-                                    <div class="qld__card qld__card__action qld__card--dark ">
-            
-            
-                                        <div class="qld__card__inner">
-                                            <div class="qld__card__content">
-                                                <div class="qld__card__content-inner">
-                                                    <h3 class="qld__card__title">
-                                                            <a aria-label="Components" aria-describedby="card-22726" class="qld__card--clickable__link" href="#">Dark</a>   
-                                                    </h3>
-                                                    <p id="card-22726" class="qld__card__description">
-                                                        Additional text about the card
-                                                    </p>
-                                                </div>
-                                            </div>
-                                            <div class="qld__card__footer">
-                                                <hr class="qld__horizontal-rule">
-                                                <div class="qld__card__footer-inner">
-                                                    Footer text
-                                                </div>
-                                            </div>
-                                        </div>
-                                    </div>
-                                </li>
-                                <li class="col-xs-12 col-md-6 col-xs-12"> 
-                                    
-                                    <div class="qld__card qld__card__action qld__card--dark-alt ">
-            
-            
-                                        <div class="qld__card__inner">
-                                            <div class="qld__card__content">
-                                                <div class="qld__card__content-inner">
-                                                    <h3 class="qld__card__title">
-                                                            <a aria-label="Components" aria-describedby="card-22726" class="qld__card--clickable__link" href="#">Dark Alternative</a>   
-                                                    </h3>
-                                                    <p id="card-22726" class="qld__card__description">
-                                                        Additional text about the card
-                                                    </p>
-                                                </div>
-                                            </div>
-                                            <div class="qld__card__footer">
-                                                <hr class="qld__horizontal-rule">
-                                                <div class="qld__card__footer-inner">
-                                                    Footer text
-                                                </div>
+                                                <hr class="qld__horizontal-rule" />
+                                                <div class="qld__card__footer-inner">Footer text</div>
                                             </div>
                                         </div>
                                     </div>
@@ -256,85 +314,67 @@
 
                             <h2>Single Click - Image</h2>
                             <ul class="qld__card-list qld__card-list--matchheight">
+                                <li class="col-xs-12 col-md-6 col-xs-12">
+                                    <div class="qld__card qld__card__action qld__card--image">
+                                        <div class="qld__responsive-media-img--bg" style="background-image: url('/mysource_files/img/card--content.png')"></div>
 
+                                        <div class="qld__card__inner">
+                                            <div class="qld__card__content">
+                                                <div class="qld__card__content-inner">
+                                                    <h3 class="qld__card__title">
+                                                        <a aria-label="Brand" aria-describedby="card-22724" class="qld__card--clickable__link" href="#">Light</a>
+                                                    </h3>
+                                                    <p id="card-22724" class="qld__card__description">Additional text about the card</p>
+                                                </div>
+                                            </div>
+                                        </div>
+                                    </div>
+                                </li>
 
-                                <li class="col-xs-12 col-md-6 col-xs-12"> 
-                                    
-                                    <div class="qld__card qld__card__action   qld__card--image  ">
-            
-                                        <div class="qld__responsive-media-img--bg" style="background-image: url('/mysource_files/img/card--content.png');"></div>          
-            
+                                <li class="col-xs-12 col-md-6 col-xs-12">
+                                    <div class="qld__card qld__card__action qld__card--alt qld__card--image">
+                                        <div class="qld__responsive-media-img--bg" style="background-image: url('/mysource_files/img/card--content.png')"></div>
+
                                         <div class="qld__card__inner">
                                             <div class="qld__card__content">
                                                 <div class="qld__card__content-inner">
                                                     <h3 class="qld__card__title">
-                                                            <a aria-label="Brand" aria-describedby="card-22724" class="qld__card--clickable__link" href="#">Light</a>   
+                                                        <a aria-label="Content" aria-describedby="card-22725" class="qld__card--clickable__link" href="#">Alternative</a>
                                                     </h3>
-                                                    <p id="card-22724" class="qld__card__description">
-                                                        Additional text about the card
-                                                    </p>
+                                                    <p id="card-22725" class="qld__card__description">Additional text about the card</p>
                                                 </div>
                                             </div>
                                         </div>
                                     </div>
                                 </li>
-            
-                                <li class="col-xs-12 col-md-6 col-xs-12"> 
-                                    
-                                    <div class="qld__card qld__card__action qld__card--alt qld__card--image  ">
-            
-                                        <div class="qld__responsive-media-img--bg" style="background-image: url('/mysource_files/img/card--content.png');"></div>          
-            
+
+                                <li class="col-xs-12 col-md-6 col-xs-12">
+                                    <div class="qld__card qld__card__action qld__card--dark qld__card--image">
+                                        <div class="qld__responsive-media-img--bg" style="background-image: url('/mysource_files/img/card--content.png')"></div>
+
                                         <div class="qld__card__inner">
                                             <div class="qld__card__content">
                                                 <div class="qld__card__content-inner">
                                                     <h3 class="qld__card__title">
-                                                            <a aria-label="Content" aria-describedby="card-22725" class="qld__card--clickable__link" href="#">Alternative</a>   
+                                                        <a aria-label="Components" aria-describedby="card-22726" class="qld__card--clickable__link" href="#">Dark</a>
                                                     </h3>
-                                                    <p id="card-22725" class="qld__card__description">
-                                                        Additional text about the card
-                                                    </p>
+                                                    <p id="card-22726" class="qld__card__description">Additional text about the card</p>
                                                 </div>
                                             </div>
                                         </div>
                                     </div>
                                 </li>
-            
-                                <li class="col-xs-12 col-md-6 col-xs-12"> 
-                                    
-                                    <div class="qld__card qld__card__action qld__card--dark  qld__card--image  ">
-            
-                                        <div class="qld__responsive-media-img--bg" style="background-image: url('/mysource_files/img/card--content.png');"></div>          
-            
+                                <li class="col-xs-12 col-md-6 col-xs-12">
+                                    <div class="qld__card qld__card__action qld__card--dark-alt qld__card--image">
+                                        <div class="qld__responsive-media-img--bg" style="background-image: url('/mysource_files/img/card--content.png')"></div>
+
                                         <div class="qld__card__inner">
                                             <div class="qld__card__content">
                                                 <div class="qld__card__content-inner">
                                                     <h3 class="qld__card__title">
-                                                            <a aria-label="Components" aria-describedby="card-22726" class="qld__card--clickable__link" href="#">Dark</a>   
+                                                        <a aria-label="Components" aria-describedby="card-22726" class="qld__card--clickable__link" href="#">Dark Alternative</a>
                                                     </h3>
-                                                    <p id="card-22726" class="qld__card__description">
-                                                        Additional text about the card
-                                                    </p>
-                                                </div>
-                                            </div>
-                                        </div>
-                                    </div>
-                                </li>
-                                <li class="col-xs-12 col-md-6 col-xs-12"> 
-                                    
-                                    <div class="qld__card qld__card__action qld__card--dark-alt  qld__card--image  ">
-            
-                                        <div class="qld__responsive-media-img--bg" style="background-image: url('/mysource_files/img/card--content.png');"></div>          
-            
-                                        <div class="qld__card__inner">
-                                            <div class="qld__card__content">
-                                                <div class="qld__card__content-inner">
-                                                    <h3 class="qld__card__title">
-                                                            <a aria-label="Components" aria-describedby="card-22726" class="qld__card--clickable__link" href="#">Dark Alternative</a>   
-                                                    </h3>
-                                                    <p id="card-22726" class="qld__card__description">
-                                                        Additional text about the card
-                                                    </p>
+                                                    <p id="card-22726" class="qld__card__description">Additional text about the card</p>
                                                 </div>
                                             </div>
                                         </div>
@@ -345,172 +385,136 @@
                             <h2>Single action - Icon</h2>
 
                             <ul class="qld__card-list qld__card-list--matchheight">
+                                <li class="col-xs-12 col-md-6 col-xs-12">
+                                    <div class="qld__card qld__card__action qld__card--icon">
+                                        <div class="qld__card__icon"><i class="fal fa-question-circle" aria-hidden="true"></i></div>
 
+                                        <div class="qld__card__inner">
+                                            <div class="qld__card__content">
+                                                <div class="qld__card__content-inner">
+                                                    <h3 class="qld__card__title">
+                                                        <a aria-label="Brand" aria-describedby="card-22724" class="qld__card--clickable__link" href="#">Light</a>
+                                                    </h3>
+                                                    <p id="card-22724" class="qld__card__description">Additional text about the card</p>
+                                                </div>
+                                            </div>
+                                        </div>
+                                    </div>
+                                </li>
 
-                                <li class="col-xs-12 col-md-6 col-xs-12"> 
-                                    
-                                    <div class="qld__card qld__card__action  qld__card--icon   ">
-            
-                                            <div class="qld__card__icon"><i class="fal fa-question-circle" aria-hidden="true"></i></div>
-            
+                                <li class="col-xs-12 col-md-6 col-xs-12">
+                                    <div class="qld__card qld__card__action qld__card--alt qld__card--icon">
+                                        <div class="qld__card__icon"><i class="fal fa-stethoscope" aria-hidden="true"></i></div>
+
                                         <div class="qld__card__inner">
                                             <div class="qld__card__content">
                                                 <div class="qld__card__content-inner">
                                                     <h3 class="qld__card__title">
-                                                            <a aria-label="Brand" aria-describedby="card-22724" class="qld__card--clickable__link" href="#">Light</a>   
+                                                        <a aria-label="Content" aria-describedby="card-22725" class="qld__card--clickable__link" href="#">Alternative</a>
                                                     </h3>
-                                                    <p id="card-22724" class="qld__card__description">
-                                                        Additional text about the card
-                                                    </p>
+                                                    <p id="card-22725" class="qld__card__description">Additional text about the card</p>
                                                 </div>
                                             </div>
                                         </div>
                                     </div>
                                 </li>
-            
-                                <li class="col-xs-12 col-md-6 col-xs-12"> 
-                                    
-                                    <div class="qld__card qld__card__action qld__card--alt qld__card--icon   ">
-            
-                                            <div class="qld__card__icon"><i class="fal fa-stethoscope" aria-hidden="true"></i></div>
-            
+
+                                <li class="col-xs-12 col-md-6 col-xs-12">
+                                    <div class="qld__card qld__card__action qld__card--dark qld__card--icon">
+                                        <div class="qld__card__icon"><i class="fal fa-heart" aria-hidden="true"></i></div>
+
                                         <div class="qld__card__inner">
                                             <div class="qld__card__content">
                                                 <div class="qld__card__content-inner">
                                                     <h3 class="qld__card__title">
-                                                            <a aria-label="Content" aria-describedby="card-22725" class="qld__card--clickable__link" href="#">Alternative</a>   
+                                                        <a aria-label="Components" aria-describedby="card-22726" class="qld__card--clickable__link" href="#">Dark</a>
                                                     </h3>
-                                                    <p id="card-22725" class="qld__card__description">
-                                                        Additional text about the card
-                                                    </p>
+                                                    <p id="card-22726" class="qld__card__description">Additional text about the card</p>
                                                 </div>
                                             </div>
                                         </div>
                                     </div>
                                 </li>
-            
-                                <li class="col-xs-12 col-md-6 col-xs-12"> 
-                                    
-                                    <div class="qld__card qld__card__action qld__card--dark qld__card--icon   ">
-            
-                                            <div class="qld__card__icon"><i class="fal fa-heart" aria-hidden="true"></i></div>
-            
+                                <li class="col-xs-12 col-md-6 col-xs-12">
+                                    <div class="qld__card qld__card__action qld__card--dark-alt qld__card--icon">
+                                        <div class="qld__card__icon"><i class="fal fa-heart" aria-hidden="true"></i></div>
+
                                         <div class="qld__card__inner">
                                             <div class="qld__card__content">
                                                 <div class="qld__card__content-inner">
                                                     <h3 class="qld__card__title">
-                                                            <a aria-label="Components" aria-describedby="card-22726" class="qld__card--clickable__link" href="#">Dark</a>   
+                                                        <a aria-label="Components" aria-describedby="card-22726" class="qld__card--clickable__link" href="#">Dark Alternative</a>
                                                     </h3>
-                                                    <p id="card-22726" class="qld__card__description">
-                                                        Additional text about the card
-                                                    </p>
+                                                    <p id="card-22726" class="qld__card__description">Additional text about the card</p>
                                                 </div>
                                             </div>
                                         </div>
                                     </div>
                                 </li>
-                                <li class="col-xs-12 col-md-6 col-xs-12"> 
-                                    
-                                    <div class="qld__card qld__card__action qld__card--dark-alt  qld__card--icon   ">
-            
-                                            <div class="qld__card__icon"><i class="fal fa-heart" aria-hidden="true"></i></div>
-            
-                                        <div class="qld__card__inner">
-                                            <div class="qld__card__content">
-                                                <div class="qld__card__content-inner">
-                                                    <h3 class="qld__card__title">
-                                                            <a aria-label="Components" aria-describedby="card-22726" class="qld__card--clickable__link" href="#">Dark Alternative</a>   
-                                                    </h3>
-                                                    <p id="card-22726" class="qld__card__description">
-                                                        Additional text about the card
-                                                    </p>
-                                                </div>
-                                            </div>
-                                        </div>
-                                    </div>
-                                </li>
-                        </ul>
+                            </ul>
                             <h2>Single action - Icon left</h2>
                             <ul class="qld__card-list qld__card-list--matchheight">
+                                <li class="col-xs-12 col-md-6 col-xs-12">
+                                    <div class="qld__card qld__card__action qld__card--icon qld__card--icon-left">
+                                        <div class="qld__card__icon"><i class="fal fa-question-circle" aria-hidden="true"></i></div>
 
+                                        <div class="qld__card__inner">
+                                            <div class="qld__card__content">
+                                                <div class="qld__card__content-inner">
+                                                    <h3 class="qld__card__title">
+                                                        <a aria-label="Brand" aria-describedby="card-22724" class="qld__card--clickable__link" href="#">Light</a>
+                                                    </h3>
+                                                    <p id="card-22724" class="qld__card__description">Additional text about the card</p>
+                                                </div>
+                                            </div>
+                                        </div>
+                                    </div>
+                                </li>
 
-                                <li class="col-xs-12 col-md-6 col-xs-12"> 
-                                    
-                                    <div class="qld__card qld__card__action  qld__card--icon  qld__card--icon-left ">
-            
-                                            <div class="qld__card__icon"><i class="fal fa-question-circle" aria-hidden="true"></i></div>
-            
+                                <li class="col-xs-12 col-md-6 col-xs-12">
+                                    <div class="qld__card qld__card__action qld__card--alt qld__card--icon qld__card--icon-left">
+                                        <div class="qld__card__icon"><i class="fal fa-stethoscope" aria-hidden="true"></i></div>
+
                                         <div class="qld__card__inner">
                                             <div class="qld__card__content">
                                                 <div class="qld__card__content-inner">
                                                     <h3 class="qld__card__title">
-                                                            <a aria-label="Brand" aria-describedby="card-22724" class="qld__card--clickable__link" href="#">Light</a>   
+                                                        <a aria-label="Content" aria-describedby="card-22725" class="qld__card--clickable__link" href="#">Alternative</a>
                                                     </h3>
-                                                    <p id="card-22724" class="qld__card__description">
-                                                        Additional text about the card
-                                                    </p>
+                                                    <p id="card-22725" class="qld__card__description">Additional text about the card</p>
                                                 </div>
                                             </div>
                                         </div>
                                     </div>
                                 </li>
-            
-                                <li class="col-xs-12 col-md-6 col-xs-12"> 
-                                    
-                                    <div class="qld__card qld__card__action qld__card--alt qld__card--icon qld__card--icon-left  ">
-            
-                                            <div class="qld__card__icon"><i class="fal fa-stethoscope" aria-hidden="true"></i></div>
-            
+
+                                <li class="col-xs-12 col-md-6 col-xs-12">
+                                    <div class="qld__card qld__card__action qld__card--dark qld__card--icon qld__card--icon-left">
+                                        <div class="qld__card__icon"><i class="fal fa-heart" aria-hidden="true"></i></div>
+
                                         <div class="qld__card__inner">
                                             <div class="qld__card__content">
                                                 <div class="qld__card__content-inner">
                                                     <h3 class="qld__card__title">
-                                                            <a aria-label="Content" aria-describedby="card-22725" class="qld__card--clickable__link" href="#">Alternative</a>   
+                                                        <a aria-label="Components" aria-describedby="card-22726" class="qld__card--clickable__link" href="#">Dark</a>
                                                     </h3>
-                                                    <p id="card-22725" class="qld__card__description">
-                                                        Additional text about the card
-                                                    </p>
+                                                    <p id="card-22726" class="qld__card__description">Additional text about the card</p>
                                                 </div>
                                             </div>
                                         </div>
                                     </div>
                                 </li>
-            
-                                <li class="col-xs-12 col-md-6 col-xs-12"> 
-                                    
-                                    <div class="qld__card qld__card__action qld__card--dark qld__card--icon qld__card--icon-left  ">
-            
-                                            <div class="qld__card__icon"><i class="fal fa-heart" aria-hidden="true"></i></div>
-            
+                                <li class="col-xs-12 col-md-6 col-xs-12">
+                                    <div class="qld__card qld__card__action qld__card--dark-alt qld__card--icon qld__card--icon-left">
+                                        <div class="qld__card__icon"><i class="fal fa-heart" aria-hidden="true"></i></div>
+
                                         <div class="qld__card__inner">
                                             <div class="qld__card__content">
                                                 <div class="qld__card__content-inner">
                                                     <h3 class="qld__card__title">
-                                                            <a aria-label="Components" aria-describedby="card-22726" class="qld__card--clickable__link" href="#">Dark</a>   
+                                                        <a aria-label="Components" aria-describedby="card-22726" class="qld__card--clickable__link" href="#">Dark Alternative</a>
                                                     </h3>
-                                                    <p id="card-22726" class="qld__card__description">
-                                                        Additional text about the card
-                                                    </p>
-                                                </div>
-                                            </div>
-                                        </div>
-                                    </div>
-                                </li>
-                                <li class="col-xs-12 col-md-6 col-xs-12"> 
-                                    
-                                    <div class="qld__card qld__card__action qld__card--dark-alt  qld__card--icon qld__card--icon-left  ">
-            
-                                            <div class="qld__card__icon"><i class="fal fa-heart" aria-hidden="true"></i></div>
-            
-                                        <div class="qld__card__inner">
-                                            <div class="qld__card__content">
-                                                <div class="qld__card__content-inner">
-                                                    <h3 class="qld__card__title">
-                                                            <a aria-label="Components" aria-describedby="card-22726" class="qld__card--clickable__link" href="#">Dark Alternative</a>   
-                                                    </h3>
-                                                    <p id="card-22726" class="qld__card__description">
-                                                        Additional text about the card
-                                                    </p>
+                                                    <p id="card-22726" class="qld__card__description">Additional text about the card</p>
                                                 </div>
                                             </div>
                                         </div>
@@ -520,112 +524,82 @@
 
                             <h2>Single Action - Arrow</h2>
                             <ul class="qld__card-list qld__card-list--matchheight">
+                                <li class="col-xs-12 col-md-6 col-xs-12">
+                                    <div class="qld__card qld__card__action qld__card--arrow">
+                                        <div class="qld__card__inner">
+                                            <div class="qld__card__content">
+                                                <div class="qld__card__content-inner">
+                                                    <h3 class="qld__card__title">
+                                                        <a aria-label="Brand" aria-describedby="card-22724" class="qld__card--clickable__link" href="#">Light</a>
+                                                    </h3>
+                                                    <p id="card-22724" class="qld__card__description">Additional text about the card</p>
+                                                </div>
+                                                <svg aria-hidden="true" xmlns="http://www.w3.org/2000/svg" class="qld__card--arrow-icon qld__icon qld__icon--md"><use href="/mysource_files/img/QLD-icons.svg#arrow-right"></use></svg>
+                                            </div>
+                                        </div>
+                                    </div>
+                                </li>
 
+                                <li class="col-xs-12 col-md-6 col-xs-12">
+                                    <div class="qld__card qld__card__action qld__card--arrow qld__card--alt">
+                                        <div class="qld__card__inner">
+                                            <div class="qld__card__content">
+                                                <div class="qld__card__content-inner">
+                                                    <h3 class="qld__card__title">
+                                                        <a aria-label="Content" aria-describedby="card-22725" class="qld__card--clickable__link" href="#">Alternative</a>
+                                                    </h3>
+                                                    <p id="card-22725" class="qld__card__description">Additional text about the card</p>
+                                                </div>
+                                                <svg aria-hidden="true" xmlns="http://www.w3.org/2000/svg" class="qld__card--arrow-icon qld__icon qld__icon--md"><use href="/mysource_files/img/QLD-icons.svg#arrow-right"></use></svg>
+                                            </div>
+                                        </div>
+                                    </div>
+                                </li>
 
-                                <li class="col-xs-12 col-md-6 col-xs-12"> 
-                                    
-                                    <div class="qld__card qld__card__action qld__card--arrow    ">
-            
-            
+                                <li class="col-xs-12 col-md-6 col-xs-12">
+                                    <div class="qld__card qld__card__action qld__card--arrow qld__card--dark">
                                         <div class="qld__card__inner">
                                             <div class="qld__card__content">
                                                 <div class="qld__card__content-inner">
                                                     <h3 class="qld__card__title">
-                                                            <a aria-label="Brand" aria-describedby="card-22724" class="qld__card--clickable__link" href="#">Light</a>   
+                                                        <a aria-label="Components" aria-describedby="card-22726" class="qld__card--clickable__link" href="#">Dark</a>
                                                     </h3>
-                                                    <p id="card-22724" class="qld__card__description">
-                                                        Additional text about the card
-                                                    </p>
+                                                    <p id="card-22726" class="qld__card__description">Additional text about the card</p>
                                                 </div>
-                                                <div class="qld__card__arrow"></div>
+                                                <svg aria-hidden="true" xmlns="http://www.w3.org/2000/svg" class="qld__card--arrow-icon qld__icon qld__icon--md"><use href="/mysource_files/img/QLD-icons.svg#arrow-right"></use></svg>
                                             </div>
-                                            
                                         </div>
                                     </div>
                                 </li>
-            
-                                <li class="col-xs-12 col-md-6 col-xs-12"> 
-                                    
-                                    <div class="qld__card qld__card__action qld__card--arrow qld__card--alt   ">
-            
-            
+                                <li class="col-xs-12 col-md-6 col-xs-12">
+                                    <div class="qld__card qld__card__action qld__card--arrow qld__card--dark-alt">
                                         <div class="qld__card__inner">
                                             <div class="qld__card__content">
                                                 <div class="qld__card__content-inner">
                                                     <h3 class="qld__card__title">
-                                                            <a aria-label="Content" aria-describedby="card-22725" class="qld__card--clickable__link" href="#">Alternative</a>   
+                                                        <a aria-label="Components" aria-describedby="card-22726" class="qld__card--clickable__link" href="#">Dark Alternative</a>
                                                     </h3>
-                                                    <p id="card-22725" class="qld__card__description">
-                                                        Additional text about the card
-                                                    </p>
+                                                    <p id="card-22726" class="qld__card__description">Additional text about the card</p>
                                                 </div>
-                                                <div class="qld__card__arrow"></div>
+                                                <svg aria-hidden="true" xmlns="http://www.w3.org/2000/svg" class="qld__card--arrow-icon qld__icon qld__icon--md"><use href="/mysource_files/img/QLD-icons.svg#arrow-right"></use></svg>
                                             </div>
                                         </div>
                                     </div>
                                 </li>
-            
-                                <li class="col-xs-12 col-md-6 col-xs-12"> 
-                                    
-                                    <div class="qld__card qld__card__action qld__card--arrow qld__card--dark   ">
-            
-            
-                                        <div class="qld__card__inner">
-                                            <div class="qld__card__content">
-                                                <div class="qld__card__content-inner">
-                                                    <h3 class="qld__card__title">
-                                                            <a aria-label="Components" aria-describedby="card-22726" class="qld__card--clickable__link" href="#">Dark</a>   
-                                                    </h3>
-                                                    <p id="card-22726" class="qld__card__description">
-                                                        Additional text about the card
-                                                    </p>
-                                                </div>
-                                                <div class="qld__card__arrow"></div>
-                                            </div>
-                                        </div>
-                                    </div>
-                                </li>
-                                <li class="col-xs-12 col-md-6 col-xs-12"> 
-                                    
-                                    <div class="qld__card qld__card__action qld__card--arrow qld__card--dark-alt   ">
-            
-            
-                                        <div class="qld__card__inner">
-                                            <div class="qld__card__content">
-                                                <div class="qld__card__content-inner">
-                                                    <h3 class="qld__card__title">
-                                                            <a aria-label="Components" aria-describedby="card-22726" class="qld__card--clickable__link" href="#">Dark Alternative</a>   
-                                                    </h3>
-                                                    <p id="card-22726" class="qld__card__description">
-                                                        Additional text about the card
-                                                    </p>
-                                                </div>
-                                                <div class="qld__card__arrow"></div>
-                                            </div>
-                                        </div>
-                                    </div>
-                                </li>
-                        </ul>
+                            </ul>
                         </div>
                     </div>
                 </div>
-            </div>  
+            </div>
         </main>
         <!-- END MAIN BODY -->
 
         <!-- WIDGETS -->
-        ${require('../components/widgets/html/component.hbs')({
-            "site":require('/src/data/site.json'),
-            "current":require('/src/data/current.json')
-        })}
-        
-        <!-- FOOTER-->
-        ${require('../components/footer/html/component.hbs')({
-            "site":require('/src/data/site.json')
-        })}
+        ${require('../components/widgets/html/component.hbs')({ "site":require('/src/data/site.json'), "current":require('/src/data/current.json') })}
 
-        <div class="footer-scripts" id="footer_js" style="display: none !important;">
-            ${require('../components/_global/html/scripts.html')}
-        </div>
+        <!-- FOOTER-->
+        ${require('../components/footer/html/component.hbs')({ "site":require('/src/data/site.json') })}
+
+        <div class="footer-scripts" id="footer_js" style="display: none !important">${require('../components/_global/html/scripts.html')}</div>
     </body>
 </html>


### PR DESCRIPTION
This pull request refactors how arrow icons are rendered across several card components, replacing CSS-based masked icons with inline SVGs for improved consistency and maintainability. It also cleans up and standardizes some CSS formatting, particularly in the `page_alert` component, removing unused code and ensuring consistent use of quotes and spacing.

### Card component icon rendering

* Replaced the `.qld__card__arrow` div and CSS mask-based arrow icon with an inline SVG (`<svg>`) for the arrow in `banner_advanced`, `card_feature`, `card_multi_action`, and `card_single_action` components, improving icon consistency and maintainability.
* Updated the `.qld__card--arrow-icon` CSS class to style the inline SVG arrow, removing mask-image logic and ensuring proper hover and dark mode color transitions.

### CSS formatting and cleanup

* Standardized the use of double quotes in CSS content and mixin calls, and removed unnecessary blank lines for better readability and consistency in `card_single_action` and `page_alert` components. 
* Removed unused and redundant CSS for icon masking and print styles in the `page_alert` component, simplifying the stylesheet.