### PR TITLE
QHWT-1407 | Mega main nav | Fix colour issues with focus

### DIFF
--- a/src/components/header/css/component.scss
+++ b/src/components/header/css/component.scss
@@ -192,7 +192,7 @@
             cursor: pointer;
             align-items: center;
             color: var(--QLD-color-light__link);
-            @include QLD-focus();
+            @include QLD-focus("light", false, -3px);
             border-left: solid $QLD-border-width-thin $QLD-color-neutral--lighter;
 
             &:hover {
@@ -269,6 +269,7 @@
             }
 
             .qld__header__toggle-main-nav {
+                @include QLD-focus("dark", false, -3px);
                 color: var(--QLD-color-dark__link);
                 border-color: var(--QLD-color-dark__border);
 
@@ -319,6 +320,7 @@
             }
 
             .qld__header__toggle-main-nav {
+                @include QLD-focus("dark", false, -3px);
                 color: var(--QLD-color-dark__link);
                 border-color: var(--QLD-color-dark__border);
 

--- a/src/components/main_navigation/css/component.scss
+++ b/src/components/main_navigation/css/component.scss
@@ -483,7 +483,6 @@ $QLD-header-md: 72px;
         cursor: pointer;
         align-items: center;
         color: var(--QLD-color-light__link);
-        @include QLD-focus("light", false);
         border-left: solid $QLD-border-width-thin $QLD-color-neutral--lighter;
 
         &:hover {
@@ -577,6 +576,13 @@ $QLD-header-md: 72px;
         @include QLD-media(lg) {
             @include QLD-space(padding-bottom, 0unit);
         }
+
+        // Reset the padding on list items in mobile as there is no arrow to obscure
+        li > a {
+            @include QLD-media(lg, "down") {
+                padding-right: 0;
+            }
+        }
     }
 
     .qld__main-nav__cta-wrapper .qld__link-list {
@@ -641,6 +647,71 @@ $QLD-header-md: 72px;
 
             .qld__icon {
                 color: var(--QLD-color-dark__action--secondary);
+            }
+        }
+    }
+
+    // Focus styles
+    .qld__main-nav__menu {
+        .qld__main-nav__menu-inner {
+            .qld__main-nav__item-link {
+                @include QLD-focus("light", false, -2px);
+                border-radius: 0;
+
+                @include QLD-media(lg, "down") {
+                    @include QLD-focus("light", false, -3px);
+                }
+            }
+
+            .qld__main-nav__item-title:has(button.qld__main-nav__item-toggle) .qld__main-nav__item-link {
+                border-top-right-radius: 1rem;
+            }
+
+            .qld__main-nav__item-toggle {
+                @include QLD-focus("light", false, -2px);
+
+                @include QLD-media(lg, "down") {
+                    @include QLD-focus("light", false, 2px);
+                }
+            }
+
+            .qld__main-nav__toggle {
+                @include QLD-focus("dark", false, -3px);
+            }
+
+            .qld__main-nav__cta-wrapper {
+                .qld__main-nav__item-link {
+                    @include QLD-focus("dark", false, -3px);
+                }
+            }
+        }
+        .qld__main-nav__menu-sub-inner {
+            li > a,
+            div.qld__main-nav__sub-footer a {
+                @include QLD-media(lg, "down") {
+                    @include QLD-focus("light", false, -3px);
+                    border-radius: 0;
+                }
+            }
+        }
+    }
+
+    // Dark mode focus styles
+    &.qld__main-nav--dark,
+    &.qld__main-nav--dark--alt {
+        .qld__main-nav__menu-inner {
+            .qld__main-nav__item-link,
+            .qld__main-nav__item-toggle {
+                &:focus {
+                    outline-color: var(--QLD-color-dark__focus);
+                }
+            }
+        }
+        .qld__link-list {
+            a:focus,
+            li > a:focus,
+            div.qld__main-nav__sub-footer a:focus {
+                outline-color: var(--QLD-color-dark__focus);
             }
         }
     }

--- a/src/components/main_navigation/js/global.js
+++ b/src/components/main_navigation/js/global.js
@@ -1,17 +1,16 @@
 /**
  * The mobile nav module
- * 
+ *
  * @module mobileNav
  */
 (function () {
-
     var mobileNav = {};
     var mobileNavEvents = {};
     var mobileNavAnimating = false;
 
     /**
      * IE8 compatible function for replacing classes on a DOM node
-     * 
+     *
      * @memberof module:mobileNav
      * @instance
      * @private
@@ -22,22 +21,21 @@
      * @param  {string} closingClass - The secondClass you want to toggle on the DOM node
      */
     function toggleClasses(element, state, openingClass, closingClass) {
-        if (state === 'opening' || state === 'open') {
-            var oldClass = openingClass || 'qld__main-nav__content--closed';
-            var newClass = closingClass || 'qld__main-nav__content--open';
+        if (state === "opening" || state === "open") {
+            var oldClass = openingClass || "qld__main-nav__content--closed";
+            var newClass = closingClass || "qld__main-nav__content--open";
         } else {
-            var oldClass = closingClass || 'qld__main-nav__content--open';
-            var newClass = openingClass || 'qld__main-nav__content--closed';
+            var oldClass = closingClass || "qld__main-nav__content--open";
+            var newClass = openingClass || "qld__main-nav__content--closed";
         }
 
         removeClass(element, oldClass);
         addClass(element, newClass);
     }
 
-
     /**
      * IE8 compatible function for removing a class
-     * 
+     *
      * @memberof module:mobileNav
      * @instance
      * @private
@@ -49,14 +47,13 @@
         if (element.classList) {
             element.classList.remove(className);
         } else {
-            element.className = element.className.replace(new RegExp('(^|\\b)' + className.split(' ').join('|') + '(\\b|$)', 'gi'), ' ');
+            element.className = element.className.replace(new RegExp("(^|\\b)" + className.split(" ").join("|") + "(\\b|$)", "gi"), " ");
         }
     }
 
-
     /**
      * IE8 compatible function for adding a class
-     * 
+     *
      * @memberof module:mobileNav
      * @instance
      * @private
@@ -68,15 +65,14 @@
         if (element.classList) {
             element.classList.add(className);
         } else {
-            element.className = element.className + ' ' + className;
+            element.className = element.className + " " + className;
         }
     }
-
 
     /**
      * IE8 compatible function for adding an event
      * https://stackoverflow.com/questions/10149963/adding-event-listener-cross-browser
-     * 
+     *
      * @memberof module:mobileNav
      * @instance
      * @private
@@ -95,7 +91,7 @@
                 event.stopPropagation();
                 event.preventDefault();
             }
-            return (handler);
+            return handler;
         }
 
         // Make sure attachHandler is also going to work
@@ -105,7 +101,7 @@
                 window.event.returnValue = false;
                 window.event.cancelBubble = true;
             }
-            return (handler);
+            return handler;
         }
 
         // Return the token and add the correct listener
@@ -114,22 +110,21 @@
             return {
                 element: element,
                 handler: listenHandler,
-                event: event
+                event: event,
             };
         } else {
-            element.attachEvent('on' + event, attachHandler);
+            element.attachEvent("on" + event, attachHandler);
             return {
                 element: element,
                 handler: attachHandler,
-                event: event
+                event: event,
             };
         }
     }
 
-
     /**
      * IE8 compatible function for removing an event
-     * 
+     *
      * @memberof module:mobileNav
      * @instance
      * @private
@@ -140,14 +135,13 @@
         if (token.element.removeEventListener) {
             token.element.removeEventListener(token.event, token.handler);
         } else {
-            token.element.detachEvent('on' + token.event, token.handler);
+            token.element.detachEvent("on" + token.event, token.handler);
         }
     }
 
-
     /**
      * IE8 compatible function for getting elements style
-     * 
+     *
      * @memberof module:mobileNav
      * @instance
      * @private
@@ -156,17 +150,12 @@
      * @param  {object} property - property to return value
      */
     function getStyle(element, property) {
-        return (
-            typeof getComputedStyle !== 'undefined' ?
-            getComputedStyle(element, null) :
-            element.currentStyle
-        )[property]; // avoid getPropertyValue altogether
+        return (typeof getComputedStyle !== "undefined" ? getComputedStyle(element, null) : element.currentStyle)[property]; // avoid getPropertyValue altogether
     }
-
 
     /**
      * Toggle a mobileNav element
-     * 
+     *
      * @memberof module:mobileNav
      *
      * @param  {string}  element   - The toggle for the main nav
@@ -188,187 +177,174 @@
             event.stopPropagation();
         } catch (error) {}
 
-
         // check this once
-        if (typeof callbacks != 'object') {
+        if (typeof callbacks != "object") {
             callbacks = {};
         }
 
-
         // Elements we modify
-        var targetId = element.getAttribute('aria-controls');
+        var targetId = element.getAttribute("aria-controls");
         var target = document.getElementById(targetId);
-        var menu = target.querySelector('.qld__main-nav__menu');
-        var overlay = target.querySelector('.qld__main-nav__overlay');
-        var closeButton = target.querySelector('.qld__main-nav__toggle--close');
-        var openButton = document.querySelector('.qld__main-nav__toggle--open');
-        var focustrapTop = menu.querySelector('.qld__main-nav__focus-trap-top');
-        var focustrapBottom = menu.querySelector('.qld__main-nav__focus-trap-bottom');
+        var menu = target.querySelector(".qld__main-nav__menu");
+        var overlay = target.querySelector(".qld__main-nav__overlay");
+        var closeButton = target.querySelector(".qld__main-nav__toggle--close");
+        var openButton = document.querySelector(".qld__main-nav__toggle--open");
+        var focustrapTop = menu.querySelector(".qld__main-nav__focus-trap-top");
+        var focustrapBottom = menu.querySelector(".qld__main-nav__focus-trap-bottom");
         var menuHeading = document.querySelector(".qld__main-nav__menu-heading");
-        var focusContent = menu.querySelectorAll('a, .qld__main-nav__toggle');
-        var closed = target.className.indexOf('qld__main-nav__content--open') === -1;
-        var header = document.querySelector('.qld__header');
-        var body = document.querySelector('.main');
-        var footer = document.querySelector('.qld__footer');
+        var focusContent = menu.querySelectorAll("a, .qld__main-nav__toggle");
+        var closed = target.className.indexOf("qld__main-nav__content--open") === -1;
+        var header = document.querySelector(".qld__header");
+        var body = document.querySelector(".main");
+        var footer = document.querySelector(".qld__footer");
 
         var menuWidth = menu.offsetWidth;
-        var state = closed ? 'opening' : '';
+        var state = closed ? "opening" : "";
 
-        overlay.style.display = 'block';
-
+        overlay.style.display = "block";
 
         (function (target, speed) {
             QLD.animate.Toggle({
                 element: menu,
-                property: 'right',
+                property: "right",
                 openSize: 0,
                 closeSize: -1 * menuWidth,
                 speed: speed || 250,
                 prefunction: function () {
                     // Set these values immediately for transitions
-                    if (state === 'opening') {
-                        menu.style.display = 'block';
+                    if (state === "opening") {
+                        menu.style.display = "block";
                         overlay.style.right = 0;
                         overlay.style.opacity = 0.5;
 
                         // run when opening
-                        if (typeof callbacks.onOpen === 'function') {
+                        if (typeof callbacks.onOpen === "function") {
                             callbacks.onOpen();
                         }
                     } else {
-                        overlay.style.opacity = '0';
+                        overlay.style.opacity = "0";
 
                         // run when closing
-                        if (typeof callbacks.onClose === 'function') {
+                        if (typeof callbacks.onClose === "function") {
                             callbacks.onClose();
                         }
                     }
                 },
                 postfunction: function () {
-                    if (state === 'opening' ) {
-
+                    if (state === "opening") {
                         // Move the focus to the close button
                         menuHeading.focus();
-                        openButton.setAttribute('aria-expanded', true);
-                        closeButton.setAttribute('aria-expanded', true);
+                        openButton.setAttribute("aria-expanded", true);
+                        closeButton.setAttribute("aria-expanded", true);
 
                         // Focus trap enabled
-                        focustrapTop.setAttribute('tabindex', 0);
-                        focustrapBottom.setAttribute('tabindex', 0);
+                        focustrapTop.setAttribute("tabindex", 0);
+                        focustrapBottom.setAttribute("tabindex", 0);
 
                         // header.setAttribute('aria-hidden', true);
-                        body.setAttribute('aria-hidden', true);
-                        footer.setAttribute('aria-hidden', true);
+                        body.setAttribute("aria-hidden", true);
+                        footer.setAttribute("aria-hidden", true);
 
                         // Add event listeners
-                        mobileNavEvents.focusTop = addEvent(focustrapTop, 'focus', function () {
+                        mobileNavEvents.focusTop = addEvent(focustrapTop, "focus", function () {
                             focusContent[focusContent.length - 1].focus();
                         });
 
-                        mobileNavEvents.focusBottom = addEvent(focustrapBottom, 'focus', function () {
+                        mobileNavEvents.focusBottom = addEvent(focustrapBottom, "focus", function () {
                             focusContent[0].focus();
                         });
 
                         // Add key listener
-                        mobileNavEvents.escKey = addEvent(document, 'keyup', function () {
+                        mobileNavEvents.escKey = addEvent(document, "keyup", function () {
                             var event = event || window.event;
-                            var overlayOpen = getStyle(overlay, 'display');
+                            var overlayOpen = getStyle(overlay, "display");
 
                             // Check the menu is open and visible and the escape key is pressed
-                            if (event.keyCode === 27 && overlayOpen === 'block') {
+                            if (event.keyCode === 27 && overlayOpen === "block") {
                                 mobileNav.Toggle(element, speed, callbacks);
                             }
                         });
 
-
-                        if (typeof callbacks.afterOpen === 'function') {
+                        if (typeof callbacks.afterOpen === "function") {
                             callbacks.afterOpen();
+                        }
+
+                        // Adjust the size of the cta wrapper in mobile view
+                        const mobileMenuWidth = document.querySelector(".qld__main-nav__menu-inner").offsetWidth;
+                        let ctaWrapper = document.querySelector(".qld__main-nav__cta-wrapper");
+                        if (mobileMenuWidth && ctaWrapper) {
+                            ctaWrapper.style.width = mobileMenuWidth + "px";
                         }
                     } else {
                         // Move the focus back to the menu button
                         closeButton.focus();
-                        openButton.setAttribute('aria-expanded', false);
-                        closeButton.setAttribute('aria-expanded', false);
+                        openButton.setAttribute("aria-expanded", false);
+                        closeButton.setAttribute("aria-expanded", false);
 
                         // Remove the focus trap
-                        focustrapTop.removeAttribute('tabindex');
-                        focustrapBottom.removeAttribute('tabindex');
+                        focustrapTop.removeAttribute("tabindex");
+                        focustrapBottom.removeAttribute("tabindex");
 
-                        header.removeAttribute('aria-hidden');
-                        body.removeAttribute('aria-hidden');
-                        footer.removeAttribute('aria-hidden');
-
+                        header.removeAttribute("aria-hidden");
+                        body.removeAttribute("aria-hidden");
+                        footer.removeAttribute("aria-hidden");
 
                         // Remove the event listeners
                         removeEvent(mobileNavEvents.focusTop);
                         removeEvent(mobileNavEvents.focusBottom);
 
-
                         // Remove the event listener for the keypress
                         removeEvent(mobileNavEvents.escKey);
 
-                        if (typeof callbacks.afterClose === 'function') {
+                        if (typeof callbacks.afterClose === "function") {
                             callbacks.afterClose();
                         }
                     }
 
-
                     // Toggle classes
                     toggleClasses(target, state);
-                    toggleClasses(
-                        document.body,
-                        state,
-                        'qld__main-nav__scroll--unlocked',
-                        'qld__main-nav__scroll--locked'
-                    );
-
+                    toggleClasses(document.body, state, "qld__main-nav__scroll--unlocked", "qld__main-nav__scroll--locked");
 
                     // Reset inline styles
-                    menu.style.display = '';
-                    menu.style.right = '';
-                    overlay.style.display = '';
-                    overlay.style.right = '';
-                    overlay.style.opacity = '';
+                    menu.style.display = "";
+                    menu.style.right = "";
+                    overlay.style.display = "";
+                    overlay.style.right = "";
+                    overlay.style.opacity = "";
 
                     mobileNavAnimating = false;
                 },
             });
         })(target, speed);
-    }
+    };
 
-   
-    window.addEventListener('DOMContentLoaded', function () {
-        
+    window.addEventListener("DOMContentLoaded", function () {
         // Add toggle event to open mobile nav
         var navToggles = document.querySelectorAll('*[aria-controls="main-nav"]');
         navToggles.forEach(function (button) {
-            button.addEventListener('click', function () {
+            button.addEventListener("click", function () {
                 mobileNav.Toggle(button);
             });
         });
 
-         // Add toggle event listeners to accordion buttons
-        var itemToggles = document.querySelectorAll('.qld__main-nav__item-toggle');
-        itemToggles.forEach(function(button) {
-            button.addEventListener('click', function () {
-
-                if(button.className.split(' ').indexOf('qld__accordion--closed')>=0){
-
-                    button.parentNode.querySelector('.qld__main-nav__item-link').classList.add('qld__main-nav__item-link--open');
+        // Add toggle event listeners to accordion buttons
+        var itemToggles = document.querySelectorAll(".qld__main-nav__item-toggle");
+        itemToggles.forEach(function (button) {
+            button.addEventListener("click", function () {
+                if (button.className.split(" ").indexOf("qld__accordion--closed") >= 0) {
+                    button.parentNode.querySelector(".qld__main-nav__item-link").classList.add("qld__main-nav__item-link--open");
                     itemToggles.forEach(function (item) {
-                        if(item.className.split(' ').indexOf('qld__accordion--open')>=0){
-                            item.parentNode.querySelector('.qld__main-nav__item-link').classList.remove('qld__main-nav__item-link--open');
+                        if (item.className.split(" ").indexOf("qld__accordion--open") >= 0) {
+                            item.parentNode.querySelector(".qld__main-nav__item-link").classList.remove("qld__main-nav__item-link--open");
                             QLD.accordion.Close(item);
                         }
                     });
-                }else{
-                    button.parentNode.querySelector('.qld__main-nav__item-link').classList.remove('qld__main-nav__item-link--open');
+                } else {
+                    button.parentNode.querySelector(".qld__main-nav__item-link").classList.remove("qld__main-nav__item-link--open");
                 }
-
 
                 QLD.accordion.Toggle(button);
             });
         });
     });
-
-}());
+})();

--- a/src/components/mega_main_navigation/css/component.scss
+++ b/src/components/mega_main_navigation/css/component.scss
@@ -17,7 +17,6 @@
             border: none;
             cursor: pointer;
             @include QLD-space(border-radius, 50%);
-            @include QLD-focus("light", false);
 
             padding: 0;
             color: var(--QLD-color-light__text);
@@ -174,8 +173,6 @@
 
         a.qld__main-nav__sub-heading {
             display: none;
-
-            width: 85%;
 
             @include QLD-media(lg) {
                 display: inline-flex;
@@ -377,15 +374,16 @@
                 &.qld__main-nav__item--has-desc {
                     box-shadow: none;
                     padding: 0;
-                    .qld__main-nav__sub-item-text {
-                        @include QLD-media(lg) {
+
+                    @include QLD-media(lg) {
+                        .qld__main-nav__sub-item-text {
                             @include QLD-space(padding, 1unit 0);
                         }
-                    }
 
-                    .qld__main-nav__sub-item-text {
-                        color: var(--QLD-color-light__link);
-                        border-bottom: solid $QLD-border-width-thin $QLD-color-neutral--lighter;
+                        a {
+                            color: var(--QLD-color-light__link);
+                            border-bottom: solid $QLD-border-width-thin $QLD-color-neutral--lighter;
+                        }
                     }
 
                     &::before {
@@ -502,6 +500,7 @@
                             }
 
                             &:hover {
+                                border-color: var(--QLD-color-dark__action--primary-hover);
                                 background-color: var(--QLD-color-dark__background);
                                 border-color: var(--QLD-color-dark__action--primary-hover);
                             }
@@ -518,6 +517,10 @@
                         .qld__main-nav__sub-item-text {
                             color: var(--QLD-color-dark__link);
                         }
+
+                        &.qld__main-nav__item--has-desc a {
+                            border-bottom-color: var(--QLD-color-dark__border);
+                        }
                     }
                 }
                 .qld__main-nav__sub-footer {
@@ -528,6 +531,7 @@
                         color: var(--QLD-color-dark__link);
 
                         &:hover {
+                            border-color: var(--QLD-color-dark__action--primary-hover);
                             background-color: var(--QLD-color-dark__background);
                             border-color: var(--QLD-color-dark__action--primary-hover);
                         }

--- a/src/components/mega_main_navigation/js/global.js
+++ b/src/components/mega_main_navigation/js/global.js
@@ -1,46 +1,41 @@
 (function () {
-   
     /**
      * The mega menu module
-     * 
+     *
      * @module megaMenu
      */
     var megaMenu = {
-
         /**
          * Initialise the mega menu listeners for keyboard navigation
-         * 
+         *
          * @memberof module:megaMenu
          */
-        'init': function () {
-
+        init: function () {
             // Top level items
-            var topNavItems = document.querySelectorAll('.qld__main-nav__item-title > a');
+            var topNavItems = document.querySelectorAll(".qld__main-nav__item-title > a");
             topNavItems.forEach(function (item) {
-                item.addEventListener('keydown', handleTopNavKeydown);
-                item.addEventListener('focusin', toggleMenu);
-                item.addEventListener('focusout', handleTopNavFocusout);
+                item.addEventListener("keydown", handleTopNavKeydown);
+                item.addEventListener("focusin", toggleMenu);
+                item.addEventListener("focusout", handleTopNavFocusout);
             });
 
             // Mega menu items
-            var menuItems = document.querySelectorAll('.qld__main-nav__menu-sub a');
+            var menuItems = document.querySelectorAll(".qld__main-nav__menu-sub a");
             menuItems.forEach(function (item) {
-                item.addEventListener('keydown', handleMenuKeypress);
+                item.addEventListener("keydown", handleMenuKeypress);
             });
-        
         },
-
     };
 
     /**
      * Handle keydown on top level nav item to close the menu
      * if ESCAPE or UP key are pressed
-     * 
+     *
      * @memberof module:megaMenu
      * @instance
      * @private
-     * 
-     * @param {Document.event} e 
+     *
+     * @param {Document.event} e
      */
     function handleTopNavKeydown(e) {
         var key = e.keyCode;
@@ -54,23 +49,26 @@
     /**
      * Handle focusout of top level nav items.
      * Close the menu, unless we have tabbed within
-     * 
+     *
      * @memberof module:megaMenu
      * @instance
      * @private
-     * 
-     * @param {Document.event} e 
+     *
+     * @param {Document.event} e
      */
     function handleTopNavFocusout(e) {
         var link = e.target;
-        var navItem = link.closest('.qld__main-nav__item');
-        var expanded = navItem.classList.contains('expanded') ? true : false;
-        var menu = navItem.querySelector('.qld__main-nav__menu-sub');
-        
+        var navItem = link.closest(".qld__main-nav__item");
+        var expanded = navItem.classList.contains("expanded") ? true : false;
+        var menu = navItem.querySelector(".qld__main-nav__menu-sub");
+
         // Short delay to ensure we are on the new active element
         // Close the menu, unless we have tabbed within
-        setTimeout(function() {
-            var menuHasFocus = menu.contains(document.activeElement) ? true : false;
+        setTimeout(function () {
+            let menuHasFocus;
+            if (menu) {
+                menuHasFocus = menu.contains(document.activeElement) ? true : false;
+            }
             if (!menuHasFocus && expanded) {
                 toggleMenu(e);
             }
@@ -79,52 +77,51 @@
 
     /**
      * Toggle the mega menu open/closed
-     * 
+     *
      * @memberof module:megaMenu
      * @instance
      * @private
-     * 
-     * @param {Document.event} e 
+     *
+     * @param {Document.event} e
      */
     function toggleMenu(e) {
         var link = e.target;
-        var navItem = link.closest('.qld__main-nav__item');
-        var expanded = navItem.classList.contains('expanded') ? true : false;
+        var navItem = link.closest(".qld__main-nav__item");
+        var expanded = navItem.classList.contains("expanded") ? true : false;
 
         if (!expanded) {
-            navItem.classList.add('expanded');
-            setTimeout(function() {
-                document.addEventListener('click', handleBackgroundClick);
+            navItem.classList.add("expanded");
+            setTimeout(function () {
+                document.addEventListener("click", handleBackgroundClick);
             }, 30);
         } else {
-            navItem.classList.remove('expanded');
-            document.removeEventListener('click', handleBackgroundClick);
+            navItem.classList.remove("expanded");
+            document.removeEventListener("click", handleBackgroundClick);
         }
     }
 
     /**
      * Close the mega menu if the user clicks outside of it while opened
-     * 
+     *
      * @memberof module:megaMenu
      * @instance
      * @private
-     * 
-     * @param {Document.event} e 
+     *
+     * @param {Document.event} e
      */
     function handleBackgroundClick(e) {
         var target = e.target;
-        var nav = document.querySelector('.qld__main-nav__menu-inner');
+        var nav = document.querySelector(".qld__main-nav__menu-inner");
 
         // If clicked outside nav
         if (!nav.contains(target)) {
-
             // Close any expanded menu(s)
-            document.querySelectorAll('.qld__main-nav__item.expanded').forEach(function(item) {
-                item.classList.remove('expanded');
+            document.querySelectorAll(".qld__main-nav__item.expanded").forEach(function (item) {
+                item.classList.remove("expanded");
             });
 
             // Remove listener
-            document.removeEventListener('click', handleBackgroundClick);
+            document.removeEventListener("click", handleBackgroundClick);
         }
     }
 
@@ -133,38 +130,36 @@
      * Close the menu on press of ESCAPE or UP
      * After TAB press, check if focus is still within menu,
      * and close if it's not
-     * 
+     *
      * @memberof module:megaMenu
      * @instance
      * @private
-     * 
-     * @param {Document.event} e 
+     *
+     * @param {Document.event} e
      */
     function handleMenuKeypress(e) {
         var link = e.target;
         var key = e.keyCode;
-        var navItem = link.closest('.qld__main-nav__item');
-        var menu = link.closest('.qld__main-nav__menu-sub');
+        var navItem = link.closest(".qld__main-nav__item");
+        var menu = link.closest(".qld__main-nav__menu-sub");
 
         // ESC or UP ARROW
         if (key === 27 || key == 38) {
-            navItem.querySelector('.qld__main-nav__item-title > a').focus();
+            navItem.querySelector(".qld__main-nav__item-title > a").focus();
         }
 
         // If TAB key is pressed only (not SHIFT + TAB)
         if (key === 9 && !e.shiftKey) {
-            setTimeout(function() {
+            setTimeout(function () {
                 var menuHasFocus = menu.contains(document.activeElement) ? true : false;
                 if (!menuHasFocus) {
                     toggleMenu(e);
                 }
             }, 20);
         }
-        
     }
 
-    window.addEventListener('DOMContentLoaded', function () {
+    window.addEventListener("DOMContentLoaded", function () {
         megaMenu.init();
     });
-
-}());
+})();

--- a/src/styles/imports/mixins.scss
+++ b/src/styles/imports/mixins.scss
@@ -405,28 +405,27 @@
  *
  * @return {string}          - The code
  */
-@mixin QLD-outline($theme: "light", $rounded: true) {
+@mixin QLD-outline($theme: "light", $rounded: true, $offset: 2px) {
     @if $theme == "dark" {
         outline: 3px solid var(--QLD-color-dark__focus);
     } @else {
         outline: 3px solid var(--QLD-color-light__focus);
-
-        // Only add the offset if it's the default style
-        outline-offset: 2px;
     }
 
     // Apply radius if rounded is true
     @if $rounded {
         border-radius: $QLD-border-radius-xs;
     }
+
+    outline-offset: $offset;
 }
 
 /**
  * QLD-focus - Add the outline to focus
  */
-@mixin QLD-focus($theme: "light", $rounded: true) {
+@mixin QLD-focus($theme: "light", $rounded: true, $offset: 2px) {
     &:focus {
-        @include QLD-outline($theme, $rounded);
+        @include QLD-outline($theme, $rounded, $offset);
     }
 
     // Remove Modzilla inner HTML dotted line. github.com/necolas/normalize.css/blob/master/normalize.css#L285


### PR DESCRIPTION
This pull request focuses on improving accessibility and consistency of focus styles across navigation components, as well as refining the mobile navigation experience. The main changes include enhanced focus styling for both light and dark modes, mobile-specific style adjustments, and code clean-up and consistency improvements in the JavaScript handling navigation behavior.

### Accessibility and Focus Style Enhancements

* Added and updated `QLD-focus` mixins with explicit mode and offset parameters for header and main navigation components, ensuring consistent focus ring appearance in both light and dark themes. 
* Introduced dark mode-specific focus outline colors for navigation elements, improving accessibility for users in dark theme.

### Mobile Navigation Improvements

* Reset the right padding on navigation list items for mobile view to prevent layout issues where no arrow is present.
* Dynamically set the width of the `.qld__main-nav__cta-wrapper` to match the mobile menu width when opening the menu, ensuring proper layout on smaller screens.

### Code Consistency and Clean-up

* Standardized string quotes to double quotes throughout `global.js` for consistency and improved readability.
* Streamlined event handler return statements and removed unnecessary parentheses for clarity. 
* Minor clean-up, such as removing unused lines and improving function closures. 

### Minor Style Adjustments

* Removed redundant `QLD-focus` mixin from the mega main navigation button for a cleaner style definition.
* Removed the `QLD-focus` mixin from main navigation links in `component.scss` to align with new focus style grouping.