### PR TITLE
QHWT-1406 | Mega and main nav | Fix menu hover styling

### DIFF
--- a/src/components/main_navigation/css/component.scss
+++ b/src/components/main_navigation/css/component.scss
@@ -113,18 +113,6 @@ $QLD-header-md: 72px;
                 &--open {
                     color: var(--QLD-color-light__heading);
                 }
-
-                &.qld__main-nav__item-link--open {
-                    &:visited {
-                        color: var(--QLD-color-light__link);
-                    }
-                }
-            }
-
-            .qld__main-nav__item-link.qld__main-nav__item-link--open {
-                &:visited {
-                    color: var(--QLD-color-light__link);
-                }
             }
         }
 
@@ -172,6 +160,10 @@ $QLD-header-md: 72px;
             position: relative;
             @include QLD-fontgrid(sm, heading);
             height: 100%;
+
+            > a.qld__main-nav__item-link.qld__main-nav__item-link--open {
+                color: var(--QLD-color-light__heading);
+            }
 
             &::before {
                 content: "";
@@ -598,6 +590,9 @@ $QLD-header-md: 72px;
             background-color: var(--QLD-color-dark__background--shade);
         }
         .qld__main-nav__menu {
+            .qld__main-nav__item-title a.qld__main-nav__item-link.qld__main-nav__item-link--open {
+                color: var(--QLD-color-dark__heading);
+            }
             .qld__main-nav__item-title::before {
                 background-color: var(--QLD-color-dark__border);
             }

--- a/src/components/mega_main_navigation/css/component.scss
+++ b/src/components/mega_main_navigation/css/component.scss
@@ -323,7 +323,7 @@
 
                 &:hover {
                     border-color: var(--QLD-color-light__action--primary);
-                    background-color: $QLD-color-neutral--white;
+                    background-color: var(--QLD-color-dark__background);
 
                     @include QLD-media(lg) {
                         background-color: transparent;
@@ -499,16 +499,15 @@
 
                             &:hover {
                                 background-color: var(--QLD-color-dark__background);
+                                border-color: var(--QLD-color-dark__action--primary-hover);
                             }
                         }
 
                         &.active {
-                            a {
-                                color: var(--QLD-color-dark__heading);
-                            }
-
+                            a,
                             span {
                                 color: var(--QLD-color-dark__heading);
+                                border-color: var(--QLD-color-dark__border);
                             }
                         }
 
@@ -526,6 +525,7 @@
 
                         &:hover {
                             background-color: var(--QLD-color-dark__background);
+                            border-color: var(--QLD-color-dark__action--primary-hover);
                         }
                     }
                 }


### PR DESCRIPTION
This pull request updates the SCSS styles for both the `main_navigation` and `mega_main_navigation` components, focusing on improving visual consistency and clarity for navigation item states (such as "open", "active", and "hover") across different themes (light and dark). The changes primarily refine how navigation links and items are styled when they are active or hovered, ensuring they use the correct color variables and border styles.

**Navigation styling improvements:**

* Refined the styling for open navigation links in `main_navigation` by removing redundant selectors and consolidating color assignments, so open links now consistently use the correct heading color for both light and dark themes.
* Updated the hover state for navigation items in `mega_main_navigation` to use the dark background color instead of white, improving contrast and consistency with the dark theme.
* Enhanced the hover and active states in `mega_main_navigation` by ensuring border colors are updated to use the appropriate dark theme action and border variables, and by ensuring both anchor and span elements in active items receive the correct heading color and border styling. 