### PR TITLE
QHDEV-513 | Storybook | Funnel readme content into storybook introduction

### DIFF
--- a/src/stories/BackToTop/BackToTop.mdx
+++ b/src/stories/BackToTop/BackToTop.mdx
@@ -4,7 +4,7 @@ import { figmaLinks } from "../../../.storybook/globals";
 
 <Meta title="Components/BackToTop" of={BackToTopStories} />
 
-# BackToTop
+# Back to Top
 
 'Back to top' button provides a convenient and efficient way for users to scroll back up to the top of long pages.
 
@@ -16,9 +16,9 @@ The 'back to top' button, is a small button placed at the end of the page on the
 
 ## Design resources
 
--   <a className="figma-link" href={figmaLinks.backToTop.design} target="_blank" rel="noopener noreferrer">
-        Component design view (Figma)
-    </a>
--   <a className="figma-link" href={figmaLinks.backToTop.ds} target="_blank" rel="noopener noreferrer">
-        Design System website
-    </a>
+- <a className="figma-link" href={figmaLinks.backToTop.design} target="_blank" rel="noopener noreferrer">
+      Component design view (Figma)
+  </a>
+- <a className="figma-link" href={figmaLinks.backToTop.ds} target="_blank" rel="noopener noreferrer">
+      Design System website
+  </a>

--- a/src/stories/BackToTop/BackToTop.stories.js
+++ b/src/stories/BackToTop/BackToTop.stories.js
@@ -6,7 +6,7 @@ const backtotopArgs = {
 };
 
 export default {
-    title: "3. Components/BackToTop",
+    title: "3. Components/Back to Top",
     render: (args) => BackToTop(args), // calls the function
     argTypes: {
         text: { control: "text", description: "Back to top" },

--- a/src/stories/Introduction.mdx
+++ b/src/stories/Introduction.mdx
@@ -1,39 +1,6 @@
-import { Meta } from "@storybook/addon-docs/blocks";
+import { Meta, Markdown } from "@storybook/addon-docs/blocks";
+import README from "../../README.md?raw";
 
 <Meta title="Introduction" />
 
-# Queensland Government Design System - VanillaJS - Edition
-
-The Queensland Government design system helps teams create consistent, user-centric digital experiences quickly.
-
-## Introduction
-
-We have developed a design system for whole-of-government, to provide a consistent look and feel across Queensland Government's digital properties.
-
-It’s a solid framework that can be tailored to suit the diverse range of web sites within Queensland.
-
-The tools help designers and developers build consistent, user-focused experiences for our audiences.
-
-## Who is it for?
-
-This design system was originally developed for the Queensland Health community yet designed with a whole-of-government lens. We are now ready to share this first iteration with all of Queensland Government.
-
-You might be an individual or part of a team, looking to make improvements to your site, or establishing a new product as part of a project. The design system will help you reduce time and cost and is fully customisable.
-
-Prior to using QGDS, please liaise with Queensland Online to ensure that the placement of your page (qld.gov.au, corporate, intranet etc) complies with the Digital Services Policy.
-
-If you have already been through the recommendation process with Queensland Online and your site has been endorsed as an approved campaign or corporate site, and is outside the franchise or Forgov model, please contact us to discuss how your team could become a community consumer of the current version of QGDS.
-
-## Cloning the repository
-
-Use `git clone https://github.com/Qld-Health-Online-Team/design-system.git` to clone the repository locally.
-
-## Running and building storybook
-
-Once you have cloned the repository, follow the below steps:
-
-1. Execute `npm install` in the directory to download the required dependencies
-
-2. Execute `npm run build-storybook` to generate and build necessary files
-
-3. Execute `npm run storybook` to locally host the application
+<Markdown>{README}</Markdown>

--- a/src/stories/RadioButtons/RadioButtons.mdx
+++ b/src/stories/RadioButtons/RadioButtons.mdx
@@ -4,7 +4,7 @@ import { figmaLinks } from "../../../.storybook/globals";
 
 <Meta of={radioButtonsStories} />
 
-# RadioButtons
+# Radio Buttons
 
 ## Overview
 
@@ -34,9 +34,9 @@ Disabled control inputs can be used to indicate inputs that are no longer valid 
 
 ## Design resources
 
--   <a className="figma-link" href={figmaLinks.radioButtons.design} target="_blank" rel="noopener noreferrer">
-        Component design view (Figma)
-    </a>
--   <a className="figma-link" href={figmaLinks.radioButtons.ds} target="_blank" rel="noopener noreferrer">
-        Design System website
-    </a>
+- <a className="figma-link" href={figmaLinks.radioButtons.design} target="_blank" rel="noopener noreferrer">
+      Component design view (Figma)
+  </a>
+- <a className="figma-link" href={figmaLinks.radioButtons.ds} target="_blank" rel="noopener noreferrer">
+      Design System website
+  </a>

--- a/src/stories/SelectBox/SelectBox.stories.js
+++ b/src/stories/SelectBox/SelectBox.stories.js
@@ -25,7 +25,7 @@ const selectBoxArgs = {
 };
 
 export default {
-    title: "3. Components/SelectBox",
+    title: "3. Components/Select Box",
     render: (args) => SelectBox(args),
     argTypes: {
         id: { control: "text", description: "The id for this component" },


### PR DESCRIPTION
This pull request updates the Storybook documentation for the Queensland Government Design System. The most significant change is the simplification of the `Introduction` page by directly importing content from the project's `README.md`. Additionally, it standardizes the naming of the "Back to Top" component across documentation and story files for consistency.

Documentation improvements:

* The `Introduction.mdx` file now imports and displays the content from `README.md` using the `Markdown` component, replacing the previously hardcoded introduction and setup instructions.
