### PR TITLE
QHDEV-627 - Close mega menu accordion on 'ESC' and 'UP' keypresses.

### DIFF
--- a/src/components/mega_main_navigation/js/global.js
+++ b/src/components/mega_main_navigation/js/global.js
@@ -142,10 +142,15 @@
         var key = e.keyCode;
         var navItem = link.closest(".qld__main-nav__item");
         var menu = link.closest(".qld__main-nav__menu-sub");
+        var button = navItem.querySelector(".qld__main-nav__item-title > button")
+        var anchor = navItem.querySelector(".qld__main-nav__item-title > a")
+        var focusTarget = anchor.offsetParent !== null ? anchor : button;
 
         // ESC or UP ARROW
         if (key === 27 || key == 38) {
-            navItem.querySelector(".qld__main-nav__item-title > a").focus();
+            focusTarget.focus();
+            toggleMenu(e);
+            QLD.accordion.Toggle(button);
         }
 
         // If TAB key is pressed only (not SHIFT + TAB)
@@ -154,6 +159,7 @@
                 var menuHasFocus = menu.contains(document.activeElement) ? true : false;
                 if (!menuHasFocus) {
                     toggleMenu(e);
+                    QLD.accordion.Toggle(button)
                 }
             }, 20);
         }

--- a/src/components/mega_main_navigation/js/global.js
+++ b/src/components/mega_main_navigation/js/global.js
@@ -12,12 +12,16 @@
          */
         init: function () {
             // Top level items
-            var topNavItems = document.querySelectorAll(".qld__main-nav__item-title > a");
+            var topNavItems = document.querySelectorAll(".qld__main-nav__item");
             topNavItems.forEach(function (item) {
-                item.addEventListener("keydown", handleTopNavKeydown);
-                item.addEventListener("focusin", toggleMenu);
-                item.addEventListener("focusout", handleTopNavFocusout);
-            });
+                var toggleBtn = item.querySelector(".qld__main-nav__item-title > button")
+                var anchor = item.querySelector(".qld__main-nav__item-title > a")
+                var el = anchor.offsetParent !== null ? anchor : toggleBtn;
+                if (!el) return;
+                el.addEventListener("keydown", handleTopNavKeydown);
+                el.addEventListener("focusin", toggleMenu);
+                el.addEventListener("focusout", handleTopNavFocusout);
+            })
 
             // Mega menu items
             var menuItems = document.querySelectorAll(".qld__main-nav__menu-sub a");
@@ -43,6 +47,7 @@
         // ESC or UP ARROW
         if (key === 27 || key == 38) {
             toggleMenu(e);
+            QLD.accordion.Toggle(e.target)
         }
     }
 


### PR DESCRIPTION
## Summary

Fixes/ improves keyboard accessibility on the mega main navigation component by closing the open accordion panel when focus leaves it via ESC, UP arrow, or TAB-out.


## Changes
  
`src/components/mega_main_navigation/js/global.js` — `handleMenuKeypress`:

- Resolves the focus target dynamically. The toggle is a `<button>` on
    desktop and an `<a>` on mobile (the other is hidden via `--desktop-hide`).
    Uses `offsetParent !== null` to pick whichever element is currently
    rendered, so focus always lands somewhere the user can see.
- On **ESC** / **UP**: focuses the resolved target and calls `QLD.accordion.Toggle(button)`
    so the panel animates closed and `aria-expanded` flips to `false`.
- On **TAB** out of the panel: same close treatment via
    `QLD.accordion.Toggle(button)`, so focus naturally moving past the last
    link in the panel closes it (consistent with the existing focusout
    behaviour on the top-level link).

## Accessibility notes
  
  - ESC-to-close is required for any disclosure widget (W3C APG).
  - UP-to-close is preserved for parity with the existing documented
    behaviour, but it's worth flagging in a follow-up: the
    [APG Disclosure pattern](https://www.w3.org/WAI/ARIA/apg/patterns/disclosure/examples/disclosure-navigation/)
    doesn't define arrow-key handling for this widget, and UP-to-close can
    interfere with browser scrolling for keyboard-only users.
  - Focus return target now adapts to viewport, so SR/keyboard users on
    mobile aren't focused onto a `display: none` element.

 
