### PR TITLE
Create storybook stories for table

### DIFF
--- a/.storybook/preview.js
+++ b/.storybook/preview.js
@@ -97,7 +97,7 @@ const preview = {
                 return storyFn();
             }
             // Get the theme key from the background, to use within the decorator
-            const themeKey = Object.keys(themeColours).find((key) => themeColours[key] === context.globals.backgrounds?.value);
+            const themeKey = Object.keys(themeColours).find((key) => key === context.globals.backgrounds?.value);
             const wrapper = document.createElement("div");
             wrapper.className = themes[themeKey] || themes["white"];
             const story = storyFn();

--- a/src/stories/Table/table.mdx
+++ b/src/stories/Table/table.mdx
@@ -1,0 +1,74 @@
+import { Canvas, Meta, Controls, Story } from "@storybook/addon-docs/blocks";
+import * as TableStories from "./table.stories";
+
+<Meta of={TableStories} />
+
+# Table
+
+Tables are available in light and dark styles. They can be borderless or contained and can have the option for vertical
+and horizontal scrolling.
+
+## Borderless
+
+When seeking to integrate and expand the information that accompanies a text, a borderless table can prove advantageous.
+It imparts a sense of continuity and cohesion, making the data feel more seamlessly integrated with the surrounding text.
+
+<Canvas of={TableStories.Borderless} />
+
+### Props
+
+<Controls of={TableStories.Borderless} />
+
+## Contained
+
+A contained table style features visible borders around the table, its rows, and columns, creating a clear and
+well-defined structure. The borders help separate data and improve readability by emphasising individual cells.
+
+
+<Canvas of={TableStories.Contained} />
+
+## Vertical Scrolling
+
+A scrollable table is ideal for dense data. Tables that are extremely long can have vertical scroll turned on via the
+vertical scroll class. On desktop these tables will scroll vertically after 1000px and on mobile they will scroll
+ vertically after 640px.
+
+<Canvas of={TableStories.VerticalScrolling} />
+
+## Custom Widths
+
+You can apply custom widths based on the expected length of the data within a corresponding column by applying a utility
+class to the `<th>` elements.
+
+By default tables are fluid and scale to the full width of the page, however a table can set to a desired width using
+the [grid](https://www.designsystem.qld.gov.au/styles/layout-foundations) system and then use the `qld__table__wrapper` which will turn on horizontal scrolling on smaller devices.
+
+```html
+15% col width: <th class="qld__table__header--width-15">
+20% col width: <th class="qld__table__header--width-20">
+25% col width: <th class="qld__table__header--width-25">
+33% col width: <th class="qld__table__header--width-33">
+40% col width: <th class="qld__table__header--width-40">
+50% col width: <th class="qld__table__header--width-50">
+75% col width: <th class="qld__table__header--width-75">
+```
+
+<Canvas of={TableStories.CustomWidths} />
+
+## Striped / Banded
+
+For data tables with more rows, use the striped alternative. Styling even and odd rows in a different way can be
+helpful to people who have reading difficulties or who enlarge text. It acts as a visual guide. Highlighting the cell
+(and row/column) on mouseover and keyboard focus to support people to see where they are.
+
+<Canvas of={TableStories.Striped} />
+
+## Multilevel Headings
+
+Tables with multiple headers may also need to have a caption to identify them and a summary to describe the layout of
+the table, see [Caption & Summary](https://www.w3.org/WAI/tutorials/tables/caption-summary). In many cases, it is worth
+considering restructuring the information in such tables
+to make them less complex for all readers.
+
+<Canvas of={TableStories.MultilevelHeadings} />
+

--- a/src/stories/Table/table.stories.js
+++ b/src/stories/Table/table.stories.js
@@ -1,0 +1,115 @@
+const indent = (str, n) => str.replace(/^/gm, " ".repeat(n));
+
+const Feat = {
+    contained: "Contained",
+    scrollable: "Scrollable",
+    customWidths: "Custom Widths",
+    striped: "Striped",
+    multilevelHeadings: "Multilevel Headings"
+}
+
+function render({features = [], numRows}) {
+    const isContained = features.includes(Feat.contained)
+    const isScrollable = features.includes(Feat.scrollable)
+    const hasCustomWidths = features.includes(Feat.customWidths)
+    const isStriped = features.includes(Feat.striped)
+    const hasMultilevelHeadings = features.includes(Feat.multilevelHeadings)
+
+    const headings = hasMultilevelHeadings
+        ? `<tr>
+  <th rowspan="2" scope="col">Header</th>
+  <th colspan="2" class="qld__table__cell-left-border qld__table__cell--middle">Header</th>
+</tr>
+<tr>
+  <th scope="col" class="qld__table__cell-left-border ${hasCustomWidths ? "qld__table__header--width-10" : ""}">Header</th>
+  <th scope="col" class="qld__table__cell-left-border">Header</th>
+</tr>`
+        : `<tr>
+  <th scope="col">Header</th>
+  <th scope="col" class="${hasCustomWidths ? "qld__table__header--width-10" : ""}">Header</th>
+  <th scope="col">Header</th>
+</tr>`
+
+    const rows = Array.from({length: numRows}).map(() => `<tr>
+  <td>Cell</td>
+  <td>Cell</td>
+  <td>Cell</td>
+</tr>`).join("\n")
+
+    const tableClasses = [
+        "qld__table",
+        "qld__align-middle",
+        isStriped && "qld__table--striped",
+        hasMultilevelHeadings && "qld__table__col-2-left-border qld__table__col-3-left-border",
+    ].filter(Boolean).join(" ")
+
+    const table = `<table class="${tableClasses}">
+  <caption>Table caption
+    <span class="qld__caption">Table is ordered by</span>
+  </caption>
+  <thead>
+${indent(headings, 4)}
+  </thead>
+  <tbody>
+${indent(rows, 4)}
+  </tbody>
+  <tfoot>
+    <tr>
+      <td>Footer</td>
+      <td>Footer</td>
+      <td>Footer</td>
+    </tr>
+  </tfoot>
+</table>`
+
+    if (isContained || isScrollable) {
+        const wrapperClasses = [
+            "qld__table__wrapper",
+            isContained && "qld__table--contained",
+            isScrollable && "qld__table--scroll",
+        ].filter(Boolean).join(" ")
+
+        return `<div class="${wrapperClasses}">
+${indent(table, 2)}
+</div>`
+    }
+    return table
+}
+
+const meta = {
+    title: "3. Components/Table",
+    render,
+    argTypes: {
+        numRows: {
+            control: {
+                type: "number",
+                min: 0,
+                max: 50,
+            }
+        },
+        features: {
+            description: "Toggle styling features to apply to the table.",
+            options: Object.values(Feat),
+            control: {
+                type: 'check',
+            }
+        },
+    },
+    args: {
+        numRows: 5
+    },
+};
+export default meta;
+
+export const Borderless = {};
+
+export const Contained = {args: {features: [Feat.contained]}}
+
+export const VerticalScrolling = {args: {numRows: 20, features: [Feat.scrollable]}}
+
+export const CustomWidths = {args: {features: [Feat.customWidths]}}
+
+export const Striped = {args: {features: [Feat.striped]}}
+
+export const MultilevelHeadings = {args: {features: [Feat.multilevelHeadings]}}
+


### PR DESCRIPTION
Duplicates the Table component design guide here: https://www.designsystem.qld.gov.au/components/table 

Background colours are applied using storybook toolbar in the header. This does mean the code snippets visible in the docs for the Table component won't show the background colour wrapper like it does in the designsystem website. I'm not sure of the best way to include it in the code snippet without adding extra complexity to the table stories.