### PR TITLE
Review existing storybook files

### DIFF
--- a/src/stories/BackToTop/BackToTop.js
+++ b/src/stories/BackToTop/BackToTop.js
@@ -1,8 +1,0 @@
-export const BackToTop = ({ text = "Back to top" }) => {
-    const container = document.createElement("div");
-    container.className = "qld__widgets__back_to_top";
-    container.innerHTML = `<a href="#content" class="qld__direction-link qld__direction-link--up" aria-label="Back to top">
-      ${text}
-    </a>`;
-    return container;
-};

--- a/src/stories/BackToTop/BackToTop.stories.js
+++ b/src/stories/BackToTop/BackToTop.stories.js
@@ -1,18 +1,16 @@
-import { BackToTop } from "./BackToTop";
-import { figmaLinks } from "../../../.storybook/globals";
-
-const backtotopArgs = {
-    text: "Back to top",
-};
+import {figmaLinks} from "../../../.storybook/globals";
 
 export default {
     title: "3. Components/Back to Top",
-    render: (args) => BackToTop(args), // calls the function
-    argTypes: {
-        text: { control: "text", description: "Back to top" },
-    },
+    render: ({text}) => `
+          <div class="qld__widgets__back_to_top">
+              <a href="#content" class="qld__direction-link qld__direction-link--up" aria-label="Back to top">
+                  ${text}
+              </a>
+          </div>
+      `,
     args: {
-        ...backtotopArgs,
+        text: "Back to top",
     },
     parameters: {
         design: {
@@ -22,7 +20,4 @@ export default {
     },
 };
 
-// Named story
-export const Default = {
-    args: { ...backtotopArgs },
-};
+export const Default = {};

--- a/src/stories/Breadcrumbs/Breadcrumbs.stories.js
+++ b/src/stories/Breadcrumbs/Breadcrumbs.stories.js
@@ -1,53 +1,53 @@
-import Handlebars from "handlebars";
-import Template from "../../components/breadcrumbs/html/component.hbs?raw";
-import { figmaLinks, themes } from "../../../.storybook/globals";
-import { themeWrapper } from "../../../.storybook/helper-functions.js";
+import Template from "../../components/breadcrumbs/html/component.hbs";
+import {figmaLinks, themes} from "../../../.storybook/globals";
+import {themeWrapper} from "../../../.storybook/helper-functions.js";
 
-const renderBreadcrumbs = ({ displayBreadcrumbs, lineage, ...args }) =>
-    Handlebars.compile(Template)({
+function render({displayBreadcrumbs, lineage, ...args}) {
+    return Template({
         current: {
             data: {
                 metadata: {
-                    displayBreadcrumbs: { value: displayBreadcrumbs },
+                    displayBreadcrumbs: {value: displayBreadcrumbs},
                 },
             },
             lineage: lineage,
         },
         ...args,
     });
+}
 
 const breadcrumbsArgs = {
     displayBreadcrumbs: "true",
     lineage: [
-        { asset_type_code: "page", asset_short_name: "Home", asset_is_site_asset: "2" },
-        { asset_type_code: "page", asset_short_name: "Design system", asset_is_site_asset: "2" },
-        { asset_type_code: "page", asset_short_name: "Library", asset_is_site_asset: "2" },
-        { asset_type_code: "page", asset_short_name: "Components", asset_is_site_asset: "2" },
-        { asset_type_code: "page", asset_short_name: "Breadcrumbs", asset_is_site_asset: "2" },
+        {asset_type_code: "page", asset_short_name: "Home", asset_is_site_asset: "2"},
+        {asset_type_code: "page", asset_short_name: "Design system", asset_is_site_asset: "2"},
+        {asset_type_code: "page", asset_short_name: "Library", asset_is_site_asset: "2"},
+        {asset_type_code: "page", asset_short_name: "Components", asset_is_site_asset: "2"},
+        {asset_type_code: "page", asset_short_name: "Breadcrumbs", asset_is_site_asset: "2"},
     ],
 };
 
 const breadcrumbsArgsLong = {
     displayBreadcrumbs: "true",
     lineage: [
-        { asset_type_code: "page", asset_short_name: "Home", asset_is_site_asset: "2" },
-        { asset_type_code: "page", asset_short_name: "Design system", asset_is_site_asset: "2" },
-        { asset_type_code: "page", asset_short_name: "Library", asset_is_site_asset: "2" },
-        { asset_type_code: "page", asset_short_name: "Components", asset_is_site_asset: "2" },
-        { asset_type_code: "page", asset_short_name: "Breadcrumbs", asset_is_site_asset: "2" },
-        { asset_type_code: "page", asset_short_name: "Page", asset_is_site_asset: "2" },
-        { asset_type_code: "page", asset_short_name: "Page", asset_is_site_asset: "2" },
-        { asset_type_code: "page", asset_short_name: "Page", asset_is_site_asset: "2" },
-        { asset_type_code: "page", asset_short_name: "Page", asset_is_site_asset: "2" },
-        { asset_type_code: "page", asset_short_name: "Page", asset_is_site_asset: "2" },
-        { asset_type_code: "page", asset_short_name: "Page", asset_is_site_asset: "2" },
-        { asset_type_code: "page", asset_short_name: "Page", asset_is_site_asset: "2" },
+        {asset_type_code: "page", asset_short_name: "Home", asset_is_site_asset: "2"},
+        {asset_type_code: "page", asset_short_name: "Design system", asset_is_site_asset: "2"},
+        {asset_type_code: "page", asset_short_name: "Library", asset_is_site_asset: "2"},
+        {asset_type_code: "page", asset_short_name: "Components", asset_is_site_asset: "2"},
+        {asset_type_code: "page", asset_short_name: "Breadcrumbs", asset_is_site_asset: "2"},
+        {asset_type_code: "page", asset_short_name: "Page", asset_is_site_asset: "2"},
+        {asset_type_code: "page", asset_short_name: "Page", asset_is_site_asset: "2"},
+        {asset_type_code: "page", asset_short_name: "Page", asset_is_site_asset: "2"},
+        {asset_type_code: "page", asset_short_name: "Page", asset_is_site_asset: "2"},
+        {asset_type_code: "page", asset_short_name: "Page", asset_is_site_asset: "2"},
+        {asset_type_code: "page", asset_short_name: "Page", asset_is_site_asset: "2"},
+        {asset_type_code: "page", asset_short_name: "Page", asset_is_site_asset: "2"},
     ],
 };
 
 export default {
     title: "3. Components/Breadcrumbs",
-    render: renderBreadcrumbs,
+    render: render,
     argTypes: {
         displayBreadcrumbs: {
             description: "Whether the component should be displayed.",
@@ -62,7 +62,7 @@ export default {
             default: "true",
         },
     },
-    args: { ...breadcrumbsArgs },
+    args: {...breadcrumbsArgs},
     parameters: {
         design: {
             type: "figma",
@@ -76,58 +76,58 @@ export const Default = {};
 export const overflow = {
     args: breadcrumbsArgsLong,
     render: (args) => {
-        return `<section class="qld__body qld__body--breadcrumb"><div class="container-fluid">` + renderBreadcrumbs(args) + `</div></section>`;
+        return `<section class="qld__body qld__body--breadcrumb"><div class="container-fluid">` + render(args) + `</div></section>`;
     },
 };
 
 export const light = {
     render: (args) => {
-        return themeWrapper(themes["light"], `${renderBreadcrumbs(args)}`);
+        return themeWrapper(themes["light"], `${render(args)}`);
     },
 };
 
 export const lightOverflow = {
     args: breadcrumbsArgsLong,
     render: (args) => {
-        return `<section class="qld__body qld__body--breadcrumb"><div class="container-fluid">` + themeWrapper(themes["light"], `${renderBreadcrumbs(args)}`) + `</div></section>`;
+        return `<section class="qld__body qld__body--breadcrumb"><div class="container-fluid">` + themeWrapper(themes["light"], `${render(args)}`) + `</div></section>`;
     },
 };
 
 export const lightAlt = {
     render: (args) => {
-        return themeWrapper(themes["light alt"], `${renderBreadcrumbs(args)}`);
+        return themeWrapper(themes["light alt"], `${render(args)}`);
     },
 };
 
 export const lightAltOverflow = {
     args: breadcrumbsArgsLong,
     render: (args) => {
-        return `<section class="qld__body qld__body--breadcrumb"><div class="container-fluid">` + themeWrapper(themes["light alt"], `${renderBreadcrumbs(args)}`) + `</div></section>`;
+        return `<section class="qld__body qld__body--breadcrumb"><div class="container-fluid">` + themeWrapper(themes["light alt"], `${render(args)}`) + `</div></section>`;
     },
 };
 
 export const dark = {
     render: (args) => {
-        return themeWrapper(themes["dark"], `${renderBreadcrumbs(args)}`);
+        return themeWrapper(themes["dark"], `${render(args)}`);
     },
 };
 
 export const darkOverflow = {
     args: breadcrumbsArgsLong,
     render: (args) => {
-        return `<section class="qld__body qld__body--breadcrumb"><div class="container-fluid">` + themeWrapper(themes["dark"], `${renderBreadcrumbs(args)}`) + `</div></section>`;
+        return `<section class="qld__body qld__body--breadcrumb"><div class="container-fluid">` + themeWrapper(themes["dark"], `${render(args)}`) + `</div></section>`;
     },
 };
 
 export const darkAlt = {
     render: (args) => {
-        return themeWrapper(themes["dark alt"], `${renderBreadcrumbs(args)}`);
+        return themeWrapper(themes["dark alt"], `${render(args)}`);
     },
 };
 
 export const darkAltOverflow = {
     args: breadcrumbsArgsLong,
     render: (args) => {
-        return `<section class="qld__body qld__body--breadcrumb"><div class="container-fluid">` + themeWrapper(themes["dark alt"], `${renderBreadcrumbs(args)}`) + `</div></section>`;
+        return `<section class="qld__body qld__body--breadcrumb"><div class="container-fluid">` + themeWrapper(themes["dark alt"], `${render(args)}`) + `</div></section>`;
     },
 };

--- a/src/stories/Callout/Callout.stories.js
+++ b/src/stories/Callout/Callout.stories.js
@@ -1,49 +1,47 @@
-import Handlebars from "handlebars";
-import Template from "../../components/callout/html/component.hbs?raw";
+import Template from "../../components/callout/html/component.hbs";
 import { figmaLinks, themes } from "../../../.storybook/globals";
 
-const renderCallout = ({ assetId, idField, bodyBackground, type, background, heading, headingVisible, body, calendarIntro, calendarDate, calendarName, ...args }) =>
-    Handlebars.compile(Template)({
+const renderCallout = ({
+    assetId,
+    idField,
+    bodyBackground,
+    type,
+    background,
+    heading,
+    headingVisible,
+    body,
+    calendarIntro,
+    calendarDate,
+    calendarName,
+    ...args
+}) =>
+    Template({
         component: {
             assetid: assetId,
             data: {
                 metadata: {
-                    id_field: { value: idField },
-                    body_background: { value: bodyBackground },
-                    type: { value: type },
-                    background: { value: background },
-                    heading: { value: heading },
-                    heading_visible: { value: headingVisible },
-                    body: { value: body },
-                    calendar_intro: { value: calendarIntro },
-                    calendar_date: { value: calendarDate },
-                    calendar_name: { value: calendarName },
+                    id_field: {value: idField},
+                    body_background: {value: bodyBackground},
+                    type: {value: type},
+                    background: {value: background},
+                    heading: {value: heading},
+                    heading_visible: {value: headingVisible},
+                    body: {value: body},
+                    calendar_intro: {value: calendarIntro},
+                    calendar_date: {value: calendarDate},
+                    calendar_name: {value: calendarName},
                 },
             },
         },
         ...args,
     });
 
-const calloutArgs = {
-    assetId: "Callout-123",
-    idField: "Callout-123",
-    bodyBackground: "",
-    type: "",
-    background: "",
-    heading: "Title of the callout",
-    headingVisible: "",
-    body: "Description of the callout. Lorem ipsum dolor sit amet, consectetur adipiscing elit. Leo, ac ipsum consequat, enim consequat viverra ut eu feugiat. Sed vitae scelerisque aliquet mauris malesuada.",
-    calendarIntro: "The next public holiday is:",
-    calendarDate: "Sunday 1 January 2026",
-    calendarName: "New Year's Day",
-};
-
-export default {
+const meta = {
     title: "3. Components/Callout",
     render: renderCallout,
     argTypes: {
-        assetId: { description: "The ID of the asset.", control: "text" },
-        idField: { description: "The ID of the field.", control: "text" },
+        assetId: {description: "The ID of the asset.", control: "text"},
+        idField: {description: "The ID of the field.", control: "text"},
         bodyBackground: {
             description: "The background colour of the callout body.",
             control: {
@@ -83,7 +81,7 @@ export default {
             },
             options: ["", "qld__callout--light", "qld__callout--alt", "qld__callout--dark", "qld__callout--dark-alt"],
         },
-        heading: { description: "The heading of the callout.", control: "text" },
+        heading: {description: "The heading of the callout.", control: "text"},
         headingVisible: {
             description: "Whether the heading is visible.",
             control: {
@@ -95,12 +93,24 @@ export default {
             },
             options: ["", "qld__callout__heading--sronly"],
         },
-        body: { description: "The body of the callout.", control: "text" },
-        calendarIntro: { description: "The calendar introduction of the callout.", control: "text" },
-        calendarDate: { description: "The calendar date of the callout.", control: "text" },
-        calendarName: { description: "The calendar name of the callout.", control: "text" },
+        body: {description: "The body of the callout.", control: "text"},
+        calendarIntro: {description: "The calendar introduction of the callout.", control: "text"},
+        calendarDate: {description: "The calendar date of the callout.", control: "text"},
+        calendarName: {description: "The calendar name of the callout.", control: "text"},
     },
-    args: calloutArgs,
+    args: {
+        assetId: "Callout-123",
+        idField: "Callout-123",
+        bodyBackground: "",
+        type: "",
+        background: "",
+        heading: "Title of the callout",
+        headingVisible: "",
+        body: "Description of the callout. Lorem ipsum dolor sit amet, consectetur adipiscing elit. Leo, ac ipsum consequat, enim consequat viverra ut eu feugiat. Sed vitae scelerisque aliquet mauris malesuada.",
+        calendarIntro: "The next public holiday is:",
+        calendarDate: "Sunday 1 January 2026",
+        calendarName: "New Year's Day",
+    },
     parameters: {
         design: {
             type: "figma",
@@ -109,36 +119,34 @@ export default {
     },
 };
 
+export default meta;
+
 export const Default = {};
 
 export const allVariants = (theme, background) => {
     return `
         <div class="${theme}" style="padding: 2rem;">
             <h3>Callout</h3>
-            ${renderCallout({ ...calloutArgs, bodyBackground: background })}
+            ${renderCallout({...meta.args, bodyBackground: background})}
             <h3>Calendar Event</h3>
-            ${renderCallout({ ...calloutArgs, type: "qld__callout--calendar-event", bodyBackground: background })}
+            ${renderCallout({...meta.args, type: "qld__callout--calendar-event", bodyBackground: background})}
         </div>
     `;
 };
 allVariants.tags = ["!dev"];
 
 export const noTitle = {
-    render: () => {
-        return renderCallout({ ...calloutArgs, headingVisible: "qld__callout__heading--sronly" });
+    args: {
+        headingVisible: "qld__callout__heading--sronly"
     },
 };
 
 export const noBody = {
-    render: () => {
-        return renderCallout({ ...calloutArgs, body: "" });
-    },
+    args: {body: ""}
 };
 
 export const calendar = {
-    render: () => {
-        return renderCallout({ ...calloutArgs, type: "qld__callout--calendar-event" });
-    },
+    args: {type: "qld__callout--calendar-event"}
 };
 
 export const white = {

--- a/src/stories/Footer/Footer.stories.js
+++ b/src/stories/Footer/Footer.stories.js
@@ -1,5 +1,4 @@
-import Handlebars from "handlebars";
-import Template from "../../components/footer/html/component.hbs?raw";
+import Template from "../../components/footer/html/component.hbs";
 import { figmaLinks } from "../../../.storybook/globals";
 
 // Helper to format links for Handlebars
@@ -122,7 +121,7 @@ const renderFooter = (args) => {
         },
     };
 
-    return Handlebars.compile(Template)({ site });
+    return Template({ site });
 };
 
 // ✅ CSF metadata
@@ -159,12 +158,11 @@ export default {
 };
 
 // Named exports for stories
-export const Default = { args: { ...footerArgs } };
-export const Light = { args: { ...footerArgs, footerStyle: "" } };
-export const Alt = { args: { ...footerArgs, footerStyle: "qld__footer--alt" } };
+export const Default = {};
+export const Light = { args: { footerStyle: "" } };
+export const Alt = { args: { footerStyle: "qld__footer--alt" } };
 export const Dark = {
     args: {
-        ...footerArgs,
         footerStyle: "qld__footer--dark",
         footerLogo: {
             asset_url: "https://www.designsystem.qld.gov.au/__data/assets/file/0022/456502/coa-delivering-for-qld-mono-white-mini-lockup.svg",
@@ -173,7 +171,6 @@ export const Dark = {
 };
 export const DarkAlt = {
     args: {
-        ...footerArgs,
         footerStyle: "qld__footer--dark-alt",
         footerLogo: {
             asset_url: "https://www.designsystem.qld.gov.au/__data/assets/file/0022/456502/coa-delivering-for-qld-mono-white-mini-lockup.svg",
@@ -183,7 +180,6 @@ export const DarkAlt = {
 
 export const FooterWithoutOptionalLinks = {
     args: {
-        ...footerArgs,
         footerSiteTitle: "Site Title",
         footerSocialLinks: [],
         footerOptionalSecondLinksList: [],
@@ -192,9 +188,7 @@ export const FooterWithoutOptionalLinks = {
 
 export const FooterWithoutQueenslandCoatOfArms = {
     args: {
-        ...footerArgs,
         footerSiteTitle: "Site Title",
-
         footerOptionalSecondLinksList: [
             { asset_short_name: "Custom Link 1", asset_url: "/privacy" },
             { asset_short_name: "Custom Link 2", asset_url: "/terms" },

--- a/src/stories/Header/Header.js
+++ b/src/stories/Header/Header.js
@@ -1,5 +1,4 @@
-import Handlebars from "handlebars";
-import Template from "../../components/header/html/component.hbs?raw";
+import Template from "../../components/header/html/component.hbs";
 import { cleanStorybookUrls } from "../../../.storybook/helper-functions";
 import { renderNavbar, navbarArgs } from "../Navbar/Navbar";
 
@@ -7,8 +6,7 @@ import { renderNavbar, navbarArgs } from "../Navbar/Navbar";
 export const renderHeader = (args) => {
     const navbarHTML = renderNavbar(navbarArgs);
 
-    const template = Handlebars.compile(Template);
-    const headerHTML = template({
+    const headerHTML = Template({
         site: {
             metadata: {
                 defaultBannerContainedBanner: {

--- a/src/stories/InPageAlert/InPageAlert.stories.js
+++ b/src/stories/InPageAlert/InPageAlert.stories.js
@@ -1,36 +1,27 @@
-import Handlebars from "handlebars";
-import Template from "../../components/page_alert/html/component.hbs?raw";
+import Template from "../../components/page_alert/html/component.hbs";
 import { figmaLinks } from "../../../.storybook/globals";
 
-const renderInPageAlert = ({ id, type, headingLevel, heading, body, ...args }) =>
-    Handlebars.compile(Template)({
+const renderInPageAlert = ({id, type, headingLevel, heading, body, ...args}) =>
+    Template({
         component: {
             data: {
                 metadata: {
-                    id_field: { value: id },
-                    type: { value: type },
-                    heading_level: { value: headingLevel },
-                    heading: { value: heading },
-                    body: { value: body },
+                    id_field: {value: id},
+                    type: {value: type},
+                    heading_level: {value: headingLevel},
+                    heading: {value: heading},
+                    body: {value: body},
                 },
             },
         },
         ...args,
     });
 
-const inPageAlertArgs = {
-    id: "123",
-    type: "info",
-    headingLevel: "h2",
-    heading: "In-page alert title",
-    body: "Woohoo! This is the body of my in-page alert",
-};
-
 export default {
     title: "3. Components/In-page Alert",
     render: renderInPageAlert,
     argTypes: {
-        id: { control: "text" },
+        id: {control: "text"},
         type: {
             control: {
                 type: "radio",
@@ -59,13 +50,19 @@ export default {
             options: ["h1", "h2", "h3", "h4", "h5", "h6"],
             description: "The heading level of the alert, for example H1, H6. The sole purpose of this variable is to change the semantic HTML tag used, not the visual appearance",
             table: {
-                defaultValue: { summary: "h2" },
+                defaultValue: {summary: "h2"},
             },
         },
-        heading: { control: "text", description: "The heading of the alert" },
-        body: { control: "text", description: "The body text of the alert" },
+        heading: {control: "text", description: "The heading of the alert"},
+        body: {control: "text", description: "The body text of the alert"},
     },
-    args: { ...inPageAlertArgs },
+    args: {
+        id: "123",
+        type: "info",
+        headingLevel: "h2",
+        heading: "In-page alert title",
+        body: "Woohoo! This is the body of my in-page alert",
+    },
     parameters: {
         design: {
             type: "figma",
@@ -74,20 +71,24 @@ export default {
     },
 };
 
-export const Default = {
-    args: {
-        ...inPageAlertArgs,
-    },
-};
+export const Default = {};
 
-export const infoVariant = (inPageAlertArgs) => renderInPageAlert({ ...inPageAlertArgs, type: "info" });
-infoVariant.tags = ["!dev"];
+export const infoVariant = {
+    args: {type: "info"},
+    tags: ["!dev"]
+}
 
-export const successVariant = (inPageAlertArgs) => renderInPageAlert({ ...inPageAlertArgs, type: "success" });
-successVariant.tags = ["!dev"];
+export const successVariant = {
+    args: {type: "success"},
+    tags: ["!dev"]
+}
 
-export const warningVariant = (inPageAlertArgs) => renderInPageAlert({ ...inPageAlertArgs, type: "warning" });
-warningVariant.tags = ["!dev"];
+export const warningVariant = {
+    args: {type: "warning"},
+    tags: ["!dev"]
+}
 
-export const errorVariant = (inPageAlertArgs) => renderInPageAlert({ ...inPageAlertArgs, type: "error" });
-errorVariant.tags = ["!dev"];
+export const errorVariant = {
+    args: {type: "error"},
+    tags: ["!dev"]
+}

--- a/src/stories/InPageNavigation/InPageNavigation.stories.js
+++ b/src/stories/InPageNavigation/InPageNavigation.stories.js
@@ -1,24 +1,18 @@
-import Handlebars from "handlebars";
-import Template from "../../components/in_page_navigation/html/component.hbs?raw";
+import Template from "../../components/in_page_navigation/html/component.hbs";
 import { figmaLinks, dummyText } from "../../../.storybook/globals";
 
-const renderInPageNavigation = ({ heading, headingType, ...args }) =>
-    Handlebars.compile(Template)({
+const renderInPageNavigation = ({heading, headingType, ...args}) =>
+    Template({
         component: {
             data: {
                 metadata: {
-                    heading: { value: heading },
-                    headingType: { value: headingType },
+                    heading: {value: heading},
+                    headingType: {value: headingType},
                 },
             },
         },
         ...args,
     });
-
-const inPageNavigationArgs = {
-    heading: "On this page",
-    headingType: "h2",
-};
 
 export default {
     title: "3. Components/In-page Navigation",
@@ -26,7 +20,7 @@ export default {
     argTypes: {
         heading: {
             description: "The title of the in-page navigation.",
-            control: { type: "text" },
+            control: {type: "text"},
         },
         headingType: {
             description: "The type of the heading the in-page navigation will scan for.",
@@ -42,11 +36,14 @@ export default {
             },
             options: ["h2", "h3", "h4", "h5", "h6"],
             table: {
-                defaultValue: { summary: "h2" },
+                defaultValue: {summary: "h2"},
             },
         },
     },
-    args: inPageNavigationArgs,
+    args: {
+        heading: "On this page",
+        headingType: "h2",
+    },
     parameters: {
         design: {
             type: "figma",
@@ -55,7 +52,8 @@ export default {
     },
     decorators: [
         (Story, context) => {
-            // Default IDs for headings. Simulates the publisher not adding custom ID's to the page headings which is a common scenario
+            // Default IDs for headings. Simulates the publisher not adding custom ID's to the page headings which is a
+            // common scenario
             if (!context.args.ids) {
                 context.args.ids = ["", "", "", "", "", "", "", "", "", "", "", "", "", "", ""];
             }
@@ -82,12 +80,12 @@ export default {
 };
 
 export const Default = {};
-export const headingLevel3 = { args: { headingType: "h3" } };
-export const headingLevel4 = { args: { headingType: "h4" } };
-export const headingLevel5 = { args: { headingType: "h5" } };
-export const headingLevel6 = { args: { headingType: "h6" } };
+export const headingLevel3 = {args: {headingType: "h3"}};
+export const headingLevel4 = {args: {headingType: "h4"}};
+export const headingLevel5 = {args: {headingType: "h5"}};
+export const headingLevel6 = {args: {headingType: "h6"}};
 export const customIdentifiers = {
-    args: { ids: ["id-1", "id-2", "id-3", "id-4", "id-5", "id-6", "id-7", "id-8", "id-9", "id-10", "id-11", "id-12", "id-13", "id-14", "id-15"] },
+    args: {ids: ["id-1", "id-2", "id-3", "id-4", "id-5", "id-6", "id-7", "id-8", "id-9", "id-10", "id-11", "id-12", "id-13", "id-14", "id-15"]},
 };
 export const duplicateIdentifiers = {
     args: {

--- a/src/stories/LinkColumns/LinkColumns.stories.js
+++ b/src/stories/LinkColumns/LinkColumns.stories.js
@@ -41,9 +41,9 @@ const linkColumnsArgs = {
 
 export default {
     title: "3. Components/Link Columns",
-    render: (args) => LinkColumns(args),
+    render: LinkColumns,
     argTypes: {
-        ariaLabel: { control: "text", description: "The aria " },
+        ariaLabel: {control: "text", description: "The aria "},
         columns: {
             control: {
                 type: "radio",
@@ -56,14 +56,18 @@ export default {
             options: [1, 2, 3],
             description: "The number of columns formatted in the link columns",
             table: {
-                defaultValue: { summary: 1 },
+                defaultValue: {summary: 1},
             },
         },
-        data: { control: "array", description: "The link the user will be taken to on click" },
-        hasViewAll: { control: "boolean", description: "Whether to show the 'View all' link" },
-        viewAllHref: { control: "text", description: "The link the 'View all' button will navigate to", if: { arg: "hasViewAll", eq: true } },
+        data: {control: "array", description: "The link the user will be taken to on click"},
+        hasViewAll: {control: "boolean", description: "Whether to show the 'View all' link"},
+        viewAllHref: {
+            control: "text",
+            description: "The link the 'View all' button will navigate to",
+            if: {arg: "hasViewAll", eq: true}
+        },
     },
-    args: { ...linkColumnsArgs },
+    args: {...linkColumnsArgs},
     parameters: {
         design: {
             type: "figma",
@@ -72,29 +76,42 @@ export default {
     },
 };
 
+const renderVariant = (variant) => LinkColumns({...linkColumnsArgs, ...variant.args});
+
 export const Default = {};
 
-export const defaultVariant = () => LinkColumns({ ...linkColumnsArgs });
-defaultVariant.tags = ["!dev"];
-export const columns1Variant = () => LinkColumns({ ...linkColumnsArgs, columns: 1 });
-columns1Variant.tags = ["!dev"];
-export const columns2Variant = () => LinkColumns({ ...linkColumnsArgs, columns: 2 });
-columns2Variant.tags = ["!dev"];
-export const columns3Variant = () => LinkColumns({ ...linkColumnsArgs, columns: 3 });
-columns3Variant.tags = ["!dev"];
-export const noViewAllVariant = () => LinkColumns({ ...linkColumnsArgs, columns: 3, hasViewAll: false });
-noViewAllVariant.tags = ["!dev"];
+export const defaultVariant = {
+    tags: ["!dev"]
+}
+
+export const columns1Variant = {
+    args: {columns: 1},
+    tags: ["!dev"]
+}
+
+export const columns2Variant = {
+    args: {columns: 2},
+    tags: ["!dev"]
+}
+export const columns3Variant = {
+    args: {columns: 3},
+    tags: ["!dev"]
+}
+export const noViewAllVariant = {
+    args: {columns: 3, hasViewAll: false},
+    tags: ["!dev"]
+}
 
 export const allVariants = () => {
     return `
         <h3>Link columns (1)</h3>
-        ${columns1Variant()}
+        ${renderVariant(columns1Variant)}
         <h3>Link columns (2)</h3>
-        ${columns2Variant()}
+        ${renderVariant(columns2Variant)}
         <h3>Link columns (3)</h3>
-        ${columns3Variant()}
+        ${renderVariant(columns3Variant)}
         <h3>Link columns without view all</h3>
-        ${noViewAllVariant()}
+        ${renderVariant(noViewAllVariant)}
     `;
 };
 allVariants.tags = ["!dev"];

--- a/src/stories/LoadingSpinner/LoadingSpinner.stories.js
+++ b/src/stories/LoadingSpinner/LoadingSpinner.stories.js
@@ -1,26 +1,19 @@
-import Handlebars from "handlebars";
-import Template from "../../components/loading_spinner/html/component.hbs?raw";
+import Template from "../../components/loading_spinner/html/component.hbs";
 import { figmaLinks } from "../../../.storybook/globals";
 
-const renderLoadingSpinner = ({ backgroundColour, layout, label, ...args }) =>
-    Handlebars.compile(Template)({
+const renderLoadingSpinner = ({backgroundColour, layout, label, ...args}) =>
+    Template({
         component: {
             data: {
                 metadata: {
-                    background_colour: { value: backgroundColour },
-                    layout: { value: layout },
-                    label: { value: label },
+                    background_colour: {value: backgroundColour},
+                    layout: {value: layout},
+                    label: {value: label},
                 },
             },
         },
         ...args,
     });
-
-const loadingSpinnerArgs = {
-    backgroundColour: "",
-    layout: "",
-    label: "Loading...",
-};
 
 export default {
     title: "3. Components/Loading Spinner",
@@ -49,9 +42,13 @@ export default {
             },
             options: ["", "landscape", "icon_only"],
         },
-        label: { description: "The label underneath the spinner.", control: "text" },
+        label: {description: "The label underneath the spinner.", control: "text"},
     },
-    args: loadingSpinnerArgs,
+    args: {
+        backgroundColour: "",
+        layout: "",
+        label: "Loading...",
+    },
     parameters: {
         design: {
             type: "figma",
@@ -63,19 +60,13 @@ export default {
 export const Default = {};
 
 export const landscape = {
-    render: () => {
-        return renderLoadingSpinner({ ...loadingSpinnerArgs, layout: "landscape" });
-    },
+    args: {layout: "landscape"}
 };
 
 export const iconOnly = {
-    render: () => {
-        return renderLoadingSpinner({ ...loadingSpinnerArgs, layout: "icon_only" });
-    },
+    args: {layout: "icon_only"}
 };
 
 export const dark = {
-    render: () => {
-        return renderLoadingSpinner({ ...loadingSpinnerArgs, backgroundColour: "dark" });
-    },
+    args: {backgroundColour: "dark"}
 };

--- a/src/stories/Navbar/Navbar.js
+++ b/src/stories/Navbar/Navbar.js
@@ -1,5 +1,4 @@
-import Handlebars from "handlebars";
-import Template from "../../components/mega_main_navigation/html/component.hbs?raw";
+import Template from "../../components/mega_main_navigation/html/component.hbs";
 import { cleanStorybookUrls } from "../../../.storybook/helper-functions";
 
 /**
@@ -80,9 +79,7 @@ const current = {
  * Render helper
  */
 export const renderNavbar = (args) => {
-    const template = Handlebars.compile(Template);
-
-    const html = template({
+    const html = Template({
         site: {
             metadata: {
                 mainNavStyle: { value: args.mainNavStyle },

--- a/src/stories/Navbar/Navbar.stories.js
+++ b/src/stories/Navbar/Navbar.stories.js
@@ -57,12 +57,6 @@ export const Default = {
         // Plain wrapper with nothing else
         return `<div class="qld__grid">${renderNavbar(args)}</div>`;
     },
-    decorators: [
-        (Story) => {
-            // Simply return the story HTML without the global theme wrapper
-            return Story();
-        },
-    ],
 };
 
 // Variants

--- a/src/stories/Pagination/Pagination.stories.js
+++ b/src/stories/Pagination/Pagination.stories.js
@@ -1,10 +1,9 @@
-import Handlebars from "handlebars";
-import Template from "../../components/pagination/html/component.hbs?raw";
+import Template from "../../components/pagination/html/component.hbs";
 import { figmaLinks, themes, dummyLink } from "../../../.storybook/globals";
 import { themeWrapper } from "../../../.storybook/helper-functions.js";
 
 const renderPagination = ({ data, ...args }) =>
-    Handlebars.compile(Template)({
+    Template({
         pagination: data,
         ...args,
     });

--- a/src/stories/PromoPanel/PromoPanel.stories.js
+++ b/src/stories/PromoPanel/PromoPanel.stories.js
@@ -1,28 +1,45 @@
-import Handlebars from "handlebars";
-import Template from "../../components/promo_panel/html/component.hbs?raw";
+import Template from "../../components/promo_panel/html/component.hbs";
 import { figmaLinks } from "../../../.storybook/globals";
 
-const renderPromoPanel = ({ id, type, title, abstract, body, promoImage, bodyBackground, imageAlignment, promoPanelIcon, linkType, ctaLinkTitle, ctaLink, primaryLinkTitle, primaryLink, secondaryLinkTitle, secondaryLink, ...args }) => {
-    const html = Handlebars.compile(Template)({
+const renderPromoPanel = ({
+    id,
+    type,
+    title,
+    abstract,
+    body,
+    promoImage,
+    bodyBackground,
+    imageAlignment,
+    promoPanelIcon,
+    linkType,
+    ctaLinkTitle,
+    ctaLink,
+    primaryLinkTitle,
+    primaryLink,
+    secondaryLinkTitle,
+    secondaryLink,
+    ...args
+}) => {
+    const html = Template({
         component: {
             data: {
                 metadata: {
-                    id_field: { value: id },
-                    type: { value: type },
-                    title: { value: title },
-                    abstract: { value: abstract },
-                    body: { value: body },
-                    promo_image: { value: promoImage },
-                    body_background: { value: bodyBackground },
-                    image_alignment: { value: imageAlignment },
-                    promo_panel_icon: { value: promoPanelIcon },
-                    link_type: { value: linkType },
-                    cta_link_title: { value: ctaLinkTitle },
-                    cta_link: { value: ctaLink },
-                    primary_link_title: { value: primaryLinkTitle },
-                    primary_link: { value: primaryLink },
-                    secondary_link_title: { value: secondaryLinkTitle },
-                    secondary_link: { value: secondaryLink },
+                    id_field: {value: id},
+                    type: {value: type},
+                    title: {value: title},
+                    abstract: {value: abstract},
+                    body: {value: body},
+                    promo_image: {value: promoImage},
+                    body_background: {value: bodyBackground},
+                    image_alignment: {value: imageAlignment},
+                    promo_panel_icon: {value: promoPanelIcon},
+                    link_type: {value: linkType},
+                    cta_link_title: {value: ctaLinkTitle},
+                    cta_link: {value: ctaLink},
+                    primary_link_title: {value: primaryLinkTitle},
+                    primary_link: {value: primaryLink},
+                    secondary_link_title: {value: secondaryLinkTitle},
+                    secondary_link: {value: secondaryLink},
                 },
             },
         },
@@ -64,7 +81,7 @@ export default {
     title: "3. Components/Promo Panel",
     render: renderPromoPanel,
     argTypes: {
-        id: { description: "The unique identifier of the component.", control: "text" },
+        id: {description: "The unique identifier of the component.", control: "text"},
         type: {
             description: "The style of the component.",
             control: {
@@ -79,10 +96,10 @@ export default {
             options: ["", "qld__body--large-text", "qld__body--contained", "qld__body--full-image"],
             default: "",
         },
-        title: { description: "The title of the component", control: "text" },
-        abstract: { description: "The abstract of the component.", control: "text" },
-        body: { description: "The body text.", control: "text" },
-        promoImage: { description: "The image on this component.", control: "text" },
+        title: {description: "The title of the component", control: "text"},
+        abstract: {description: "The abstract of the component.", control: "text"},
+        body: {description: "The body text.", control: "text"},
+        promoImage: {description: "The image on this component.", control: "text"},
         bodyBackground: {
             description: "The colour theme of the component.",
             control: {
@@ -110,7 +127,7 @@ export default {
             options: ["qld__promo-panel--image-left", "qld__promo-panel--image-right"],
             default: "qld__promo-panel--image-left",
         },
-        promoPanelIcon: { description: "The icon displayed", control: "text" },
+        promoPanelIcon: {description: "The icon displayed", control: "text"},
         linkType: {
             description: "Whether the link should be of type CTA or Button.",
             control: {
@@ -123,14 +140,14 @@ export default {
             options: ["cta", "button"],
             default: "cta",
         },
-        ctaLinkTitle: { description: "CTA link title.", control: "text" },
-        ctaLink: { description: "CTA link link.", control: "text" },
-        primaryLinkTitle: { description: "Primary button title.", control: "text" },
-        primaryLink: { description: "Primary button link.", control: "text" },
-        secondaryLinkTitle: { description: "Secondary button title.", control: "text" },
-        secondaryLink: { description: "Secondary button link.", control: "text" },
+        ctaLinkTitle: {description: "CTA link title.", control: "text"},
+        ctaLink: {description: "CTA link link.", control: "text"},
+        primaryLinkTitle: {description: "Primary button title.", control: "text"},
+        primaryLink: {description: "Primary button link.", control: "text"},
+        secondaryLinkTitle: {description: "Secondary button title.", control: "text"},
+        secondaryLink: {description: "Secondary button link.", control: "text"},
     },
-    args: { ...promoPanelArgs },
+    args: {...promoPanelArgs},
     parameters: {
         design: {
             type: "figma",
@@ -141,85 +158,55 @@ export default {
 
 export const Default = {};
 
-export const defaultVariant = () => renderPromoPanel({ ...promoPanelArgs, bodyBackground: "" });
-defaultVariant.tags = ["!dev"];
+export const defaultVariant = {
+    args: {bodyBackground: ""},
+    tags: ["!dev"]
+}
 
 export const largeText = {
     args: {
-        ...promoPanelArgs,
         type: "qld__body--large-text",
-    },
-    render: (args) => {
-        return renderPromoPanel(args);
     },
 };
 
 export const contained = {
     args: {
-        ...promoPanelArgs,
         type: "qld__body--contained",
-    },
-    render: (args) => {
-        return renderPromoPanel(args);
     },
 };
 
 export const fullImage = {
     args: {
-        ...promoPanelArgs,
         type: "qld__body--full-image",
-    },
-    render: (args) => {
-        return renderPromoPanel(args);
     },
 };
 
 export const white = {
     args: {
-        ...promoPanelArgs,
         bodyBackground: "",
-    },
-    render: (args) => {
-        return renderPromoPanel(args);
     },
 };
 
 export const light = {
     args: {
-        ...promoPanelArgs,
         bodyBackground: "qld__body--light",
-    },
-    render: (args) => {
-        return renderPromoPanel(args);
     },
 };
 
 export const lightAlt = {
     args: {
-        ...promoPanelArgs,
         bodyBackground: "qld__body--alt",
-    },
-    render: (args) => {
-        return renderPromoPanel(args);
     },
 };
 
 export const dark = {
     args: {
-        ...promoPanelArgs,
         bodyBackground: "qld__body--dark",
-    },
-    render: (args) => {
-        return renderPromoPanel(args);
     },
 };
 
 export const darkAlt = {
     args: {
-        ...promoPanelArgs,
         bodyBackground: "qld__body--dark-alt",
-    },
-    render: (args) => {
-        return renderPromoPanel(args);
     },
 };

--- a/src/stories/RadioButtons/RadioButtons.stories.js
+++ b/src/stories/RadioButtons/RadioButtons.stories.js
@@ -23,7 +23,7 @@ const radioButtonsArgs = {
 
 export default {
     title: "3. Components/Radio Buttons",
-    render: (args) => RadioButtons(args),
+    render: RadioButtons,
     argTypes: {
         id: { control: "text", description: "The id for this component" },
         legend: { control: "text", description: "The legend of the radio button group" },

--- a/src/stories/SelectBox/SelectBox.stories.js
+++ b/src/stories/SelectBox/SelectBox.stories.js
@@ -26,7 +26,7 @@ const selectBoxArgs = {
 
 export default {
     title: "3. Components/Select Box",
-    render: (args) => SelectBox(args),
+    render: SelectBox,
     argTypes: {
         id: { control: "text", description: "The id for this component" },
         extraClass: { control: "text", description: "Extra classes that will be applied to the < select > element" },

--- a/src/stories/Tags/Tags.stories.js
+++ b/src/stories/Tags/Tags.stories.js
@@ -12,7 +12,7 @@ const tagsArgs = {
 
 export default {
     title: "3. Components/Tags",
-    render: (args) => Tags(args),
+    render: Tags,
     argTypes: {
         type: {
             control: {

--- a/src/stories/VideoPlayer/VideoPlayer.stories.js
+++ b/src/stories/VideoPlayer/VideoPlayer.stories.js
@@ -1,5 +1,4 @@
-import Handlebars from "handlebars";
-import Template from "../../components/video_player/html/component.hbs?raw";
+import Template from "../../components/video_player/html/component.hbs";
 import { figmaLinks } from "../../../.storybook/globals";
 
 const videoPlayerArgs = {
@@ -18,24 +17,39 @@ const videoPlayerArgs = {
         "<h2>Optional Heading</h2><p>psum vulputate faucibus commodo laoreet tincidunt amet suspendisse urna. Turpis elementum eget dis senectus in enim varius aliquam. Vel amet odio nibh at sollicitudin. Nullam condimentum lectus.</p>",
 };
 
-const renderVideoPlayer = ({ videoType, videoLayout, stackOptions, videoAlignItems, videoId, videoSize, videoDuration, videoCaption, transcriptOptions, transcriptLink, transcriptText, videoDescription, bodyBackground, ...args }) => {
-    return Handlebars.compile(Template)({
+const renderVideoPlayer = ({
+    videoType,
+    videoLayout,
+    stackOptions,
+    videoAlignItems,
+    videoId,
+    videoSize,
+    videoDuration,
+    videoCaption,
+    transcriptOptions,
+    transcriptLink,
+    transcriptText,
+    videoDescription,
+    bodyBackground,
+    ...args
+}) => {
+    return Template({
         component: {
             data: {
                 metadata: {
-                    video_type: { value: videoType },
-                    video_layout: { value: videoLayout },
-                    stack_options: { value: stackOptions },
-                    video_align_items: { value: videoAlignItems },
-                    video_id: { value: videoId },
-                    video_size: { value: videoSize },
-                    video_duration: { value: videoDuration },
-                    video_caption: { value: videoCaption },
-                    transcript_options: { value: transcriptOptions },
-                    transcript_link: { value: transcriptLink },
-                    transcript: { value: transcriptText },
-                    video_description: { value: videoDescription },
-                    body_background: { value: bodyBackground },
+                    video_type: {value: videoType},
+                    video_layout: {value: videoLayout},
+                    stack_options: {value: stackOptions},
+                    video_align_items: {value: videoAlignItems},
+                    video_id: {value: videoId},
+                    video_size: {value: videoSize},
+                    video_duration: {value: videoDuration},
+                    video_caption: {value: videoCaption},
+                    transcript_options: {value: transcriptOptions},
+                    transcript_link: {value: transcriptLink},
+                    transcript: {value: transcriptText},
+                    video_description: {value: videoDescription},
+                    body_background: {value: bodyBackground},
                 },
             },
         },
@@ -48,25 +62,25 @@ export default {
     render: renderVideoPlayer,
     argTypes: {
         videoType: {
-            control: { type: "radio" },
+            control: {type: "radio"},
             options: ["youtube", "vimeo"],
             description: "The platform hosting the video. Choose between YouTube or Vimeo.",
         },
         videoLayout: {
-            control: { type: "radio" },
+            control: {type: "radio"},
             options: ["stack", "two_column"],
             description: "Layout for displaying the video and related content.",
         },
         stackOptions: {
-            control: { type: "radio" },
+            control: {type: "radio"},
             options: ["left_aligned", "centered"],
-            if: { arg: "videoLayout", eq: "stack" },
+            if: {arg: "videoLayout", eq: "stack"},
             description: "Alignment of stacked elements. Only applicable when the layout is set to 'stack'.",
         },
         videoAlignItems: {
-            control: { type: "radio" },
+            control: {type: "radio"},
             options: ["top", "centered_vertically"],
-            if: { arg: "videoLayout", neq: "stack" },
+            if: {arg: "videoLayout", neq: "stack"},
             description: "Vertical alignment of the video when not using a 'stack' layout.",
         },
         videoId: {
@@ -74,9 +88,9 @@ export default {
             description: "Unique identifier for the video. This can be a YouTube or Vimeo video ID.",
         },
         videoSize: {
-            control: { type: "radio" },
+            control: {type: "radio"},
             options: ["fill_grid", "eight_col"],
-            if: { arg: "videoLayout", eq: "stack" },
+            if: {arg: "videoLayout", eq: "stack"},
             description: "The size of the video within the layout grid.",
         },
         videoDuration: {
@@ -99,13 +113,13 @@ export default {
             description: "How the transcript is presented—either as a link or within an accordion.",
         },
         transcriptLink: {
-            control: { type: "text" },
-            if: { arg: "transcriptOptions", eq: "link" },
+            control: {type: "text"},
+            if: {arg: "transcriptOptions", eq: "link"},
             description: "The URL for the transcript link. Required if 'transcriptOptions' is set to 'link'.",
         },
         transcriptText: {
-            control: { type: "text" },
-            if: { arg: "transcriptOptions", eq: "accordion" },
+            control: {type: "text"},
+            if: {arg: "transcriptOptions", eq: "accordion"},
             description: "The full transcript text. Required if 'transcriptOptions' is set to 'accordion'.",
         },
         videoDescription: {
@@ -113,7 +127,7 @@ export default {
             description: "An optional description providing additional details about the video content.",
         },
         bodyBackground: {
-            control: { type: "radio" },
+            control: {type: "radio"},
             labels: {
                 white: "White",
                 light: "Light",
@@ -125,7 +139,7 @@ export default {
             description: "The background theme for the video player.",
         },
     },
-    args: { ...videoPlayerArgs },
+    args: {...videoPlayerArgs},
     parameters: {
         design: {
             type: "figma",
@@ -136,37 +150,31 @@ export default {
 
 export const Default = {};
 
-export const defaultVariant = (videoPlayerArgs) => renderVideoPlayer({ ...videoPlayerArgs, videoType: "vimeo" });
-defaultVariant.tags = ["!dev"];
+export const defaultVariant = {
+    args: {videoType: "vimeo"},
+    tags: ["!dev"]
+}
 
 export const light = {
     args: {
-        ...videoPlayerArgs,
         bodyBackground: "light",
     },
-    render: (args) => renderVideoPlayer(args),
 };
 
 export const lightAlt = {
     args: {
-        ...videoPlayerArgs,
         bodyBackground: "alt",
     },
-    render: (args) => renderVideoPlayer(args),
 };
 
 export const dark = {
     args: {
-        ...videoPlayerArgs,
         bodyBackground: "dark",
     },
-    render: (args) => renderVideoPlayer(args),
 };
 
 export const darkAlt = {
     args: {
-        ...videoPlayerArgs,
         bodyBackground: "dark-alt",
     },
-    render: (args) => renderVideoPlayer(args),
 };


### PR DESCRIPTION
- Convert stories to CSF3 where simple to do so
- Replacing '?raw' component imports with just '.hbs'. The custom vite plugin handles precompiling the Handlebar templates.