### PR TITLE
 QHDEV-631 | Utilities | Add space utility classes into core utilities

### DIFF
--- a/src/styles/imports/utilities.scss
+++ b/src/styles/imports/utilities.scss
@@ -1,149 +1,149 @@
 // Screen Hidden Content
 .visuallyhidden {
-	@extend %screen-hide;
+    @extend %screen-hide;
 }
 
 // When screen hidden content is focused restore it to view
 .visuallyhidden.focusable:active,
 .visuallyhidden.focusable:focus {
-	@extend %screen-show;
+    @extend %screen-show;
 }
 
 // Bootstrap friendly class
 .sr-only {
-	@extend .visuallyhidden;
+    @extend .visuallyhidden;
 }
 
 // Clear fix class for containers of floated elements
 .clearfix {
-	@extend %clearfix;
+    @extend %clearfix;
 }
 
 // Hide from both screenreaders and browsers: h5bp.com/u
 .hidden {
-	display: none !important;
-	visibility: hidden;
+    display: none !important;
+    visibility: hidden;
 }
 
 // Hide visually and from screenreaders, but maintain layout
 .invisible {
-	visibility: hidden;
+    visibility: hidden;
 }
 
 // Float classes
 .pull-left {
-	float: left;
+    float: left;
 }
 img.pull-left {
-	margin-right: 1em;
+    margin-right: 1em;
 }
 
 .pull-right {
-	float: right;
+    float: right;
 }
 img.pull-right {
-	margin-left: 1em;
+    margin-left: 1em;
 }
 
 // Vertically aligned classes
 .qld__align-middle,
 .qld__align-middle th,
 .qld__align-middle td {
-	vertical-align: middle !important;
+    vertical-align: middle !important;
 }
 
 // 16:9 Ratio container for embedded video
 // This container is suitable for something like youtube videos
 .video-container {
-	position: relative;
-	padding-bottom: 56.25%; // Video area
-	padding-top: 30px; // 30px controls container
-	height: 0;
-	overflow: hidden;
-	margin-bottom: 1em;
+    position: relative;
+    padding-bottom: 56.25%; // Video area
+    padding-top: 30px; // 30px controls container
+    height: 0;
+    overflow: hidden;
+    margin-bottom: 1em;
 }
 
 .video-container iframe,
 .video-container object,
 .video-container embed {
-	position: absolute;
-	top: 0;
-	left: 0;
-	width: 100%;
-	height: 100%;
+    position: absolute;
+    top: 0;
+    left: 0;
+    width: 100%;
+    height: 100%;
 }
 
 .hide_content {
-	display: none;
+    display: none;
 }
 
 .text-error {
-	color: $QLD-color-status__error;
+    color: $QLD-color-status__error;
 }
 
 .text-success {
-	color: $QLD-color-status__success;
+    color: $QLD-color-status__success;
 }
 
 .text-warning {
-	color: $QLD-color-status__caution;
+    color: $QLD-color-status__caution;
 }
 
 .text-info {
-	color: $QLD-color-status__info;
+    color: $QLD-color-status__info;
 }
 
 .text-center {
-	text-align: center;
+    text-align: center;
 }
 
 .text-left {
-	text-align: left;
+    text-align: left;
 }
 
 .text-right {
-	text-align: right;
+    text-align: right;
 }
 
 .qld__text-bold {
-	font-weight: $QLD-font-weight-bold;
+    font-weight: $QLD-font-weight-bold;
 }
 
 .qld__text-normal {
-	font-weight: $QLD-font-weight-regular;
+    font-weight: $QLD-font-weight-regular;
 }
 
 .qld__text-italic {
-	font-style: italic;
+    font-style: italic;
 }
 
 .qld__full-width {
-	width: 100%;
+    width: 100%;
 }
 
 .qld__full-height {
-	height: 100%;
+    height: 100%;
 }
 
 .order-first {
-	order: -1;
+    order: -1;
 }
 
 .capitalize {
-	text-transform: capitalize;
+    text-transform: capitalize;
 }
 
 .capitalised:first-letter {
-	text-transform: uppercase;
+    text-transform: uppercase;
 }
 
 .breakout {
-	width: 100vw;
-	position: relative;
-	left: 50%;
-	right: 50%;
-	margin-left: -50vw;
-	margin-right: -50vw;
+    width: 100vw;
+    position: relative;
+    left: 50%;
+    right: 50%;
+    margin-left: -50vw;
+    margin-right: -50vw;
 }
 
 *.qld__max-width,
@@ -162,157 +162,157 @@ figure.qld__max-width,
 span.qld__max-width,
 div.qld__max-width,
 a.qld__max-width {
-	.qld__grid &,
-	.qld__body &,
-	.qld__footer &,
-	[class^="qld__display"] & {
-		max-width: 100%;
-	}
+    .qld__grid &,
+    .qld__body &,
+    .qld__footer &,
+    [class^="qld__display"] & {
+        max-width: 100%;
+    }
 }
 
 /** @mixin QLD-fontgrid  replace line hight with this + use the variable (map) */
 .qld__body {
-	.qld__default-xs,
-	.qld__default-sm,
-	.qld__default-md,
-	.qld__default-lg,
-	.qld__default-xl,
-	.qld__default-xxl,
-	.qld__default-xxxl {
-		font-weight: $QLD-font-weight-regular;
-	}
+    .qld__default-xs,
+    .qld__default-sm,
+    .qld__default-md,
+    .qld__default-lg,
+    .qld__default-xl,
+    .qld__default-xxl,
+    .qld__default-xxxl {
+        font-weight: $QLD-font-weight-regular;
+    }
 
-	.qld__no-space {
-		line-height: 1 !important;
-	}
+    .qld__no-space {
+        line-height: 1 !important;
+    }
 
-	.qld__default-xs {
-		font-size: var(--QLD-default-mobile-xs);
-		line-height: 20px;
+    .qld__default-xs {
+        font-size: var(--QLD-default-mobile-xs);
+        line-height: 20px;
 
-		&.qld__heading-space {
-			line-height: var(--QLD-heading-space-xs);
-		}
-	}
+        &.qld__heading-space {
+            line-height: var(--QLD-heading-space-xs);
+        }
+    }
 
-	.qld__default-sm {
-		font-size: var(--QLD-default-mobile-sm);
-		line-height: 24px;
+    .qld__default-sm {
+        font-size: var(--QLD-default-mobile-sm);
+        line-height: 24px;
 
-		&.qld__heading-space {
-			line-height: var(--QLD-heading-space-sm);
-		}
-	}
+        &.qld__heading-space {
+            line-height: var(--QLD-heading-space-sm);
+        }
+    }
 
-	.qld__default-md {
-		font-size: var(--QLD-default-mobile-md);
-		line-height: 32px;
+    .qld__default-md {
+        font-size: var(--QLD-default-mobile-md);
+        line-height: 32px;
 
-		&.qld__heading-space {
-			line-height: var(--QLD-heading-space-md);
-		}
-	}
+        &.qld__heading-space {
+            line-height: var(--QLD-heading-space-md);
+        }
+    }
 
-	.qld__default-lg {
-		font-size: var(--QLD-default-mobile-lg);
-		line-height: 36px;
+    .qld__default-lg {
+        font-size: var(--QLD-default-mobile-lg);
+        line-height: 36px;
 
-		&.qld__heading-space {
-			line-height: var(--QLD-heading-space-lg);
-		}
-	}
+        &.qld__heading-space {
+            line-height: var(--QLD-heading-space-lg);
+        }
+    }
 
-	.qld__default-xl {
-		font-size: var(--QLD-default-mobile-xl);
-		line-height: 36px;
+    .qld__default-xl {
+        font-size: var(--QLD-default-mobile-xl);
+        line-height: 36px;
 
-		&.qld__heading-space {
-			line-height: var(--QLD-heading-space-xl);
-		}
-	}
+        &.qld__heading-space {
+            line-height: var(--QLD-heading-space-xl);
+        }
+    }
 
-	.qld__default-xxl {
-		font-size: var(--QLD-default-mobile-xxl);
-		line-height: 48px;
+    .qld__default-xxl {
+        font-size: var(--QLD-default-mobile-xxl);
+        line-height: 48px;
 
-		&.qld__heading-space {
-			line-height: var(--QLD-heading-space-xxl);
-		}
-	}
+        &.qld__heading-space {
+            line-height: var(--QLD-heading-space-xxl);
+        }
+    }
 
-	.qld__default-xxxl {
-		font-size: var(--QLD-default-mobile-xxxl);
-		line-height: 60px;
+    .qld__default-xxxl {
+        font-size: var(--QLD-default-mobile-xxxl);
+        line-height: 60px;
 
-		&.qld__heading-space {
-			line-height: var(--QLD-heading-space-xxxl);
-		}
-	}
+        &.qld__heading-space {
+            line-height: var(--QLD-heading-space-xxxl);
+        }
+    }
 
-	@include QLD-media(lg) {
-		.qld__default-xs {
-			font-size: var(--QLD-default-desktop-xs);
-			line-height: 20px;
-		}
+    @include QLD-media(lg) {
+        .qld__default-xs {
+            font-size: var(--QLD-default-desktop-xs);
+            line-height: 20px;
+        }
 
-		.qld__default-sm {
-			font-size: var(--QLD-default-desktop-sm);
-			line-height: 24px;
-		}
+        .qld__default-sm {
+            font-size: var(--QLD-default-desktop-sm);
+            line-height: 24px;
+        }
 
-		.qld__default-md {
-			font-size: var(--QLD-default-desktop-md);
-			line-height: 32px;
-		}
+        .qld__default-md {
+            font-size: var(--QLD-default-desktop-md);
+            line-height: 32px;
+        }
 
-		.qld__default-lg {
-			font-size: var(--QLD-default-desktop-lg);
-			line-height: 36px;
-		}
+        .qld__default-lg {
+            font-size: var(--QLD-default-desktop-lg);
+            line-height: 36px;
+        }
 
-		.qld__default-xl {
-			font-size: var(--QLD-default-desktop-xl);
-			line-height: 48px;
-		}
+        .qld__default-xl {
+            font-size: var(--QLD-default-desktop-xl);
+            line-height: 48px;
+        }
 
-		.qld__default-xxl {
-			font-size: var(--QLD-default-desktop-xxl);
-			line-height: 60px;
-		}
+        .qld__default-xxl {
+            font-size: var(--QLD-default-desktop-xxl);
+            line-height: 60px;
+        }
 
-		.qld__default-xxxl {
-			font-size: var(--QLD-default-desktop-xxxl);
-			line-height: 72px;
-		}
+        .qld__default-xxxl {
+            font-size: var(--QLD-default-desktop-xxxl);
+            line-height: 72px;
+        }
 
-		.qld__default-xs.qld__heading-space {
-			line-height: var(--QLD-heading-space-xs);
-		}
+        .qld__default-xs.qld__heading-space {
+            line-height: var(--QLD-heading-space-xs);
+        }
 
-		.qld__default-sm.qld__heading-space {
-			line-height: var(--QLD-heading-space-sm);
-		}
+        .qld__default-sm.qld__heading-space {
+            line-height: var(--QLD-heading-space-sm);
+        }
 
-		.qld__default-md.qld__heading-space {
-			line-height: var(--QLD-heading-space-md);
-		}
+        .qld__default-md.qld__heading-space {
+            line-height: var(--QLD-heading-space-md);
+        }
 
-		.qld__default-lg.qld__heading-space {
-			line-height: var(--QLD-heading-space-lg);
-		}
+        .qld__default-lg.qld__heading-space {
+            line-height: var(--QLD-heading-space-lg);
+        }
 
-		.qld__default-xl.qld__heading-space {
-			line-height: var(--QLD-heading-space-xl);
-		}
+        .qld__default-xl.qld__heading-space {
+            line-height: var(--QLD-heading-space-xl);
+        }
 
-		.qld__default-xxl.qld__heading-space {
-			line-height: var(--QLD-heading-space-xxl);
-		}
+        .qld__default-xxl.qld__heading-space {
+            line-height: var(--QLD-heading-space-xxl);
+        }
 
-		.qld__default-xxxl.qld__heading-space {
-			line-height: var(--QLD-heading-space-xxxl);
-		}
-	}
+        .qld__default-xxxl.qld__heading-space {
+            line-height: var(--QLD-heading-space-xxxl);
+        }
+    }
 }
 
 /**
@@ -320,175 +320,175 @@ a.qld__max-width {
 */
 
 .qld__border-radius--xs {
-	border-radius: $QLD-border-radius-xs;
+    border-radius: $QLD-border-radius-xs;
 }
 
 .qld__border-radius--sm {
-	border-radius: $QLD-border-radius-sm;
+    border-radius: $QLD-border-radius-sm;
 }
 
 .qld__border-radius--md {
-	border-radius: $QLD-border-radius-md;
+    border-radius: $QLD-border-radius-md;
 }
 
 .qld__border-radius--lg {
-	border-radius: $QLD-border-radius-md;
+    border-radius: $QLD-border-radius-md;
 
-	@include QLD-media(lg) {
-		border-radius: $QLD-border-radius-lg;
-	}
+    @include QLD-media(lg) {
+        border-radius: $QLD-border-radius-lg;
+    }
 }
 
 .qld__border-radius--lg {
-	border-radius: $QLD-border-radius-lg;
+    border-radius: $QLD-border-radius-lg;
 
-	@include QLD-media(lg) {
-		border-radius: $QLD-border-radius-xl;
-	}
+    @include QLD-media(lg) {
+        border-radius: $QLD-border-radius-xl;
+    }
 }
 
 /** 
   Spacing utility classes
 */
 * + * + .qld__margin-t-section {
-	margin-top: map-get($QLD-space-map, $QLD-margin__section--mobile) + px !important;
+    margin-top: map-get($QLD-space-map, $QLD-margin__section--mobile) + px !important;
 
-	@include QLD-media(lg) {
-		margin-top: map-get($QLD-space-map, $QLD-margin__section--desktop) + px !important;
-	}
+    @include QLD-media(lg) {
+        margin-top: map-get($QLD-space-map, $QLD-margin__section--desktop) + px !important;
+    }
 }
 
 * + .qld__margin-t-content-block {
-	margin-top: map-get($QLD-space-map, $QLD-margin__content-block--mobile) + px !important;
+    margin-top: map-get($QLD-space-map, $QLD-margin__content-block--mobile) + px !important;
 
-	@include QLD-media(lg) {
-		margin-top: map-get($QLD-space-map, $QLD-margin__content-block--desktop) + px !important;
-	}
+    @include QLD-media(lg) {
+        margin-top: map-get($QLD-space-map, $QLD-margin__content-block--desktop) + px !important;
+    }
 }
 
 * + .qld__margin-t-component {
-	margin-top: map-get($QLD-space-map, $QLD-margin__component--mobile) + px !important;
+    margin-top: map-get($QLD-space-map, $QLD-margin__component--mobile) + px !important;
 
-	@include QLD-media(lg) {
-		margin-top: map-get($QLD-space-map, $QLD-margin__component--desktop) + px !important;
-	}
+    @include QLD-media(lg) {
+        margin-top: map-get($QLD-space-map, $QLD-margin__component--desktop) + px !important;
+    }
 }
 
 * + .qld__margin-t-text-element {
-	margin-top: map-get($QLD-space-map, $QLD-margin__text-element--mobile) + px !important;
+    margin-top: map-get($QLD-space-map, $QLD-margin__text-element--mobile) + px !important;
 
-	@include QLD-media(lg) {
-		margin-top: map-get($QLD-space-map, $QLD-margin__text-element--desktop) + px !important;
-	}
+    @include QLD-media(lg) {
+        margin-top: map-get($QLD-space-map, $QLD-margin__text-element--desktop) + px !important;
+    }
 }
 
 * + .qld__margin-t-p {
-	margin-top: map-get($QLD-space-map, $QLD-margin__p--mobile) + px !important;
+    margin-top: map-get($QLD-space-map, $QLD-margin__p--mobile) + px !important;
 
-	@include QLD-media(lg) {
-		margin-top: map-get($QLD-space-map, $QLD-margin__p--desktop) + px !important;
-	}
+    @include QLD-media(lg) {
+        margin-top: map-get($QLD-space-map, $QLD-margin__p--desktop) + px !important;
+    }
 }
 
 * + .qld__margin-t-li--sm {
-	margin: 0;
-	padding: 0;
+    margin: 0;
+    padding: 0;
 
-	li,
-	ol,
-	ul {
-		margin-top: map-get($QLD-space-map, $QLD-margin__li-close--mobile) + px !important;
+    li,
+    ol,
+    ul {
+        margin-top: map-get($QLD-space-map, $QLD-margin__li-close--mobile) + px !important;
 
-		@include QLD-media(lg) {
-			margin-top: map-get($QLD-space-map, $QLD-margin__li-close--desktop) + px !important;
-		}
-	}
+        @include QLD-media(lg) {
+            margin-top: map-get($QLD-space-map, $QLD-margin__li-close--desktop) + px !important;
+        }
+    }
 }
 
 * + .qld__margin-t-li--lg {
-	margin: 0;
-	padding: 0;
+    margin: 0;
+    padding: 0;
 
-	li,
-	ol,
-	ul {
-		margin-top: map-get($QLD-space-map, $QLD-margin__li-wide--mobile) + px !important;
+    li,
+    ol,
+    ul {
+        margin-top: map-get($QLD-space-map, $QLD-margin__li-wide--mobile) + px !important;
 
-		@include QLD-media(lg) {
-			margin-top: map-get($QLD-space-map, $QLD-margin__li-wide--desktop) + px !important;
-		}
-	}
+        @include QLD-media(lg) {
+            margin-top: map-get($QLD-space-map, $QLD-margin__li-wide--desktop) + px !important;
+        }
+    }
 }
 
 * + .qld__margin-t-label {
-	margin-top: map-get($QLD-space-map, $QLD-margin__lables--mobile) + px !important;
+    margin-top: map-get($QLD-space-map, $QLD-margin__lables--mobile) + px !important;
 
-	@include QLD-media(lg) {
-		margin-top: map-get($QLD-space-map, $QLD-margin__lables--desktop) + px !important;
-	}
+    @include QLD-media(lg) {
+        margin-top: map-get($QLD-space-map, $QLD-margin__lables--desktop) + px !important;
+    }
 }
 
 * + .qld__margin-t-none {
-	margin-top: map-get($QLD-space-map, 0) + px !important;
+    margin-top: map-get($QLD-space-map, 0) + px !important;
 
-	@include QLD-media(lg) {
-		margin-top: map-get($QLD-space-map, 0) + px !important;
-	}
+    @include QLD-media(lg) {
+        margin-top: map-get($QLD-space-map, 0) + px !important;
+    }
 }
 
 * + .qld__padding-t-none {
-	padding-top: map-get($QLD-space-map, 0) + px !important;
+    padding-top: map-get($QLD-space-map, 0) + px !important;
 }
 
 /** 
   Spacing flex utility row classes
 */
 .qld__row-gap-content-block {
-	row-gap: map-get($QLD-space-map, $QLD-margin__content-block--mobile) + px !important;
+    row-gap: map-get($QLD-space-map, $QLD-margin__content-block--mobile) + px !important;
 
-	@include QLD-media(lg) {
-		row-gap: map-get($QLD-space-map, $QLD-margin__content-block--desktop) + px !important;
-	}
+    @include QLD-media(lg) {
+        row-gap: map-get($QLD-space-map, $QLD-margin__content-block--desktop) + px !important;
+    }
 }
 
 .qld__row-gap-component {
-	row-gap: map-get($QLD-space-map, $QLD-margin__component--mobile) + px !important;
+    row-gap: map-get($QLD-space-map, $QLD-margin__component--mobile) + px !important;
 
-	@include QLD-media(lg) {
-		row-gap: map-get($QLD-space-map, $QLD-margin__component--desktop) + px !important;
-	}
+    @include QLD-media(lg) {
+        row-gap: map-get($QLD-space-map, $QLD-margin__component--desktop) + px !important;
+    }
 }
 
 .qld__row-gap-text-element {
-	row-gap: map-get($QLD-space-map, $QLD-margin__text-element--mobile) + px !important;
+    row-gap: map-get($QLD-space-map, $QLD-margin__text-element--mobile) + px !important;
 
-	@include QLD-media(lg) {
-		row-gap: map-get($QLD-space-map, $QLD-margin__text-element--desktop) + px !important;
-	}
+    @include QLD-media(lg) {
+        row-gap: map-get($QLD-space-map, $QLD-margin__text-element--desktop) + px !important;
+    }
 }
 
 .qld__row-gap-p {
-	row-gap: map-get($QLD-space-map, $QLD-margin__p--mobile) + px !important;
+    row-gap: map-get($QLD-space-map, $QLD-margin__p--mobile) + px !important;
 
-	@include QLD-media(lg) {
-		row-gap: map-get($QLD-space-map, $QLD-margin__p--desktop) + px !important;
-	}
+    @include QLD-media(lg) {
+        row-gap: map-get($QLD-space-map, $QLD-margin__p--desktop) + px !important;
+    }
 }
 
 .qld__row-gap-li--sm {
-	row-gap: map-get($QLD-space-map, $QLD-margin__li-close--mobile) + px !important;
+    row-gap: map-get($QLD-space-map, $QLD-margin__li-close--mobile) + px !important;
 
-	@include QLD-media(lg) {
-		row-gap: map-get($QLD-space-map, $QLD-margin__li-close--desktop) + px !important;
-	}
+    @include QLD-media(lg) {
+        row-gap: map-get($QLD-space-map, $QLD-margin__li-close--desktop) + px !important;
+    }
 }
 
 .qld__row-gap-li--lg {
-	row-gap: map-get($QLD-space-map, $QLD-margin__li-wide--mobile) + px !important;
+    row-gap: map-get($QLD-space-map, $QLD-margin__li-wide--mobile) + px !important;
 
-	@include QLD-media(lg) {
-		row-gap: map-get($QLD-space-map, $QLD-margin__li-wide--desktop) + px !important;
-	}
+    @include QLD-media(lg) {
+        row-gap: map-get($QLD-space-map, $QLD-margin__li-wide--desktop) + px !important;
+    }
 }
 
 /** 
@@ -496,51 +496,51 @@ a.qld__max-width {
 */
 
 .qld__col-gap-content-block {
-	column-gap: map-get($QLD-space-map, $QLD-margin__content-block--mobile) + px !important;
+    column-gap: map-get($QLD-space-map, $QLD-margin__content-block--mobile) + px !important;
 
-	@include QLD-media(lg) {
-		column-gap: map-get($QLD-space-map, $QLD-margin__content-block--desktop) + px !important;
-	}
+    @include QLD-media(lg) {
+        column-gap: map-get($QLD-space-map, $QLD-margin__content-block--desktop) + px !important;
+    }
 }
 
 .qld__col-gap-component {
-	column-gap: map-get($QLD-space-map, $QLD-margin__component--mobile) + px !important;
+    column-gap: map-get($QLD-space-map, $QLD-margin__component--mobile) + px !important;
 
-	@include QLD-media(lg) {
-		column-gap: map-get($QLD-space-map, $QLD-margin__component--desktop) + px !important;
-	}
+    @include QLD-media(lg) {
+        column-gap: map-get($QLD-space-map, $QLD-margin__component--desktop) + px !important;
+    }
 }
 
 .qld__col-gap-text-element {
-	column-gap: map-get($QLD-space-map, $QLD-margin__text-element--mobile) + px !important;
+    column-gap: map-get($QLD-space-map, $QLD-margin__text-element--mobile) + px !important;
 
-	@include QLD-media(lg) {
-		column-gap: map-get($QLD-space-map, $QLD-margin__text-element--desktop) + px !important;
-	}
+    @include QLD-media(lg) {
+        column-gap: map-get($QLD-space-map, $QLD-margin__text-element--desktop) + px !important;
+    }
 }
 
 .qld__col-gap-p {
-	column-gap: map-get($QLD-space-map, $QLD-margin__p--mobile) + px !important;
+    column-gap: map-get($QLD-space-map, $QLD-margin__p--mobile) + px !important;
 
-	@include QLD-media(lg) {
-		column-gap: map-get($QLD-space-map, $QLD-margin__p--desktop) + px !important;
-	}
+    @include QLD-media(lg) {
+        column-gap: map-get($QLD-space-map, $QLD-margin__p--desktop) + px !important;
+    }
 }
 
 .qld__col-gap-li--sm {
-	column-gap: map-get($QLD-space-map, $QLD-margin__li-close--mobile) + px !important;
+    column-gap: map-get($QLD-space-map, $QLD-margin__li-close--mobile) + px !important;
 
-	@include QLD-media(lg) {
-		column-gap: map-get($QLD-space-map, $QLD-margin__li-close--desktop) + px !important;
-	}
+    @include QLD-media(lg) {
+        column-gap: map-get($QLD-space-map, $QLD-margin__li-close--desktop) + px !important;
+    }
 }
 
 .qld__col-gap-li--lg {
-	column-gap: map-get($QLD-space-map, $QLD-margin__li-wide--mobile) + px !important;
+    column-gap: map-get($QLD-space-map, $QLD-margin__li-wide--mobile) + px !important;
 
-	@include QLD-media(lg) {
-		column-gap: map-get($QLD-space-map, $QLD-margin__li-wide--desktop) + px !important;
-	}
+    @include QLD-media(lg) {
+        column-gap: map-get($QLD-space-map, $QLD-margin__li-wide--desktop) + px !important;
+    }
 }
 
 /*   New Classes that apply the form sizes variables
@@ -554,77 +554,77 @@ input.qld__text-input--block.qld__field-width--2char,
 .qld__select:has(select.qld__text-input--block.qld__field-width--2char),
 .qld__select:has(select.qld__select-control.qld__field-width--2char),
 textarea.qld__text-input--block.qld__field-width--2char {
-	max-width: $QLD-fixed-width__char-2;
+    max-width: $QLD-fixed-width__char-2;
 }
 
 input.qld__text-input--block.qld__field-width--3char,
 .qld__select:has(select.qld__text-input--block.qld__field-width--3char),
 .qld__select:has(select.qld__select-control.qld__field-width--3char),
 textarea.qld__text-input--block.qld__field-width--3char {
-	max-width: $QLD-fixed-width__char-3;
+    max-width: $QLD-fixed-width__char-3;
 }
 
 input.qld__text-input--block.qld__field-width--4char,
 .qld__select:has(select.qld__text-input--block.qld__field-width--4char),
 .qld__select:has(select.qld__select-control.qld__field-width--4char),
 textarea.qld__text-input--block.qld__field-width--4char {
-	max-width: $QLD-fixed-width__char-4;
+    max-width: $QLD-fixed-width__char-4;
 }
 
 input.qld__text-input--block.qld__field-width--5char,
 .qld__select:has(select.qld__text-input--block.qld__field-width--5char),
 .qld__select:has(select.qld__select-control.qld__field-width--5char),
 textarea.qld__text-input--block.qld__field-width--5char {
-	max-width: $QLD-fixed-width__char-5;
+    max-width: $QLD-fixed-width__char-5;
 }
 
 input.qld__text-input--block.qld__field-width--10char,
 .qld__select:has(select.qld__text-input--block.qld__field-width--10char),
 .qld__select:has(select.qld__select-control.qld__field-width--10char),
 textarea.qld__text-input--block.qld__field-width--10char {
-	max-width: $QLD-fixed-width__char-10;
+    max-width: $QLD-fixed-width__char-10;
 }
 
 input.qld__text-input--block.qld__field-width--20char,
 .qld__select:has(select.qld__text-input--block.qld__field-width--20char),
 .qld__select:has(select.qld__select-control.qld__field-width--20char),
 textarea.qld__text-input--block.qld__field-width--20char {
-	max-width: $QLD-fixed-width__char-20;
+    max-width: $QLD-fixed-width__char-20;
 }
 
 input.qld__text-input--block.qld__field-width--xs,
 .qld__select:has(select.qld__text-input--block.qld__field-width--xs),
 .qld__select:has(select.qld__select-control.qld__field-width--xs),
 textarea.qld__text-input--block.qld__field-width--xs {
-	max-width: $QLD-form-input__width-xs;
+    max-width: $QLD-form-input__width-xs;
 }
 
 input.qld__text-input--block.qld__field-width--sm,
 .qld__select:has(select.qld__text-input--block.qld__field-width--sm),
 .qld__select:has(select.qld__select-control.qld__field-width--sm),
 textarea.qld__text-input--block.qld__field-width--sm {
-	max-width: $QLD-form-input__width-sm;
+    max-width: $QLD-form-input__width-sm;
 }
 
 input.qld__text-input--block.qld__field-width--md,
 .qld__select:has(select.qld__text-input--block.qld__field-width--md),
 .qld__select:has(select.qld__select-control.qld__field-width--md),
 textarea.qld__text-input--block.qld__field-width--md {
-	max-width: $QLD-form-input__width-md;
+    max-width: $QLD-form-input__width-md;
 }
 
 input.qld__text-input--block.qld__field-width--lg,
 .qld__select:has(select.qld__text-input--block.qld__field-width--lg),
 .qld__select:has(select.qld__select-control.qld__field-width--lg),
 textarea.qld__text-input--block.qld__field-width--lg {
-	max-width: $QLD-form-input__width-lg;
+    max-width: $QLD-form-input__width-lg;
 }
 
 input.qld__text-input--block.qld__field-width--xl,
 .qld__select:has(select.qld__text-input--block.qld__field-width--xl),
 .qld__select:has(select.qld__select-control.qld__field-width--xl),
 textarea.qld__text-input--block.qld__field-width--xl {
-	max-width: $QLD-form-input__width-xl;
+    max-width: $QLD-form-input__width-xl;
 }
 
 /*  Default for all fluid styls is full - these are adjusts at larger break points, they keeps the fluid width style fomrs looking good on mobile  */
@@ -633,51 +633,51 @@ input.qld__text-input--block.qld__field-width--full,
 .qld__select:has(select.qld__text-input--block.qld__field-width--full),
 .qld__select:has(select.qld__select-control.qld__field-width--full),
 textarea.qld__text-input--block.qld__field-width--full {
-	max-width: $QLD-fluid-width__full;
+    max-width: $QLD-fluid-width__full;
 }
 
 input.qld__text-input--block.qld__field-width--3-quarters,
 .qld__select:has(select.qld__text-input--block.qld__field-width--3-quarters),
 .qld__select:has(select.qld__select-control.qld__field-width--3-quarters),
 textarea.qld__text-input--block.qld__field-width--3-quarters {
-	max-width: $QLD-fluid-width__full;
+    max-width: $QLD-fluid-width__full;
 }
 
 input.qld__text-input--block.qld__field-width--half,
 .qld__select:has(select.qld__text-input--block.qld__field-width--half),
 .qld__select:has(select.qld__select-control.qld__field-width--half),
 textarea.qld__text-input--block.qld__field-width--half {
-	max-width: $QLD-fluid-width__full;
+    max-width: $QLD-fluid-width__full;
 }
 
 input.qld__text-input--block.qld__field-width--1-quarter,
 .qld__select:has(select.qld__text-input--block.qld__field-width--1-quarter),
 .qld__select:has(select.qld__select-control.qld__field-width--1-quarter),
 textarea.qld__text-input--block.qld__field-width--1-quarter {
-	max-width: $QLD-fluid-width__full;
+    max-width: $QLD-fluid-width__full;
 }
 
 @include QLD-media(md) {
-	input.qld__text-input--block.qld__field-width--1-quarter,
-	.qld__select:has(select.qld__text-input--block.qld__field-width--1-quarter),
-	.qld__select:has(select.qld__select-control.qld__field-width--1-quarter),
-	textarea.qld__text-input--block.qld__field-width--1-quarter {
-		max-width: $QLD-fluid-width__1-quarter;
-	}
+    input.qld__text-input--block.qld__field-width--1-quarter,
+    .qld__select:has(select.qld__text-input--block.qld__field-width--1-quarter),
+    .qld__select:has(select.qld__select-control.qld__field-width--1-quarter),
+    textarea.qld__text-input--block.qld__field-width--1-quarter {
+        max-width: $QLD-fluid-width__1-quarter;
+    }
 
-	input.qld__text-input--block.qld__field-width--half,
-	.qld__select:has(select.qld__text-input--block.qld__field-width--half),
-	.qld__select:has(select.qld__select-control.qld__field-width--half),
-	textarea.qld__text-input--block.qld__field-width--half {
-		max-width: $QLD-fluid-width__half;
-	}
+    input.qld__text-input--block.qld__field-width--half,
+    .qld__select:has(select.qld__text-input--block.qld__field-width--half),
+    .qld__select:has(select.qld__select-control.qld__field-width--half),
+    textarea.qld__text-input--block.qld__field-width--half {
+        max-width: $QLD-fluid-width__half;
+    }
 
-	input.qld__text-input--block.qld__field-width--3-quarters,
-	.qld__select:has(select.qld__text-input--block.qld__field-width--3-quarters),
-	.qld__select:has(select.qld__select-control.qld__field-width--3-quarters),
-	textarea.qld__text-input--block.qld__field-width--3-quarters {
-		max-width: $QLD-fluid-width__3-quarters;
-	}
+    input.qld__text-input--block.qld__field-width--3-quarters,
+    .qld__select:has(select.qld__text-input--block.qld__field-width--3-quarters),
+    .qld__select:has(select.qld__select-control.qld__field-width--3-quarters),
+    textarea.qld__text-input--block.qld__field-width--3-quarters {
+        max-width: $QLD-fluid-width__3-quarters;
+    }
 }
 
 /*
@@ -685,67 +685,140 @@ Written to address squiz forms' error state issues
 */
 
 div.sq-form-question-tickbox-list.sq-form-question-error {
-	fieldset {
-		label::before {
-			box-shadow: 0 0 0 3px $QLD-color-status__error;
-		}
-	}
+    fieldset {
+        label::before {
+            box-shadow: 0 0 0 3px $QLD-color-status__error;
+        }
+    }
 }
 
 div.sq-form-question-option-list.sq-form-question-error {
-	fieldset {
-		label::before {
-			box-shadow: 0 0 0 3px $QLD-color-status__error;
-		}
-	}
+    fieldset {
+        label::before {
+            box-shadow: 0 0 0 3px $QLD-color-status__error;
+        }
+    }
 }
 
 div.sq-form-question-error {
-	input[type="text"]:not(:focus),
-	input[type="email"]:not(:focus),
-	input[type="date"]:not(:focus),
-	textarea:not(:focus),
-	select:not(:focus) {
-		border-color: $QLD-color-status__error;
-		background-color: $QLD-color-status__error--lightest;
-	}
+    input[type="text"]:not(:focus),
+    input[type="email"]:not(:focus),
+    input[type="date"]:not(:focus),
+    textarea:not(:focus),
+    select:not(:focus) {
+        border-color: $QLD-color-status__error;
+        background-color: $QLD-color-status__error--lightest;
+    }
 }
 
 .qld__body--dark,
 .qld__body--dark-alt {
-	.sq-form-error {
-		color: $QLD-color-status__error--lightest;
-	}
+    .sq-form-error {
+        color: $QLD-color-status__error--lightest;
+    }
 }
 
 .sq-form-error {
-	color: $QLD-color-status__error;
+    color: $QLD-color-status__error;
 }
 
 .qld__text-columns-2 {
-	/* Margin removed for utility-based spacing */
+    /* Margin removed for utility-based spacing */
 
-	@media screen and (min-width: 992px) {
-		column-count: 2;
-		column-gap: 2rem;
+    @media screen and (min-width: 992px) {
+        column-count: 2;
+        column-gap: 2rem;
 
-		/* Prevent headings from breaking across columns (limited browser support) */
-		.qld__text-columns-2 h1,
-		.qld__text-columns-2 h2,
-		.qld__text-columns-2 h3,
-		.qld__text-columns-2 h4,
-		.qld__text-columns-2 h5,
-		.qld__text-columns-2 h6 {
-			break-after: avoid;
-			break-inside: avoid;
-			page-break-after: avoid;
-		}
+        /* Prevent headings from breaking across columns (limited browser support) */
+        .qld__text-columns-2 h1,
+        .qld__text-columns-2 h2,
+        .qld__text-columns-2 h3,
+        .qld__text-columns-2 h4,
+        .qld__text-columns-2 h5,
+        .qld__text-columns-2 h6 {
+            break-after: avoid;
+            break-inside: avoid;
+            page-break-after: avoid;
+        }
 
-		/* Utility to keep block-level content together in one column */
-		.qld__keep-together {
-			break-inside: avoid;
-			display: inline-block;
-			width: 100%;
-		}
-	}
+        /* Utility to keep block-level content together in one column */
+        .qld__keep-together {
+            break-inside: avoid;
+            display: inline-block;
+            width: 100%;
+        }
+    }
+}
+
+// Spacing utility classes
+.mt-0 {
+    @include QLD-space(margin-top, 0);
+}
+
+.mt-1 {
+    @include QLD-space(margin-top, 1unit);
+}
+
+.mt-2 {
+    @include QLD-space(margin-top, 2unit);
+}
+
+.mt-3 {
+    @include QLD-space(margin-top, 3unit);
+}
+
+.mb-0 {
+    @include QLD-space(margin-bottom, 0);
+}
+
+.mb-1 {
+    @include QLD-space(margin-bottom, 1unit);
+}
+
+.mb-2 {
+    @include QLD-space(margin-bottom, 2unit);
+}
+
+.mb-3 {
+    @include QLD-space(margin-bottom, 3unit);
+}
+
+.mx-0 {
+    @include QLD-space(margin-left, 0);
+    @include QLD-space(margin-right, 0);
+}
+
+.mx-1 {
+    @include QLD-space(margin-left, 1unit);
+    @include QLD-space(margin-right, 1unit);
+}
+
+.mx-2 {
+    @include QLD-space(margin-left, 2unit);
+    @include QLD-space(margin-right, 2unit);
+}
+
+.mx-3 {
+    @include QLD-space(margin-left, 3unit);
+    @include QLD-space(margin-right, 3unit);
+}
+
+.my-0 {
+    @include QLD-space(margin-top, 0);
+    @include QLD-space(margin-bottom, 0);
+}
+
+.my-1 {
+    @include QLD-space(margin-top, 1unit);
+    @include QLD-space(margin-bottom, 1unit);
+}
+
+.my-2 {
+    @include QLD-space(margin-top, 2unit);
+    @include QLD-space(margin-bottom, 2unit);
+}
+
+.my-3 {
+    @include QLD-space(margin-top, 3unit);
+    @include QLD-space(margin-bottom, 3unit);
 }


### PR DESCRIPTION
This pull request adds a set of spacing utility classes to the `utilities.scss` file, making it easier to apply consistent margin spacing throughout the application using predefined class names.

Spacing utility classes:

* Added `.mt-*`, `.mb-*`, `.mx-*`, and `.my-*` classes for top, bottom, horizontal, and vertical margins, respectively, with values ranging from 0 to 3 units, all utilizing the `QLD-space` mixin for consistent spacing.