### PR TITLE
 QHDEV-632 | Banner | Add banner textures to banner colour

### DIFF
--- a/src/components/banner/html/component.hbs
+++ b/src/components/banner/html/component.hbs
@@ -6,11 +6,39 @@
 
     {{#ifCond current.data.metadata.displayBreadcrumbs.value '==' 'true'}}qld__banner--breadcrumbs{{/ifCond}}
     "
-    {{#ifCond site.metadata.defaultBannerType.value '==' 'texture'}}
-    style="background-image: url(./?a={{site.metadata.defaultBannerTexture.value}});"
+    {{#ifCond @root.site.metadata.defaultBannerColour.value '==' 'light'}}
+        {{#ifCond @root.site.metadata.defaultBannerType.value '==' 'texture'}}
+            {{#if @root.site.metadata.defaultBannerTexture.value}}
+                style="background-image: url({{@root.site.metadata.defaultBannerTextureUrl.value}});"
+            {{/if}}
+        {{/ifCond}}
     {{/ifCond}}
-    
+
+        {{#ifCond @root.site.metadata.defaultBannerColour.value '==' 'alternate'}}
+        {{#ifCond @root.site.metadata.defaultBannerType.value '==' 'texture'}}
+            {{#if @root.site.metadata.defaultBannerTexture.value}}
+                style="background-image: url({{@root.site.metadata.defaultBannerTextureUrl.value}});"
+            {{/if}}
+        {{/ifCond}}
+    {{/ifCond}}
+
+    {{#ifCond @root.site.metadata.defaultBannerColour.value '==' 'dark'}}
+        {{#ifCond @root.site.metadata.defaultBannerType.value '==' 'texture'}}
+            {{#if @root.site.metadata.defaultBannerTextureDark.value}}
+                style="background-image: url({{@root.site.metadata.defaultBannerTextureDarkUrl.value}});"
+            {{/if}}
+        {{/ifCond}}
+    {{/ifCond}}
+
+    {{#ifCond @root.site.metadata.defaultBannerColour.value '==' 'dark-alternate'}}
+        {{#ifCond @root.site.metadata.defaultBannerType.value '==' 'texture'}}
+            {{#if @root.site.metadata.defaultBannerTextureDark.value}}
+                style="background-image: url({{@root.site.metadata.defaultBannerTextureDarkUrl.value}});"
+            {{/if}}
+        {{/ifCond}}
+    {{/ifCond}}
 >
+
 <!--@@ Breadcrumbs - Mobile @@-->
 {{#ifCond current.data.metadata.displayBreadcrumbs.value '==' 'true'}}
     <nav class="qld__breadcrumbs qld__banner__breadcrumbs qld__banner__breadcrumbs--mobile" aria-label="breadcrumb">


### PR DESCRIPTION
This pull request updates the logic in the `banner` component template to support different banner background textures based on the selected banner colour theme. The changes ensure that the correct texture image URL is applied for each banner colour variant, improving flexibility and visual consistency.

Banner background texture logic improvements:

* Updated the conditional logic in `component.hbs` to apply the appropriate background image URL based on the value of `defaultBannerColour` (`light`, `alternate`, `dark`, or `dark-alternate`) and whether the banner type is set to `texture`. The template now uses the corresponding texture URL for each colour variant, including support for both light and dark texture URLs.