### PR TITLE
QHDEV-648 | CTA Links | Update cta link chevron to handle link wrapping

### DIFF
--- a/src/components/_global/css/cta_links/component.scss
+++ b/src/components/_global/css/cta_links/component.scss
@@ -14,7 +14,7 @@ a.qld__cta-link {
 
     &::before {
         @include QLD-space(width, 1unit);
-        top: 50%;
+        top: 1rem;
         right: 0.3rem;
     }
 

--- a/src/components/_global/css/link_columns/component.scss
+++ b/src/components/_global/css/link_columns/component.scss
@@ -43,6 +43,14 @@
             padding-right: 2rem;
         }
 
+        // Rule that ensures that if a cta-link is used in the link columns, the correct arrow is displayed
+        a.qld__cta-link:not(.qld__cta-link--view-all) {
+            &::before,
+            &::after {
+                display: none;
+            }
+        }
+
         &::before {
             @include QLD-space(margin, 0 0.5unit 0 0.5unit);
             flex: 0 0 auto;

--- a/src/stories/CTALink/CTALink.stories.js
+++ b/src/stories/CTALink/CTALink.stories.js
@@ -57,9 +57,6 @@ export default {
 
 export const Default = {};
 
-export const defaultVariant = (ctaLinkArgs) => CTALink({ ...ctaLinkArgs });
-defaultVariant.tags = ["!dev"];
-
 export const viewAllVariant = (ctaLinkArgs) =>
     CTALink({
         ...ctaLinkArgs,
@@ -76,20 +73,69 @@ disabledVariant.tags = ["!dev"];
 
 export const linkedListExample = (ctaLinkArgs) => {
     return `
-        <ul class="qld__link-list qld__margin-t-li--lg">
+        <ul aria-label="Related links" class="qld__link-columns qld__link-columns--2-col">
             <li>${CTALink({
                 ...ctaLinkArgs,
-                text: "Sign up",
-                href: "javascript:void(0);",
-                target: "",
+                text: "Contact us",
             })}</li>
             <li>${CTALink({
+                ...ctaLinkArgs,
+                text: "About us",
+            })}</li>
+            <li>${CTALink({
+                ...ctaLinkArgs,
+                text: "Products",
+            })}</li>
+            <li>${CTALink({
+                ...ctaLinkArgs,
+                text: "FAQ",
+            })}</li>
+            <li>${CTALink({
+                ...ctaLinkArgs,
+                text: "Terms and conditions",
+            })}</li>
+            <li>${CTALink({
+                ...ctaLinkArgs,
+                text: "Privacy policy",
+            })}</li>
+            <li>${CTALink({
+                ...ctaLinkArgs,
+                text: "Blog",
+            })}</li>
+            <li>${CTALink({
+                ...ctaLinkArgs,
+                text: "Careers",
+            })}</li>
+            <li>${CTALink({
+                ...ctaLinkArgs,
+                text: "Press",
+            })}</li>
+            <li>${CTALink({
+                ...ctaLinkArgs,
+                text: "Resources",
+            })}</li>
+            <li>${CTALink({
+                ...ctaLinkArgs,
+                text: "Partners",
+            })}</li>
+            <li>${CTALink({
+                ...ctaLinkArgs,
+                text: "Events",
+            })}</li>
+            <li>${CTALink({
+                ...ctaLinkArgs,
+                text: "Community",
+            })}</li>
+            <li>${CTALink({
+                ...ctaLinkArgs,
+                text: "Sitemap",
+            })}</li>
+            <li class="qld__link-columns__all-link">${CTALink({
                 ...ctaLinkArgs,
                 text: "View all",
-                href: "javascript:void(0);",
-                target: "",
                 isViewAll: true,
-            })}</li>
+            })}
+            </li>
         </ul>
     `;
 };
@@ -98,43 +144,54 @@ linkedListExample.parameters = {
     actions: { disable: true },
 };
 
-const allVariants = () => {
+export const longCtaLinkExample = (ctaLinkArgs) => {
+    return `
+        <div style="width: 300px;">
+            ${CTALink({
+                ...ctaLinkArgs,
+                text: "Super super long link super long link super long link super long link",
+            })}
+        </div>
+    `;
+};
+
+const allVariants = (args) => {
     return `
         <h3>Default</h3>
-        ${defaultVariant(ctaLinkArgs)}
+        ${CTALink(args)}
         <h3>View all</h3>
-        ${viewAllVariant(ctaLinkArgs)}
+        ${viewAllVariant(args)}
         <h3>Disabled</h3>
-        ${disabledVariant(ctaLinkArgs)}
+        ${disabledVariant(args)}
     `;
 };
 
 export const white = {
-    render: () => {
-        return themeWrapper(themes["white"], allVariants());
+    render: (args) => {
+        return themeWrapper(themes["white"], allVariants(args));
     },
 };
 
 export const light = {
-    render: () => {
-        return themeWrapper(themes["light"], allVariants());
+    render: (args) => {
+        return themeWrapper(themes["light"], allVariants(args));
     },
 };
 
 export const lightAlt = {
-    render: () => {
-        return themeWrapper(themes["light alt"], allVariants());
+    render: (args) => {
+        return themeWrapper(themes["light alt"], allVariants(args));
     },
 };
 
 export const dark = {
-    render: () => {
-        return themeWrapper(themes["dark"], allVariants());
+    render: (args) => {
+        return themeWrapper(themes["dark"], allVariants(args));
     },
 };
 
 export const darkAlt = {
-    render: () => {
-        return themeWrapper(themes["dark alt"], allVariants());
+    render: (args) => {
+        return themeWrapper(themes["dark alt"], allVariants(args));
     },
 };


### PR DESCRIPTION
This pull request updates the `CTALink` component styles and its Storybook stories to improve support for link columns layouts, refines the display of call-to-action (CTA) arrows, and enhances the demonstration of the component's variants. The changes streamline the code, improve accessibility, and ensure that CTA links render correctly in different contexts.

**Styling and Layout Adjustments:**

* Added a specific CSS rule in `link_columns/component.scss` to hide the default CTA arrow icons when a CTA link is used within link columns, except for the "View all" variant. This ensures visual consistency and prevents duplicate or misplaced arrows.
* Adjusted the positioning of the CTA link arrow in `cta_links/component.scss` by changing the `top` property from `50%` to `1rem` for better alignment.

**Storybook and Demo Improvements:**

* Updated the `linkedListExample` story to use the `qld__link-columns` layout with an ARIA label for accessibility, and expanded the example to include a broader set of link types, demonstrating how the CTA link behaves in a column layout.
* Added a new `longCtaLinkExample` story to showcase how the CTA link handles very long link text within a constrained width.
* Refactored variant rendering in the stories: removed the unused `defaultVariant`, and updated the theme stories (`white`, `light`, `lightAlt`, `dark`, `darkAlt`) to pass arguments correctly, improving code clarity and flexibility for testing different variants. [[1]](diffhunk://#diff-17c2ae2ca3c479f46f9846c450f48d6411651bc4307483edc6f11ce724f9c26cL60-L62) [[2]](diffhunk://#diff-17c2ae2ca3c479f46f9846c450f48d6411651bc4307483edc6f11ce724f9c26cL101-R195)