### PR TITLE
Setup vitest to test storybook stories locally

### DIFF
--- a/.storybook/assets/index.js
+++ b/.storybook/assets/index.js
@@ -3,10 +3,6 @@ import "../core-assets/handlebar-helpers.js";
 import initAnimate from "./animate-js.js";
 import initAccordion from "./accordion-js.js";
 import { initBreadcrumbs, getTheElements } from "./breadcrumbs-js.js";
-import initComponents from "../../src/component-loader.js";
-
-// ES module initialisation for Core components
-initComponents();
 
 // ES module initialisation for Storybook specific components
 document.addEventListener("DOMContentLoaded", () => {

--- a/.storybook/decorators.js
+++ b/.storybook/decorators.js
@@ -1,0 +1,36 @@
+/**
+ * Decorator factory that runs component init functions after each story renders.
+ *
+ * The DOM isn't ready when a Storybook decorator runs synchronously, so init
+ * is deferred via setTimeout. Each init function receives the story's
+ * canvasElement as its root, scoping any DOM queries to that story's container.
+ * This makes the decorator safe in docs mode where multiple stories share the
+ * same page.
+ *
+ * Init functions may optionally return a cleanup function. If they do, it will
+ * be called before the next render — covering both story navigation and arg
+ * changes — to remove any event listeners or other side effects.
+ *
+ * @param {Array<function(HTMLElement): (function|void)>} initFunctions
+ * @returns {function} Storybook decorator
+ *
+ * @example
+ * // In a stories file:
+ * export default {
+ *     decorators: [initComponents([initMegaMenu, initToggleTip])],
+ * };
+ */
+export function initComponents(initFunctions = []) {
+    let cleanups = [];
+    return (storyFn, context) => {
+        cleanups.forEach((fn) => fn?.());
+        cleanups = [];
+        const story = storyFn();
+        setTimeout(() => {
+            cleanups = initFunctions
+                .map((initFunction) => initFunction(context.canvasElement))
+                .filter(Boolean);
+        }, 0);
+        return story;
+    };
+}

--- a/.storybook/decorators.js
+++ b/.storybook/decorators.js
@@ -7,15 +7,15 @@
  * This makes the decorator safe in docs mode where multiple stories share the
  * same page.
  *
- * Init functions may optionally return a cleanup function. If they do, it will
+ * Init functions may optionally return a clean-up function. If they do, it will
  * be called before the next render — covering both story navigation and arg
  * changes — to remove any event listeners or other side effects.
  *
- * @param {Array<function(HTMLElement): (function|void)>} initFunctions
+ * @param {Array<function(Document|Element): (function|void)>} initFunctions
  * @returns {function} Storybook decorator
  *
  * @example
- * // In a stories file:
+ * // In a story file:
  * export default {
  *     decorators: [initComponents([initMegaMenu, initToggleTip])],
  * };

--- a/.storybook/main.js
+++ b/.storybook/main.js
@@ -4,7 +4,14 @@ import hbsPlugin from "./vite-plugin-hbs.js";
 
 const config = {
     stories: ["../src/**/*.mdx", "../src/**/*.stories.@(js|jsx|mjs|ts|tsx)"],
-    addons: ["@storybook/addon-a11y", "@storybook/addon-themes", "@storybook/addon-designs", "@storybook/addon-docs", "@storybook/addon-vitest"],
+    addons: [
+        "@storybook/addon-a11y",
+        "@storybook/addon-themes",
+        "@storybook/addon-designs",
+        "@storybook/addon-docs",
+        "@storybook/addon-vitest",
+        "@chromatic-com/storybook"
+    ],
     framework: {
         name: "@storybook/html-vite",
         options: {},

--- a/.storybook/main.js
+++ b/.storybook/main.js
@@ -1,17 +1,17 @@
 /** @type { import('@storybook/html-vite').StorybookConfig } */
 import sassGlobImports from "vite-plugin-sass-glob-import";
-import hbsPlugin from "./vite-plugin-hbs.js"
+import hbsPlugin from "./vite-plugin-hbs.js";
 
 const config = {
     stories: ["../src/**/*.mdx", "../src/**/*.stories.@(js|jsx|mjs|ts|tsx)"],
-    addons: ["@storybook/addon-a11y", "@storybook/addon-themes", "@storybook/addon-designs", "@storybook/addon-docs"],
+    addons: ["@storybook/addon-a11y", "@storybook/addon-themes", "@storybook/addon-designs", "@storybook/addon-docs", "@storybook/addon-vitest"],
     framework: {
         name: "@storybook/html-vite",
         options: {},
     },
     async viteFinal(config) {
         config.plugins.push(sassGlobImports());
-        config.plugins.push(hbsPlugin())
+        config.plugins.push(hbsPlugin());
         return config;
     },
     staticDirs: ["../dist/mysource_files/img", "./core-assets", "./assets"],

--- a/chromatic.config.json
+++ b/chromatic.config.json
@@ -1,0 +1,5 @@
+{
+  "onlyChanged": true,
+  "projectId": "Project:68140a0f3433aefd633f34b7",
+  "zip": true
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -32,7 +32,9 @@
                 "@storybook/addon-designs": "^11.1.3",
                 "@storybook/addon-docs": "^10.4.0",
                 "@storybook/addon-themes": "^10.4.0",
+                "@storybook/addon-vitest": "^10.4.1",
                 "@storybook/html-vite": "^10.4.0",
+                "@vitest/browser-playwright": "^4.1.7",
                 "autoprefixer": "^10.4.14",
                 "chromatic": "^17.0.0",
                 "copy-webpack-plugin": "^11.0.0",
@@ -51,6 +53,7 @@
                 "imports-loader": "^4.0.1",
                 "jsdoc": "^4.0.2",
                 "mini-css-extract-plugin": "^2.7.6",
+                "playwright": "^1.60.0",
                 "postcss-loader": "^7.3.3",
                 "postcss-scss": "^4.0.9",
                 "prettier": "3.8.3",
@@ -66,6 +69,7 @@
                 "url-loader": "^4.1.1",
                 "vite": "^7.2.6",
                 "vite-plugin-sass-glob-import": "^6.0.2",
+                "vitest": "^4.1.7",
                 "webpack": "^5.88.0",
                 "webpack-cli": "^5.1.4",
                 "webpack-dev-server": "^4.15.1"
@@ -1721,6 +1725,13 @@
             "engines": {
                 "node": ">=6.9.0"
             }
+        },
+        "node_modules/@blazediff/core": {
+            "version": "1.9.1",
+            "resolved": "https://registry.npmjs.org/@blazediff/core/-/core-1.9.1.tgz",
+            "integrity": "sha512-ehg3jIkYKulZh+8om/O25vkvSsXXwC+skXmyA87FFx6A/45eqOkZsBltMw/TVteb0mloiGT8oGRTcjRAz66zaA==",
+            "dev": true,
+            "license": "MIT"
         },
         "node_modules/@cacheable/memory": {
             "version": "2.0.9",
@@ -4014,6 +4025,13 @@
                 "prettier": ">=3.0.0"
             }
         },
+        "node_modules/@polka/url": {
+            "version": "1.0.0-next.29",
+            "resolved": "https://registry.npmjs.org/@polka/url/-/url-1.0.0-next.29.tgz",
+            "integrity": "sha512-wwQAWhWSuHaag8c4q/KN/vCoeOJYshAIvMQwD4GpSb3OiZklFfvAgmj0VCBBImRpuF/aFgIRzllXlVX93Jevww==",
+            "dev": true,
+            "license": "MIT"
+        },
         "node_modules/@rollup/rollup-android-arm-eabi": {
             "version": "4.53.3",
             "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.53.3.tgz",
@@ -4356,6 +4374,13 @@
                 "url": "https://github.com/sponsors/sindresorhus"
             }
         },
+        "node_modules/@standard-schema/spec": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.1.0.tgz",
+            "integrity": "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==",
+            "dev": true,
+            "license": "MIT"
+        },
         "node_modules/@storybook/addon-a11y": {
             "version": "10.4.0",
             "resolved": "https://registry.npmjs.org/@storybook/addon-a11y/-/addon-a11y-10.4.0.tgz",
@@ -4445,6 +4470,42 @@
             },
             "peerDependencies": {
                 "storybook": "^10.4.0"
+            }
+        },
+        "node_modules/@storybook/addon-vitest": {
+            "version": "10.4.2",
+            "resolved": "https://registry.npmjs.org/@storybook/addon-vitest/-/addon-vitest-10.4.2.tgz",
+            "integrity": "sha512-gq1ZVr0IOLgiS2PzaJqHxKLczwrXvA5g3W2k/FVJA19fJNFNUut1IyQCQRSJTXLLXbnNaa8I0wjGGc2BoLarJg==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@storybook/global": "^5.0.0",
+                "@storybook/icons": "^2.0.2"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/storybook"
+            },
+            "peerDependencies": {
+                "@vitest/browser": "^3.0.0 || ^4.0.0",
+                "@vitest/browser-playwright": "^4.0.0",
+                "@vitest/runner": "^3.0.0 || ^4.0.0",
+                "storybook": "^10.4.2",
+                "vitest": "^3.0.0 || ^4.0.0"
+            },
+            "peerDependenciesMeta": {
+                "@vitest/browser": {
+                    "optional": true
+                },
+                "@vitest/browser-playwright": {
+                    "optional": true
+                },
+                "@vitest/runner": {
+                    "optional": true
+                },
+                "vitest": {
+                    "optional": true
+                }
             }
         },
         "node_modules/@storybook/builder-vite": {
@@ -5240,6 +5301,101 @@
                 "url": "https://opencollective.com/eslint"
             }
         },
+        "node_modules/@vitest/browser": {
+            "version": "4.1.8",
+            "resolved": "https://registry.npmjs.org/@vitest/browser/-/browser-4.1.8.tgz",
+            "integrity": "sha512-u21VzX07HzlJYpFgkxmjEXar/tG2UqWGgyGG/46SrrPc7rSdCTPw5vuowopO9CIqF8UCUQzDFdbVnNpw6N0BfQ==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@blazediff/core": "1.9.1",
+                "@vitest/mocker": "4.1.8",
+                "@vitest/utils": "4.1.8",
+                "magic-string": "^0.30.21",
+                "pngjs": "^7.0.0",
+                "sirv": "^3.0.2",
+                "tinyrainbow": "^3.1.0",
+                "ws": "^8.19.0"
+            },
+            "funding": {
+                "url": "https://opencollective.com/vitest"
+            },
+            "peerDependencies": {
+                "vitest": "4.1.8"
+            }
+        },
+        "node_modules/@vitest/browser-playwright": {
+            "version": "4.1.8",
+            "resolved": "https://registry.npmjs.org/@vitest/browser-playwright/-/browser-playwright-4.1.8.tgz",
+            "integrity": "sha512-SR7FqgegaexEg73xvf3ArtygXegagMdXnL0EZMpxrWvvhQxvicD/E8p0ib0J91riPRtQUViyh67Xjw3NqvyhVg==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@vitest/browser": "4.1.8",
+                "@vitest/mocker": "4.1.8",
+                "tinyrainbow": "^3.1.0"
+            },
+            "funding": {
+                "url": "https://opencollective.com/vitest"
+            },
+            "peerDependencies": {
+                "playwright": "*",
+                "vitest": "4.1.8"
+            },
+            "peerDependenciesMeta": {
+                "playwright": {
+                    "optional": false
+                }
+            }
+        },
+        "node_modules/@vitest/browser-playwright/node_modules/tinyrainbow": {
+            "version": "3.1.0",
+            "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-3.1.0.tgz",
+            "integrity": "sha512-Bf+ILmBgretUrdJxzXM0SgXLZ3XfiaUuOj/IKQHuTXip+05Xn+uyEYdVg0kYDipTBcLrCVyUzAPz7QmArb0mmw==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=14.0.0"
+            }
+        },
+        "node_modules/@vitest/browser/node_modules/@vitest/pretty-format": {
+            "version": "4.1.8",
+            "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-4.1.8.tgz",
+            "integrity": "sha512-9GasEBxpZ1VYIpqHf/0+YGg121uSNwCKOJqIrTwWP/TB7DmFCiaBpNl3aPZzoLWfWkuqhbH8vJIVobZkvdo2cA==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "tinyrainbow": "^3.1.0"
+            },
+            "funding": {
+                "url": "https://opencollective.com/vitest"
+            }
+        },
+        "node_modules/@vitest/browser/node_modules/@vitest/utils": {
+            "version": "4.1.8",
+            "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-4.1.8.tgz",
+            "integrity": "sha512-uOJamYALNhfJ6iolExyQM40yIQwDqYnkKtQ5VCiSe17E33H0aQ/u+1GlRuz4LZBk6Mm3sg90G9hEbmEt37C1Zg==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@vitest/pretty-format": "4.1.8",
+                "convert-source-map": "^2.0.0",
+                "tinyrainbow": "^3.1.0"
+            },
+            "funding": {
+                "url": "https://opencollective.com/vitest"
+            }
+        },
+        "node_modules/@vitest/browser/node_modules/tinyrainbow": {
+            "version": "3.1.0",
+            "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-3.1.0.tgz",
+            "integrity": "sha512-Bf+ILmBgretUrdJxzXM0SgXLZ3XfiaUuOj/IKQHuTXip+05Xn+uyEYdVg0kYDipTBcLrCVyUzAPz7QmArb0mmw==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=14.0.0"
+            }
+        },
         "node_modules/@vitest/expect": {
             "version": "3.2.4",
             "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-3.2.4.tgz",
@@ -5257,6 +5413,43 @@
                 "url": "https://opencollective.com/vitest"
             }
         },
+        "node_modules/@vitest/mocker": {
+            "version": "4.1.8",
+            "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-4.1.8.tgz",
+            "integrity": "sha512-LEiN/xe4OSIbKe9HQIp5OC24agGD9J5CnmMgsLohVVoOPWL9a2sBoR6VBx43jQZb7Kr1l4RCuyCJzcAa0+dojw==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@vitest/spy": "4.1.8",
+                "estree-walker": "^3.0.3",
+                "magic-string": "^0.30.21"
+            },
+            "funding": {
+                "url": "https://opencollective.com/vitest"
+            },
+            "peerDependencies": {
+                "msw": "^2.4.9",
+                "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
+            },
+            "peerDependenciesMeta": {
+                "msw": {
+                    "optional": true
+                },
+                "vite": {
+                    "optional": true
+                }
+            }
+        },
+        "node_modules/@vitest/mocker/node_modules/@vitest/spy": {
+            "version": "4.1.8",
+            "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-4.1.8.tgz",
+            "integrity": "sha512-6EevtBp6OZOPF7bmz36HrGMeP3txgVSrgebWxHOafDXGkhIzfXK14f8KF6MuFfgXXUeHxmpD3BQxkV00/3s5mA==",
+            "dev": true,
+            "license": "MIT",
+            "funding": {
+                "url": "https://opencollective.com/vitest"
+            }
+        },
         "node_modules/@vitest/pretty-format": {
             "version": "3.2.4",
             "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-3.2.4.tgz",
@@ -5268,6 +5461,112 @@
             },
             "funding": {
                 "url": "https://opencollective.com/vitest"
+            }
+        },
+        "node_modules/@vitest/runner": {
+            "version": "4.1.8",
+            "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-4.1.8.tgz",
+            "integrity": "sha512-EmVxeBAfMJvycdjd6Hm+RbFBbA9fKvo0Kx37hNpBYoYeavH3RNsBXWDooR1mgD52dCrxIIuP7UotpfiwOikvcg==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@vitest/utils": "4.1.8",
+                "pathe": "^2.0.3"
+            },
+            "funding": {
+                "url": "https://opencollective.com/vitest"
+            }
+        },
+        "node_modules/@vitest/runner/node_modules/@vitest/pretty-format": {
+            "version": "4.1.8",
+            "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-4.1.8.tgz",
+            "integrity": "sha512-9GasEBxpZ1VYIpqHf/0+YGg121uSNwCKOJqIrTwWP/TB7DmFCiaBpNl3aPZzoLWfWkuqhbH8vJIVobZkvdo2cA==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "tinyrainbow": "^3.1.0"
+            },
+            "funding": {
+                "url": "https://opencollective.com/vitest"
+            }
+        },
+        "node_modules/@vitest/runner/node_modules/@vitest/utils": {
+            "version": "4.1.8",
+            "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-4.1.8.tgz",
+            "integrity": "sha512-uOJamYALNhfJ6iolExyQM40yIQwDqYnkKtQ5VCiSe17E33H0aQ/u+1GlRuz4LZBk6Mm3sg90G9hEbmEt37C1Zg==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@vitest/pretty-format": "4.1.8",
+                "convert-source-map": "^2.0.0",
+                "tinyrainbow": "^3.1.0"
+            },
+            "funding": {
+                "url": "https://opencollective.com/vitest"
+            }
+        },
+        "node_modules/@vitest/runner/node_modules/tinyrainbow": {
+            "version": "3.1.0",
+            "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-3.1.0.tgz",
+            "integrity": "sha512-Bf+ILmBgretUrdJxzXM0SgXLZ3XfiaUuOj/IKQHuTXip+05Xn+uyEYdVg0kYDipTBcLrCVyUzAPz7QmArb0mmw==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=14.0.0"
+            }
+        },
+        "node_modules/@vitest/snapshot": {
+            "version": "4.1.8",
+            "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-4.1.8.tgz",
+            "integrity": "sha512-acfZboRmAIf05DEKcBQy33VXojFJjtUdLyo7oOmV9kebb2xdU01UknNiPuPZoJZQyO7DF0gZdTGTpeAzET9QPQ==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@vitest/pretty-format": "4.1.8",
+                "@vitest/utils": "4.1.8",
+                "magic-string": "^0.30.21",
+                "pathe": "^2.0.3"
+            },
+            "funding": {
+                "url": "https://opencollective.com/vitest"
+            }
+        },
+        "node_modules/@vitest/snapshot/node_modules/@vitest/pretty-format": {
+            "version": "4.1.8",
+            "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-4.1.8.tgz",
+            "integrity": "sha512-9GasEBxpZ1VYIpqHf/0+YGg121uSNwCKOJqIrTwWP/TB7DmFCiaBpNl3aPZzoLWfWkuqhbH8vJIVobZkvdo2cA==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "tinyrainbow": "^3.1.0"
+            },
+            "funding": {
+                "url": "https://opencollective.com/vitest"
+            }
+        },
+        "node_modules/@vitest/snapshot/node_modules/@vitest/utils": {
+            "version": "4.1.8",
+            "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-4.1.8.tgz",
+            "integrity": "sha512-uOJamYALNhfJ6iolExyQM40yIQwDqYnkKtQ5VCiSe17E33H0aQ/u+1GlRuz4LZBk6Mm3sg90G9hEbmEt37C1Zg==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@vitest/pretty-format": "4.1.8",
+                "convert-source-map": "^2.0.0",
+                "tinyrainbow": "^3.1.0"
+            },
+            "funding": {
+                "url": "https://opencollective.com/vitest"
+            }
+        },
+        "node_modules/@vitest/snapshot/node_modules/tinyrainbow": {
+            "version": "3.1.0",
+            "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-3.1.0.tgz",
+            "integrity": "sha512-Bf+ILmBgretUrdJxzXM0SgXLZ3XfiaUuOj/IKQHuTXip+05Xn+uyEYdVg0kYDipTBcLrCVyUzAPz7QmArb0mmw==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=14.0.0"
             }
         },
         "node_modules/@vitest/spy": {
@@ -8874,6 +9173,16 @@
                 "node": ">=4.0"
             }
         },
+        "node_modules/estree-walker": {
+            "version": "3.0.3",
+            "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
+            "integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@types/estree": "^1.0.0"
+            }
+        },
         "node_modules/esutils": {
             "version": "2.0.3",
             "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.3.tgz",
@@ -8996,6 +9305,16 @@
             "resolved": "https://registry.npmjs.org/yallist/-/yallist-2.1.2.tgz",
             "integrity": "sha512-ncTzHV7NvsQZkYe1DW7cbDLm0YpzHmZF5r/iyP3ZnQtMiJ+pjzisCiMNI+Sj+xQF5pXhSHxSB3uDbsBTzY/c2A==",
             "license": "ISC"
+        },
+        "node_modules/expect-type": {
+            "version": "1.3.0",
+            "resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.3.0.tgz",
+            "integrity": "sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA==",
+            "dev": true,
+            "license": "Apache-2.0",
+            "engines": {
+                "node": ">=12.0.0"
+            }
         },
         "node_modules/express": {
             "version": "4.22.1",
@@ -11485,6 +11804,16 @@
                 "lz-string": "bin/bin.js"
             }
         },
+        "node_modules/magic-string": {
+            "version": "0.30.21",
+            "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
+            "integrity": "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@jridgewell/sourcemap-codec": "^1.5.5"
+            }
+        },
         "node_modules/make-dir": {
             "version": "1.3.0",
             "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-1.3.0.tgz",
@@ -12718,6 +13047,16 @@
                 "mkdirp": "bin/cmd.js"
             }
         },
+        "node_modules/mrmime": {
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/mrmime/-/mrmime-2.0.1.tgz",
+            "integrity": "sha512-Y3wQdFg2Va6etvQ5I82yUhGdsKrcYox6p7FfL1LbK2J4V01F9TGlepTIhnK24t7koZibmg82KGglhA1XK5IsLQ==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=10"
+            }
+        },
         "node_modules/ms": {
             "version": "2.1.3",
             "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
@@ -12949,6 +13288,17 @@
             "resolved": "https://registry.npmjs.org/obuf/-/obuf-1.1.2.tgz",
             "integrity": "sha512-PX1wu0AmAdPqOL1mWhqmlOd8kOIZQwGZw6rh7uby9fTc5lhaOWFLX3I6R1hrF9k3zUY40e6igsLGkDXK92LJNg==",
             "dev": true,
+            "license": "MIT"
+        },
+        "node_modules/obug": {
+            "version": "2.1.1",
+            "resolved": "https://registry.npmjs.org/obug/-/obug-2.1.1.tgz",
+            "integrity": "sha512-uTqF9MuPraAQ+IsnPf366RG4cP9RtUi7MLO1N3KEc+wb0a6yKpeL0lmk2IB1jY5KHPAlTc6T/JRdC/YqxHNwkQ==",
+            "dev": true,
+            "funding": [
+                "https://github.com/sponsors/sxzz",
+                "https://opencollective.com/debug"
+            ],
             "license": "MIT"
         },
         "node_modules/on-finished": {
@@ -13412,6 +13762,13 @@
                 "node": ">=8"
             }
         },
+        "node_modules/pathe": {
+            "version": "2.0.3",
+            "resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
+            "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
+            "dev": true,
+            "license": "MIT"
+        },
         "node_modules/pathval": {
             "version": "2.0.1",
             "resolved": "https://registry.npmjs.org/pathval/-/pathval-2.0.1.tgz",
@@ -13545,6 +13902,63 @@
             },
             "engines": {
                 "node": ">=8"
+            }
+        },
+        "node_modules/playwright": {
+            "version": "1.60.0",
+            "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.60.0.tgz",
+            "integrity": "sha512-hheHdokM8cdqCb0lcE3s+zT4t4W+vvjpGxsZlDnikarzx8tSzMebh3UiFtgqwFwnTnjYQcsyMF8ei2mCO/tpeA==",
+            "dev": true,
+            "license": "Apache-2.0",
+            "dependencies": {
+                "playwright-core": "1.60.0"
+            },
+            "bin": {
+                "playwright": "cli.js"
+            },
+            "engines": {
+                "node": ">=18"
+            },
+            "optionalDependencies": {
+                "fsevents": "2.3.2"
+            }
+        },
+        "node_modules/playwright-core": {
+            "version": "1.60.0",
+            "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.60.0.tgz",
+            "integrity": "sha512-9bW6zvX/m0lEbgTKJ6YppOKx8H3VOPBMOCFh2irXFOT4BbHgrx5hPjwJYLT40Lu+4qtD36qKc/Hn56StUW57IA==",
+            "dev": true,
+            "license": "Apache-2.0",
+            "bin": {
+                "playwright-core": "cli.js"
+            },
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/playwright/node_modules/fsevents": {
+            "version": "2.3.2",
+            "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+            "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+            "dev": true,
+            "hasInstallScript": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "darwin"
+            ],
+            "engines": {
+                "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+            }
+        },
+        "node_modules/pngjs": {
+            "version": "7.0.0",
+            "resolved": "https://registry.npmjs.org/pngjs/-/pngjs-7.0.0.tgz",
+            "integrity": "sha512-LKWqWJRhstyYo9pGvgor/ivk2w94eSjE3RGVuzLGlr3NmD8bf7RcYGze1mNdEHRP6TRP6rMuDHk5t44hnTRyow==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=14.19.0"
             }
         },
         "node_modules/possible-typed-array-names": {
@@ -15041,11 +15455,33 @@
                 "url": "https://github.com/sponsors/ljharb"
             }
         },
+        "node_modules/siginfo": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/siginfo/-/siginfo-2.0.0.tgz",
+            "integrity": "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==",
+            "dev": true,
+            "license": "ISC"
+        },
         "node_modules/signal-exit": {
             "version": "3.0.7",
             "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.7.tgz",
             "integrity": "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==",
             "license": "ISC"
+        },
+        "node_modules/sirv": {
+            "version": "3.0.2",
+            "resolved": "https://registry.npmjs.org/sirv/-/sirv-3.0.2.tgz",
+            "integrity": "sha512-2wcC/oGxHis/BoHkkPwldgiPSYcpZK3JU28WoMVv55yHJgcZ8rlXvuG9iZggz+sU1d4bRgIGASwyWqjxu3FM0g==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@polka/url": "^1.0.0-next.24",
+                "mrmime": "^2.0.0",
+                "totalist": "^3.0.0"
+            },
+            "engines": {
+                "node": ">=18"
+            }
         },
         "node_modules/slash": {
             "version": "1.0.0",
@@ -15195,6 +15631,13 @@
                 "node": ">= 6"
             }
         },
+        "node_modules/stackback": {
+            "version": "0.0.2",
+            "resolved": "https://registry.npmjs.org/stackback/-/stackback-0.0.2.tgz",
+            "integrity": "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==",
+            "dev": true,
+            "license": "MIT"
+        },
         "node_modules/statuses": {
             "version": "2.0.2",
             "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.2.tgz",
@@ -15205,10 +15648,17 @@
                 "node": ">= 0.8"
             }
         },
+        "node_modules/std-env": {
+            "version": "4.1.0",
+            "resolved": "https://registry.npmjs.org/std-env/-/std-env-4.1.0.tgz",
+            "integrity": "sha512-Rq7ybcX2RuC55r9oaPVEW7/xu3tj8u4GeBYHBWCychFtzMIr86A7e3PPEBPT37sHStKX3+TiX/Fr/ACmJLVlLQ==",
+            "dev": true,
+            "license": "MIT"
+        },
         "node_modules/storybook": {
-            "version": "10.4.0",
-            "resolved": "https://registry.npmjs.org/storybook/-/storybook-10.4.0.tgz",
-            "integrity": "sha512-zrtctbVa6xEXCXuE3vsiR0At31zLOtzj8QudN/GaBJLZl0Z2DfF1rDPtTxdAbAp11M2J/7JVHaTIQKXauQPbmg==",
+            "version": "10.4.2",
+            "resolved": "https://registry.npmjs.org/storybook/-/storybook-10.4.2.tgz",
+            "integrity": "sha512-5Ax5vbHxFgMBGGhQDm75Rrumm/HZC4ICFhMcJaM0UlqnC/4FKj/IaZtImZFupknyiiyUEcWHPQFA2kX3/VSv1A==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -16071,6 +16521,23 @@
             "dev": true,
             "license": "MIT"
         },
+        "node_modules/tinybench": {
+            "version": "2.9.0",
+            "resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.9.0.tgz",
+            "integrity": "sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==",
+            "dev": true,
+            "license": "MIT"
+        },
+        "node_modules/tinyexec": {
+            "version": "1.2.4",
+            "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-1.2.4.tgz",
+            "integrity": "sha512-SHf/r48b7vOrjve9PxJo3MN5v5yuyjHvdUcrQffT3WXMUfnGmHDVbC4k3sHJaJTgZCwpUplIaAo5ANtMyp3YHg==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=18"
+            }
+        },
         "node_modules/tinyglobby": {
             "version": "0.2.15",
             "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.15.tgz",
@@ -16230,6 +16697,16 @@
             "license": "MIT",
             "engines": {
                 "node": ">=0.6"
+            }
+        },
+        "node_modules/totalist": {
+            "version": "3.0.1",
+            "resolved": "https://registry.npmjs.org/totalist/-/totalist-3.0.1.tgz",
+            "integrity": "sha512-sf4i37nQ2LBx4m3wB74y+ubopq6W/dIzXg0FDGjsYnZHVa1Da8FH853wlL2gtUhg+xJXjfk3kUZS3BRoQeoQBQ==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=6"
             }
         },
         "node_modules/trim-repeated": {
@@ -17389,6 +17866,192 @@
                 "url": "https://github.com/sponsors/jonschlinkert"
             }
         },
+        "node_modules/vitest": {
+            "version": "4.1.8",
+            "resolved": "https://registry.npmjs.org/vitest/-/vitest-4.1.8.tgz",
+            "integrity": "sha512-flY6ScbCIt9HThs+C5HS7jvGOB560DJtk/Z15IQROTA6zEy49Nh8T/dofWTQL+n3vswqn87sbJNiuqw1SDp5Ig==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@vitest/expect": "4.1.8",
+                "@vitest/mocker": "4.1.8",
+                "@vitest/pretty-format": "4.1.8",
+                "@vitest/runner": "4.1.8",
+                "@vitest/snapshot": "4.1.8",
+                "@vitest/spy": "4.1.8",
+                "@vitest/utils": "4.1.8",
+                "es-module-lexer": "^2.0.0",
+                "expect-type": "^1.3.0",
+                "magic-string": "^0.30.21",
+                "obug": "^2.1.1",
+                "pathe": "^2.0.3",
+                "picomatch": "^4.0.3",
+                "std-env": "^4.0.0-rc.1",
+                "tinybench": "^2.9.0",
+                "tinyexec": "^1.0.2",
+                "tinyglobby": "^0.2.15",
+                "tinyrainbow": "^3.1.0",
+                "vite": "^6.0.0 || ^7.0.0 || ^8.0.0",
+                "why-is-node-running": "^2.3.0"
+            },
+            "bin": {
+                "vitest": "vitest.mjs"
+            },
+            "engines": {
+                "node": "^20.0.0 || ^22.0.0 || >=24.0.0"
+            },
+            "funding": {
+                "url": "https://opencollective.com/vitest"
+            },
+            "peerDependencies": {
+                "@edge-runtime/vm": "*",
+                "@opentelemetry/api": "^1.9.0",
+                "@types/node": "^20.0.0 || ^22.0.0 || >=24.0.0",
+                "@vitest/browser-playwright": "4.1.8",
+                "@vitest/browser-preview": "4.1.8",
+                "@vitest/browser-webdriverio": "4.1.8",
+                "@vitest/coverage-istanbul": "4.1.8",
+                "@vitest/coverage-v8": "4.1.8",
+                "@vitest/ui": "4.1.8",
+                "happy-dom": "*",
+                "jsdom": "*",
+                "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
+            },
+            "peerDependenciesMeta": {
+                "@edge-runtime/vm": {
+                    "optional": true
+                },
+                "@opentelemetry/api": {
+                    "optional": true
+                },
+                "@types/node": {
+                    "optional": true
+                },
+                "@vitest/browser-playwright": {
+                    "optional": true
+                },
+                "@vitest/browser-preview": {
+                    "optional": true
+                },
+                "@vitest/browser-webdriverio": {
+                    "optional": true
+                },
+                "@vitest/coverage-istanbul": {
+                    "optional": true
+                },
+                "@vitest/coverage-v8": {
+                    "optional": true
+                },
+                "@vitest/ui": {
+                    "optional": true
+                },
+                "happy-dom": {
+                    "optional": true
+                },
+                "jsdom": {
+                    "optional": true
+                },
+                "vite": {
+                    "optional": false
+                }
+            }
+        },
+        "node_modules/vitest/node_modules/@vitest/expect": {
+            "version": "4.1.8",
+            "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-4.1.8.tgz",
+            "integrity": "sha512-h3nDO677RDLEGlBxyQ5CW8RlMThSKSRLUePLOx09gNIWRL40edgA1GCZSZgf1W55MFAG6/Sw14KeaAnqv0NKdQ==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@standard-schema/spec": "^1.1.0",
+                "@types/chai": "^5.2.2",
+                "@vitest/spy": "4.1.8",
+                "@vitest/utils": "4.1.8",
+                "chai": "^6.2.2",
+                "tinyrainbow": "^3.1.0"
+            },
+            "funding": {
+                "url": "https://opencollective.com/vitest"
+            }
+        },
+        "node_modules/vitest/node_modules/@vitest/pretty-format": {
+            "version": "4.1.8",
+            "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-4.1.8.tgz",
+            "integrity": "sha512-9GasEBxpZ1VYIpqHf/0+YGg121uSNwCKOJqIrTwWP/TB7DmFCiaBpNl3aPZzoLWfWkuqhbH8vJIVobZkvdo2cA==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "tinyrainbow": "^3.1.0"
+            },
+            "funding": {
+                "url": "https://opencollective.com/vitest"
+            }
+        },
+        "node_modules/vitest/node_modules/@vitest/spy": {
+            "version": "4.1.8",
+            "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-4.1.8.tgz",
+            "integrity": "sha512-6EevtBp6OZOPF7bmz36HrGMeP3txgVSrgebWxHOafDXGkhIzfXK14f8KF6MuFfgXXUeHxmpD3BQxkV00/3s5mA==",
+            "dev": true,
+            "license": "MIT",
+            "funding": {
+                "url": "https://opencollective.com/vitest"
+            }
+        },
+        "node_modules/vitest/node_modules/@vitest/utils": {
+            "version": "4.1.8",
+            "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-4.1.8.tgz",
+            "integrity": "sha512-uOJamYALNhfJ6iolExyQM40yIQwDqYnkKtQ5VCiSe17E33H0aQ/u+1GlRuz4LZBk6Mm3sg90G9hEbmEt37C1Zg==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@vitest/pretty-format": "4.1.8",
+                "convert-source-map": "^2.0.0",
+                "tinyrainbow": "^3.1.0"
+            },
+            "funding": {
+                "url": "https://opencollective.com/vitest"
+            }
+        },
+        "node_modules/vitest/node_modules/chai": {
+            "version": "6.2.2",
+            "resolved": "https://registry.npmjs.org/chai/-/chai-6.2.2.tgz",
+            "integrity": "sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/vitest/node_modules/es-module-lexer": {
+            "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-2.1.0.tgz",
+            "integrity": "sha512-n27zTYMjYu1aj4MjCWzSP7G9r75utsaoc8m61weK+W8JMBGGQybd43GstCXZ3WNmSFtGT9wi59qQTW6mhTR5LQ==",
+            "dev": true,
+            "license": "MIT"
+        },
+        "node_modules/vitest/node_modules/picomatch": {
+            "version": "4.0.4",
+            "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
+            "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=12"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/jonschlinkert"
+            }
+        },
+        "node_modules/vitest/node_modules/tinyrainbow": {
+            "version": "3.1.0",
+            "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-3.1.0.tgz",
+            "integrity": "sha512-Bf+ILmBgretUrdJxzXM0SgXLZ3XfiaUuOj/IKQHuTXip+05Xn+uyEYdVg0kYDipTBcLrCVyUzAPz7QmArb0mmw==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=14.0.0"
+            }
+        },
         "node_modules/watchpack": {
             "version": "2.4.4",
             "resolved": "https://registry.npmjs.org/watchpack/-/watchpack-2.4.4.tgz",
@@ -17756,6 +18419,23 @@
                 "url": "https://github.com/sponsors/ljharb"
             }
         },
+        "node_modules/why-is-node-running": {
+            "version": "2.3.0",
+            "resolved": "https://registry.npmjs.org/why-is-node-running/-/why-is-node-running-2.3.0.tgz",
+            "integrity": "sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "siginfo": "^2.0.0",
+                "stackback": "0.0.2"
+            },
+            "bin": {
+                "why-is-node-running": "cli.js"
+            },
+            "engines": {
+                "node": ">=8"
+            }
+        },
         "node_modules/wildcard": {
             "version": "2.0.1",
             "resolved": "https://registry.npmjs.org/wildcard/-/wildcard-2.0.1.tgz",
@@ -17812,9 +18492,9 @@
             }
         },
         "node_modules/ws": {
-            "version": "8.18.3",
-            "resolved": "https://registry.npmjs.org/ws/-/ws-8.18.3.tgz",
-            "integrity": "sha512-PEIGCY5tSlUt50cqyMXfCzX+oOPqN0vuGqWzbcJ2xvnkzkq46oOpz7dQaTDBdfICb4N14+GARUDw2XV2N4tvzg==",
+            "version": "8.21.0",
+            "resolved": "https://registry.npmjs.org/ws/-/ws-8.21.0.tgz",
+            "integrity": "sha512-Vsp28b7DRcimFQvrqu2Wek3z1iYxDCWqHYB8Qsnk/S4RfaCQzPGPyBNuVjJV3cd6UiKtUtp6sNM77gWvzcCH+g==",
             "dev": true,
             "license": "MIT",
             "engines": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -23,6 +23,7 @@
                 "@babel/plugin-syntax-dynamic-import": "^7.8.3",
                 "@babel/preset-env": "^7.22.5",
                 "@babel/preset-react": "^7.22.5",
+                "@chromatic-com/storybook": "^5.2.1",
                 "@eslint/css": "^1.3.0",
                 "@eslint/js": "^10.0.1",
                 "@eslint/json": "^2.0.0",
@@ -1794,6 +1795,99 @@
                 "@keyv/serialize": "^1.1.1"
             }
         },
+        "node_modules/@chromatic-com/storybook": {
+            "version": "5.2.1",
+            "resolved": "https://registry.npmjs.org/@chromatic-com/storybook/-/storybook-5.2.1.tgz",
+            "integrity": "sha512-z6I7NJk/0VngA64y5TNYaB4Hc2X8+90n4op6lBt9PvWk5TmIlFLDqdX33rlrwbNRkkYijVgA/wO04rVYXi5Mlg==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@neoconfetti/react": "^1.0.0",
+                "chromatic": "16.10.0",
+                "jsonfile": "^6.1.0",
+                "strip-ansi": "^7.1.0"
+            },
+            "engines": {
+                "node": ">=20.0.0",
+                "yarn": ">=1.22.18"
+            },
+            "peerDependencies": {
+                "storybook": "^0.0.0-0 || ^10.1.0 || ^10.1.0-0 || ^10.2.0-0 || ^10.3.0-0 || ^10.4.0-0 || ^10.5.0-0 || ^10.6.0-0"
+            }
+        },
+        "node_modules/@chromatic-com/storybook/node_modules/ansi-regex": {
+            "version": "6.2.2",
+            "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.2.2.tgz",
+            "integrity": "sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=12"
+            },
+            "funding": {
+                "url": "https://github.com/chalk/ansi-regex?sponsor=1"
+            }
+        },
+        "node_modules/@chromatic-com/storybook/node_modules/chromatic": {
+            "version": "16.10.0",
+            "resolved": "https://registry.npmjs.org/chromatic/-/chromatic-16.10.0.tgz",
+            "integrity": "sha512-nFsztmnu7rFiGafUJgXvLUNpqmRylz92eNvzBoJNTKKQj4EQUyxznwnfpf1dTs7hXtWD8JwcH92jADydaHA1sw==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "semver": "^7.3.5"
+            },
+            "bin": {
+                "chroma": "dist/bin.cjs",
+                "chromatic": "dist/bin.cjs",
+                "chromatic-cli": "dist/bin.cjs"
+            },
+            "peerDependencies": {
+                "@chromatic-com/cypress": "^0.*.* || ^1.0.0",
+                "@chromatic-com/playwright": "^0.*.* || ^1.0.0",
+                "@chromatic-com/vitest": "^0.*.* || ^1.0.0"
+            },
+            "peerDependenciesMeta": {
+                "@chromatic-com/cypress": {
+                    "optional": true
+                },
+                "@chromatic-com/playwright": {
+                    "optional": true
+                },
+                "@chromatic-com/vitest": {
+                    "optional": true
+                }
+            }
+        },
+        "node_modules/@chromatic-com/storybook/node_modules/semver": {
+            "version": "7.8.3",
+            "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.3.tgz",
+            "integrity": "sha512-wnilbGyMxzbY7dNOl7jpKbLSjcfeweJWU5j4+u5qW+6/wuGD9KzIGOyZnQVSBM9E7DtWaaH3CyHkppYrKYoxwg==",
+            "dev": true,
+            "license": "ISC",
+            "bin": {
+                "semver": "bin/semver.js"
+            },
+            "engines": {
+                "node": ">=10"
+            }
+        },
+        "node_modules/@chromatic-com/storybook/node_modules/strip-ansi": {
+            "version": "7.2.0",
+            "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.2.0.tgz",
+            "integrity": "sha512-yDPMNjp4WyfYBkHnjIRLfca1i6KMyGCtsVgoKe/z1+6vukgaENdgGBZt+ZmKPc4gavvEZ5OgHfHdrazhgNyG7w==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "ansi-regex": "^6.2.2"
+            },
+            "engines": {
+                "node": ">=12"
+            },
+            "funding": {
+                "url": "https://github.com/chalk/strip-ansi?sponsor=1"
+            }
+        },
         "node_modules/@csstools/css-calc": {
             "version": "3.2.1",
             "resolved": "https://registry.npmjs.org/@csstools/css-calc/-/css-calc-3.2.1.tgz",
@@ -2976,6 +3070,13 @@
                 "@emnapi/core": "^1.7.1",
                 "@emnapi/runtime": "^1.7.1"
             }
+        },
+        "node_modules/@neoconfetti/react": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/@neoconfetti/react/-/react-1.0.0.tgz",
+            "integrity": "sha512-klcSooChXXOzIm+SE5IISIAn3bYzYfPjbX7D7HoqZL84oAfgREeSg5vSIaSFH+DaGzzvImTyWe1OyrJ67vik4A==",
+            "dev": true,
+            "license": "MIT"
         },
         "node_modules/@nodelib/fs.scandir": {
             "version": "2.1.5",
@@ -11566,6 +11667,19 @@
                 "node": ">=6"
             }
         },
+        "node_modules/jsonfile": {
+            "version": "6.2.1",
+            "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.2.1.tgz",
+            "integrity": "sha512-zwOTdL3rFQ/lRdBnntKVOX6k5cKJwEc1HdilT71BWEu7J41gXIB2MRp+vxduPSwZJPWBxEzv4yH1wYLJGUHX4Q==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "universalify": "^2.0.0"
+            },
+            "optionalDependencies": {
+                "graceful-fs": "^4.1.6"
+            }
+        },
         "node_modules/katex": {
             "version": "0.16.47",
             "resolved": "https://registry.npmjs.org/katex/-/katex-0.16.47.tgz",
@@ -17010,6 +17124,16 @@
             "funding": {
                 "type": "opencollective",
                 "url": "https://opencollective.com/unified"
+            }
+        },
+        "node_modules/universalify": {
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.1.tgz",
+            "integrity": "sha512-gptHNQghINnc/vTGIk0SOFGFNXw7JVrlRUtConJRlvaw6DuX0wO5Jeko9sWrMBhh+PsYAZ7oXAiOnf/UKogyiw==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">= 10.0.0"
             }
         },
         "node_modules/unpipe": {

--- a/package.json
+++ b/package.json
@@ -19,7 +19,10 @@
         "lint": "npm run lint:js && npm run lint:styles",
         "build-storybook": "node .storybook/prepare-storybook.js && storybook build",
         "storybook": "storybook dev -p 6006",
-        "add-story": "bash scripts/add_story.sh"
+        "add-story": "bash scripts/add_story.sh",
+        "test": "vitest run",
+        "test:watch": "vitest",
+        "test:storybook": "vitest --project=storybook"
     },
     "keywords": [],
     "author": "",
@@ -38,7 +41,9 @@
         "@storybook/addon-designs": "^11.1.3",
         "@storybook/addon-docs": "^10.4.0",
         "@storybook/addon-themes": "^10.4.0",
+        "@storybook/addon-vitest": "^10.4.1",
         "@storybook/html-vite": "^10.4.0",
+        "@vitest/browser-playwright": "^4.1.7",
         "autoprefixer": "^10.4.14",
         "chromatic": "^17.0.0",
         "copy-webpack-plugin": "^11.0.0",
@@ -57,6 +62,7 @@
         "imports-loader": "^4.0.1",
         "jsdoc": "^4.0.2",
         "mini-css-extract-plugin": "^2.7.6",
+        "playwright": "^1.60.0",
         "postcss-loader": "^7.3.3",
         "postcss-scss": "^4.0.9",
         "prettier": "3.8.3",
@@ -72,6 +78,7 @@
         "url-loader": "^4.1.1",
         "vite": "^7.2.6",
         "vite-plugin-sass-glob-import": "^6.0.2",
+        "vitest": "^4.1.7",
         "webpack": "^5.88.0",
         "webpack-cli": "^5.1.4",
         "webpack-dev-server": "^4.15.1"

--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
         "@babel/plugin-syntax-dynamic-import": "^7.8.3",
         "@babel/preset-env": "^7.22.5",
         "@babel/preset-react": "^7.22.5",
+        "@chromatic-com/storybook": "^5.2.1",
         "@eslint/css": "^1.3.0",
         "@eslint/js": "^10.0.1",
         "@eslint/json": "^2.0.0",

--- a/src/components/_global/js/cta_links/global.js
+++ b/src/components/_global/js/cta_links/global.js
@@ -1,5 +1,8 @@
-export default function initCtaLinks(document = document) {
-    document.querySelectorAll(".qld__cta-link.qld__cta-link--view-all").forEach((ctaLink) => {
+/**
+ * @param {Document|Element} root
+ */
+export default function initCtaLinks(root = document) {
+    root.querySelectorAll(".qld__cta-link.qld__cta-link--view-all").forEach((ctaLink) => {
         const viewAllIconWrapperClass = "qld__cta-link--view-all-icon--wrapper";
 
         // First check that the cta is not already wrapped

--- a/src/components/_global/js/select_boxes/global.js
+++ b/src/components/_global/js/select_boxes/global.js
@@ -2,8 +2,11 @@
  * @module selectBoxes
  */
 
-export default function initSelectBoxes(document = document) {
-    document.querySelectorAll("select").forEach((select) => {
+/**
+ * @param {Document|Element} root
+ */
+export default function initSelectBoxes(root = document) {
+    root.querySelectorAll("select").forEach((select) => {
         // First check that the select is not already wrapped
         if (select.closest(".qld__select")) {
             return;

--- a/src/components/accordion/js/global.js
+++ b/src/components/accordion/js/global.js
@@ -310,9 +310,9 @@ const accordion = {};
      *
      * @param  {string}  elements - The DOM node/s to toggle
      * @param  {integer} speed    - The speed in ms for the animation
-     *
+     * @param  {Document | HTMLElement}  root     - The root element to search for the target element
      */
-    accordion.Open = function (elements, speed) {
+    accordion.Open = function (elements, speed, root = document) {
 
         // stop event propagation
         try {
@@ -328,7 +328,7 @@ const accordion = {};
 
             var element = elements[i];
             var targetId = element.getAttribute('aria-controls');
-            var target = document.getElementById(targetId);
+            var target = root.querySelector(`[id="${targetId}"]`);
 
             // let’s find out if this accordion is still closed
             var height = 0;
@@ -353,9 +353,9 @@ const accordion = {};
                     category: 'accordion',
                     action: 'close',
                     label: targetId
-                });            
+                });
             }
-            
+
             (function (target, speed, element) {
                 window.QLD.animate.Run({
                     element: target,
@@ -379,9 +379,9 @@ const accordion = {};
      *
      * @param  {string}  elements - The DOM node/s to toggle
      * @param  {integer} speed    - The speed in ms for the animation
-     *
+     * @param  {Document | HTMLElement}  root     - The root element to search for the target element
      */
-    accordion.Close = function (elements, speed) {
+    accordion.Close = function (elements, speed, root = document) {
 
         // stop event propagation
         try {
@@ -397,7 +397,7 @@ const accordion = {};
 
             var element = elements[i];
             var targetId = element.getAttribute('aria-controls');
-            var target = document.getElementById(targetId);
+            var target = root.querySelector(`[id="${targetId}"]`);
 
             toggleClasses(element, 'closing');
             setAriaRoles(element, target, 'closing');

--- a/src/components/in_page_navigation/js/global.js
+++ b/src/components/in_page_navigation/js/global.js
@@ -4,15 +4,19 @@ import { normaliseIdentifier } from "../../../helpers/global-helpers.js";
  * @module inPageNavigation
  */
 
-export default function initInPageNavigation(document = document) {
-    const navs = document.querySelectorAll(".qld__inpage-nav-links");
-    const mainEl = document.querySelector("main.main");
+/**
+ *
+ * @param {Document|Element} root
+ */
+export default function initInPageNavigation(root = document) {
+    const navs = root.querySelectorAll(".qld__inpage-nav-links");
+    const mainEl = root.querySelector("main.main");
     const isLandingPage = mainEl && mainEl.classList.contains("landing");
 
     // For all In-Page Nav components
     navs.forEach((nav) => {
         const headingSelector = nav.getAttribute("data-headingType") ? nav.getAttribute("data-headingType") : "h2";
-        const pageContent = isLandingPage ? mainEl : document.getElementById("content");
+        const pageContent = isLandingPage ? mainEl : root.querySelector('[id="content"]')
         // Gracefully handle missing page content element
         if (!pageContent) {
             return;

--- a/src/components/mega_main_navigation/js/global.js
+++ b/src/components/mega_main_navigation/js/global.js
@@ -9,49 +9,64 @@
  *  - Focusout (toggle button or submenu): close submenu unless focus stays within
  */
 
-import {accordion} from "../../accordion/js/global.js";
+import { accordion } from "../../accordion/js/global.js";
 
 /** Selector matching all interactive elements that can receive focus. */
 const FOCUSABLE_SELECTOR = 'a[href], button:not([disabled]), input:not([disabled]), select:not([disabled]), textarea:not([disabled]), [tabindex]:not([tabindex="-1"])';
 
-export function initMegaMenu() {
-    const navItemEls = document.querySelectorAll(".qld__main-nav__item");
+export function initMegaMenu(root = document) {
+    const navItemEls = root.querySelectorAll(".qld__main-nav__item");
 
-    const navItems = Array.from(navItemEls).map((item) => {
-        const navItemTitle = item.querySelector(".qld__main-nav__item-title");
-        if (!navItemTitle) return null;
-        const toggleBtnEl = navItemTitle.querySelector("button");
-        return {
-            linkEl: navItemTitle.querySelector("a"),
-            toggleBtnEl,
-            subMenuEl: item.querySelector(".qld__main-nav__menu-sub"),
-            clickingInsideSubMenu: false,
-            handlers: {},
-        };
-    }).filter(Boolean);
+    const navItems = Array.from(navItemEls)
+        .map((item) => {
+            const navItemTitle = item.querySelector(".qld__main-nav__item-title");
+            if (!navItemTitle) return null;
+            const toggleBtnEl = navItemTitle.querySelector("button");
+            return {
+                rootEl: root,
+                linkEl: navItemTitle.querySelector("a"),
+                toggleBtnEl,
+                subMenuEl: item.querySelector(".qld__main-nav__menu-sub"),
+                clickingInsideSubMenu: false,
+                handlers: {},
+            };
+        })
+        .filter(Boolean);
 
-    // Single shared mouseup listener to reset the clickingInsideSubMenu flag
-    // across all items. Registered once rather than once per item.
-    document.addEventListener("mouseup", () => {
+    if (navItems.length === 0) return () => {};
+
+    const mouseUpHandler = () => {
         navItems.forEach((item) => {
             item.clickingInsideSubMenu = false;
         });
-    });
+    };
+    document.addEventListener("mouseup", mouseUpHandler);
 
     navItems.forEach((item) => {
-        const {toggleBtnEl, subMenuEl} = item;
-        item.handlers.click = handleToggleBtnClick(item, navItems);
-        toggleBtnEl?.addEventListener("click", item.handlers.click);
-
-        subMenuEl?.addEventListener("mousedown", () => {
+        const { toggleBtnEl, subMenuEl } = item;
+        if (toggleBtnEl) {
+            item.handlers.click = handleToggleBtnClick(item, navItems);
+            toggleBtnEl.addEventListener("click", item.handlers.click);
+        }
+        item.handlers.mousedown = () => {
             item.clickingInsideSubMenu = true;
-        });
+        };
+        subMenuEl?.addEventListener("mousedown", item.handlers.mousedown);
     });
+
+    return () => {
+        navItems.forEach((item) => {
+            if (item.toggleBtnEl && isSubMenuOpen(item.toggleBtnEl)) closeSubMenu(item);
+            item.toggleBtnEl?.removeEventListener("click", item.handlers.click);
+            item.subMenuEl?.removeEventListener("mousedown", item.handlers.mousedown);
+        });
+        document.removeEventListener("mouseup", mouseUpHandler);
+    };
 }
 
 function handleToggleBtnClick(item, navItems) {
     return () => {
-        const {toggleBtnEl} = item;
+        const { toggleBtnEl } = item;
         if (isSubMenuOpen(toggleBtnEl)) {
             closeSubMenu(item);
         } else {
@@ -66,8 +81,8 @@ function handleToggleBtnClick(item, navItems) {
  * Listeners are stored on item.handlers so they can be removed on close.
  */
 function openSubMenu(item) {
-    const {linkEl, toggleBtnEl, subMenuEl} = item;
-    accordion.Open(toggleBtnEl);
+    const { linkEl, toggleBtnEl, subMenuEl } = item;
+    accordion.Open(toggleBtnEl, undefined, item.rootEl);
     syncNavItemLinkClass(linkEl, true);
 
     item.handlers.documentEscape = handleDocumentEscape(item);
@@ -88,8 +103,8 @@ function openSubMenu(item) {
  * Closes the submenu and removes all associated event listeners registered in openSubMenu.
  */
 function closeSubMenu(item) {
-    const {linkEl, toggleBtnEl, subMenuEl} = item;
-    accordion.Close(toggleBtnEl);
+    const { linkEl, toggleBtnEl, subMenuEl } = item;
+    accordion.Close(toggleBtnEl, undefined, item.rootEl);
     syncNavItemLinkClass(linkEl, false);
 
     document.removeEventListener("keydown", item.handlers.documentEscape, true);
@@ -111,7 +126,7 @@ function handleDocumentEscape(item) {
 
 function handleOutsideClick(item) {
     return (e) => {
-        const {toggleBtnEl, subMenuEl} = item;
+        const { toggleBtnEl, subMenuEl } = item;
         if (toggleBtnEl?.contains(e.target)) return;
         if (subMenuEl?.contains(e.target)) return;
         closeSubMenu(item);
@@ -142,7 +157,7 @@ function handleFocusOut(item) {
         // is null when clicking non-focusable whitespace, so we track mousedown instead.
         if (item.clickingInsideSubMenu) return;
 
-        const {toggleBtnEl, subMenuEl} = item;
+        const { toggleBtnEl, subMenuEl } = item;
         const focusMovingTo = e.relatedTarget;
         if (subMenuEl?.contains(focusMovingTo)) return;
         if (toggleBtnEl?.contains(focusMovingTo)) return;

--- a/src/stories/CTALink/CTALink.js
+++ b/src/stories/CTALink/CTALink.js
@@ -1,5 +1,0 @@
-export const CTALink = ({ id, text, href, target, isViewAll, isDisabled }) => {
-    return `
-        <a id="${id}" href="${href}" target="${target}" class="qld__cta-link ${isViewAll ? "qld__cta-link--view-all" : ""}" ${isDisabled ? "disabled" : ""}>${text}</a>
-    `;
-};

--- a/src/stories/CTALink/CTALink.stories.js
+++ b/src/stories/CTALink/CTALink.stories.js
@@ -1,19 +1,23 @@
-import { CTALink } from "./CTALink";
 import { themes, dummyLink, storyParams } from "../../../.storybook/globals";
 import { themeWrapper } from "../../../.storybook/helper-functions";
+import { initComponents } from "../../../.storybook/decorators";
+import initCtaLinks from "../../components/_global/js/cta_links/global";
 
-const ctaLinkArgs = {
-    id: "cta-link-1",
-    text: "CTA Link",
-    href: dummyLink,
-    target: "_blank",
-    isViewAll: false,
-    isDisabled: false,
-};
-
-export default {
+const meta = {
     title: "3. Components/Call to action (CTA)",
-    render: (args) => CTALink(args),
+    render: ({ id, text, href, target, isViewAll, isDisabled }) => {
+        return `
+            <a 
+            id="${id}" 
+            href="${href}" 
+            target="${target}" 
+            class="qld__cta-link ${isViewAll ? "qld__cta-link--view-all" : ""}" 
+            ${isDisabled ? "disabled" : ""}>
+                ${text}
+            </a>
+        `;
+    },
+    decorators: [initComponents([initCtaLinks])],
     argTypes: {
         id: { control: "text", description: "The unique identifier of the component" },
         text: { control: "text", description: "The text of the component" },
@@ -46,147 +50,92 @@ export default {
             description: "If the component is in a disabled state",
         },
     },
-    args: { ...ctaLinkArgs },
+    args: {
+        id: "cta-link-1",
+        text: "CTA Link",
+        href: dummyLink,
+        target: "_blank",
+        isViewAll: false,
+        isDisabled: false,
+    },
     parameters: storyParams("ctaLink"),
 };
+export default meta;
 
 export const Default = {};
 
-export const viewAllVariant = (ctaLinkArgs) =>
-    CTALink({
-        ...ctaLinkArgs,
-        isViewAll: true,
-    });
-viewAllVariant.tags = ["!dev"];
-
-export const disabledVariant = (ctaLinkArgs) =>
-    CTALink({
-        ...ctaLinkArgs,
-        isDisabled: true,
-    });
-disabledVariant.tags = ["!dev"];
-
-export const linkedListExample = (ctaLinkArgs) => {
-    return `
-        <ul aria-label="Related links" class="qld__link-columns qld__link-columns--2-col">
-            <li>${CTALink({
-                ...ctaLinkArgs,
-                text: "Contact us",
-            })}</li>
-            <li>${CTALink({
-                ...ctaLinkArgs,
-                text: "About us",
-            })}</li>
-            <li>${CTALink({
-                ...ctaLinkArgs,
-                text: "Products",
-            })}</li>
-            <li>${CTALink({
-                ...ctaLinkArgs,
-                text: "FAQ",
-            })}</li>
-            <li>${CTALink({
-                ...ctaLinkArgs,
-                text: "Terms and conditions",
-            })}</li>
-            <li>${CTALink({
-                ...ctaLinkArgs,
-                text: "Privacy policy",
-            })}</li>
-            <li>${CTALink({
-                ...ctaLinkArgs,
-                text: "Blog",
-            })}</li>
-            <li>${CTALink({
-                ...ctaLinkArgs,
-                text: "Careers",
-            })}</li>
-            <li>${CTALink({
-                ...ctaLinkArgs,
-                text: "Press",
-            })}</li>
-            <li>${CTALink({
-                ...ctaLinkArgs,
-                text: "Resources",
-            })}</li>
-            <li>${CTALink({
-                ...ctaLinkArgs,
-                text: "Partners",
-            })}</li>
-            <li>${CTALink({
-                ...ctaLinkArgs,
-                text: "Events",
-            })}</li>
-            <li>${CTALink({
-                ...ctaLinkArgs,
-                text: "Community",
-            })}</li>
-            <li>${CTALink({
-                ...ctaLinkArgs,
-                text: "Sitemap",
-            })}</li>
-            <li class="qld__link-columns__all-link">${CTALink({
-                ...ctaLinkArgs,
-                text: "View all",
-                isViewAll: true,
-            })}
-            </li>
-        </ul>
-    `;
-};
-linkedListExample.parameters = {
-    controls: { disable: true },
-    actions: { disable: true },
+export const ViewAllVariant = {
+    args: { isViewAll: true },
 };
 
-export const longCtaLinkExample = (ctaLinkArgs) => {
-    return `
-        <div style="width: 300px;">
-            ${CTALink({
-                ...ctaLinkArgs,
-                text: "Super super long link super long link super long link super long link",
-            })}
-        </div>
-    `;
+export const DisabledVariant = {
+    args: { isDisabled: true },
 };
 
-const allVariants = (args) => {
-    return `
+export const LinkedListExample = {
+    render: (args) => `
+    <ul aria-label="Related links" class="qld__link-columns qld__link-columns--2-col">
+        <li>${meta.render({ ...args, text: "Contact us" })}</li>
+        <li>${meta.render({ ...args, text: "About us" })}</li>
+        <li>${meta.render({ ...args, text: "Products" })}</li>
+        <li>${meta.render({ ...args, text: "FAQ" })}</li>
+        <li>${meta.render({ ...args, text: "Terms and conditions" })}</li>
+        <li>${meta.render({ ...args, text: "Privacy policy" })}</li>
+        <li>${meta.render({ ...args, text: "Blog" })}</li>
+        <li>${meta.render({ ...args, text: "Careers" })}</li>
+        <li>${meta.render({ ...args, text: "Press" })}</li>
+        <li>${meta.render({ ...args, text: "Resources" })}</li>
+        <li>${meta.render({ ...args, text: "Partners" })}</li>
+        <li>${meta.render({ ...args, text: "Events" })}</li>
+        <li>${meta.render({ ...args, text: "Community" })}</li>
+        <li>${meta.render({ ...args, text: "Sitemap" })}</li>
+        <li class="qld__link-columns__all-link">${meta.render({ ...args, text: "View all", isViewAll: true })}</li>
+    </ul>
+    `,
+};
+
+export const LongCtaLinkExample = {
+    render: (args) => `<div style="width: 300px;">${meta.render(args)}</div>`,
+    args: { text: "Super super long link super long link super long link super long link" },
+};
+
+export const AllVariants = {
+    render: (args) => `
         <h3>Default</h3>
-        ${CTALink(args)}
+        ${meta.render(args)}
         <h3>View all</h3>
-        ${viewAllVariant(args)}
+        ${meta.render({ ...args, ...ViewAllVariant.args })}
         <h3>Disabled</h3>
-        ${disabledVariant(args)}
-    `;
+        ${meta.render({ ...args, ...DisabledVariant.args })}
+    `,
 };
 
-export const white = {
+export const White = {
     render: (args) => {
-        return themeWrapper(themes["white"], allVariants(args));
+        return themeWrapper(themes["white"], AllVariants.render(args));
     },
 };
 
-export const light = {
+export const Light = {
     render: (args) => {
-        return themeWrapper(themes["light"], allVariants(args));
+        return themeWrapper(themes["light"], AllVariants.render(args));
     },
 };
 
-export const lightAlt = {
+export const LightAlt = {
     render: (args) => {
-        return themeWrapper(themes["light alt"], allVariants(args));
+        return themeWrapper(themes["light alt"], AllVariants.render(args));
     },
 };
 
-export const dark = {
+export const Dark = {
     render: (args) => {
-        return themeWrapper(themes["dark"], allVariants(args));
+        return themeWrapper(themes["dark"], AllVariants.render(args));
     },
 };
 
-export const darkAlt = {
+export const DarkAlt = {
     render: (args) => {
-        return themeWrapper(themes["dark alt"], allVariants(args));
+        return themeWrapper(themes["dark alt"], AllVariants.render(args));
     },
 };

--- a/src/stories/Cards/CardMultiAction.stories.js
+++ b/src/stories/Cards/CardMultiAction.stories.js
@@ -1,6 +1,8 @@
 import Template from "../../components/card_multi_action/html/component.hbs";
 import { storyParams, iconSpritePath } from "../../../.storybook/globals";
 import ToowoombaImage from "./Toowoomba-web.jpeg";
+import { initComponents } from "../../../.storybook/decorators";
+import initCtaLinks from "../../components/_global/js/cta_links/global";
 
 const mockSite = {
     metadata: { coreSiteIcons: { value: iconSpritePath } },
@@ -96,6 +98,7 @@ function render(args) {
 const meta = {
     title: "3. Components/Cards/Card Multi Action",
     render,
+    decorators: [initComponents([initCtaLinks])],
     argTypes: {
         cardType: {
             description: "Display style for each card.",

--- a/src/stories/Cards/CardSingleAction.stories.js
+++ b/src/stories/Cards/CardSingleAction.stories.js
@@ -1,6 +1,8 @@
 import Template from "../../components/card_single_action/html/component.hbs";
 import { storyParams, iconSpritePath } from "../../../.storybook/globals";
 import ToowoombaImage from "./Toowoomba-web.jpeg";
+import { initComponents } from "../../../.storybook/decorators";
+import initCtaLinks from "../../components/_global/js/cta_links/global";
 
 const mockSite = {
     metadata: { coreSiteIcons: { value: iconSpritePath } },
@@ -77,6 +79,7 @@ function render(args) {
 const meta = {
     title: "3. Components/Cards/Card Single Action",
     render,
+    decorators: [initComponents([initCtaLinks])],
     argTypes: {
         cardType: {
             description: "Display style for each card.",

--- a/src/stories/Forms/SelectBox/SelectBox.stories.js
+++ b/src/stories/Forms/SelectBox/SelectBox.stories.js
@@ -1,6 +1,8 @@
 import { SelectBox } from "./SelectBox";
 import { themes, storyParams } from "../../../../.storybook/globals";
 import { themeWrapper } from "../../../../.storybook/helper-functions.js";
+import { initComponents } from "../../../../.storybook/decorators";
+import initSelectBoxes from "../../../components/_global/js/select_boxes/global";
 
 const selectBoxArgs = {
     id: "select1",
@@ -27,6 +29,7 @@ const selectBoxArgs = {
 export default {
     title: "3. Components/Forms/Select",
     render: SelectBox,
+    decorators: [initComponents([initSelectBoxes])],
     argTypes: {
         id: { control: "text", description: "The id for this component" },
         extraClass: { control: "text", description: "Extra classes that will be applied to the < select > element" },

--- a/src/stories/Forms/forms.stories.js
+++ b/src/stories/Forms/forms.stories.js
@@ -2,6 +2,8 @@ import { Checkboxes } from "./Checkboxes/Checkboxes";
 import { RadioButtons } from "./RadioButtons/RadioButtons";
 import { SelectBox } from "./SelectBox/SelectBox";
 import { storyParams } from "../../../.storybook/globals";
+import initSelectBoxes from "../../components/_global/js/select_boxes/global";
+import { initComponents } from "../../../.storybook/decorators";
 
 function renderTextInput({ id, label, hint, required, optional, state, filled, value = "" }) {
     const stateClass = state === "valid" ? " qld__text-input--valid" : state === "error" ? " qld__text-input--error" : "";
@@ -151,6 +153,7 @@ function renderForm({ filled, showErrors }) {
 const meta = {
     title: "3. Components/Forms",
     render: renderForm,
+    decorators: [initComponents([initSelectBoxes])],
     argTypes: {
         filled: {
             description: "Apply the filled input style across all form fields.",

--- a/src/stories/InPageNavigation/InPageNavigation.stories.js
+++ b/src/stories/InPageNavigation/InPageNavigation.stories.js
@@ -1,5 +1,7 @@
 import Template from "../../components/in_page_navigation/html/component.hbs";
 import { dummyText, storyParams } from "../../../.storybook/globals";
+import { initComponents } from "../../../.storybook/decorators";
+import initInPageNavigation from "../../components/in_page_navigation/js/global";
 
 const renderInPageNavigation = ({ heading, headingType, ...args }) =>
     Template({
@@ -46,6 +48,7 @@ export default {
     },
     parameters: storyParams("inPageNavigation"),
     decorators: [
+        initComponents([initInPageNavigation]),
         (Story, context) => {
             // Default IDs for headings. Simulates the publisher not adding custom ID's to the page headings which is a
             // common scenario

--- a/src/stories/LinkColumns/LinkColumns.stories.js
+++ b/src/stories/LinkColumns/LinkColumns.stories.js
@@ -1,6 +1,8 @@
 import { LinkColumns } from "./LinkColumns";
 import { themes, dummyLink, storyParams } from "../../../.storybook/globals";
 import { themeWrapper } from "../../../.storybook/helper-functions";
+import { initComponents } from "../../../.storybook/decorators";
+import initCtaLinks from "../../components/_global/js/cta_links/global";
 
 const linkColumnsArgs = {
     ariaLabel: "related links",
@@ -42,6 +44,7 @@ const linkColumnsArgs = {
 export default {
     title: "3. Components/Link Columns",
     render: LinkColumns,
+    decorators: [initComponents([initCtaLinks])],
     argTypes: {
         ariaLabel: { control: "text", description: "The aria " },
         columns: {

--- a/src/stories/MegaMainNavigation/mega_main_navigation.stories.js
+++ b/src/stories/MegaMainNavigation/mega_main_navigation.stories.js
@@ -2,6 +2,7 @@ import Template from "../../components/mega_main_navigation/html/component.hbs";
 import { initMegaMenu } from "../../components/mega_main_navigation/js/global.js";
 import { within, userEvent, expect } from "storybook/test";
 import { storyParams } from "../../../.storybook/globals";
+import { initComponents } from "../../../.storybook/decorators";
 
 function render(args) {
     const { site, children, currentAssetid, showMegaMenu, showHomeIcon, showPageDescLevelOne, showPageDescLevelTwo, showViewAll, preHeaderTheme, navStyle, ctaOneText, ctaOneIcon, ctaTwoText, ctaTwoIcon } = args;
@@ -140,10 +141,25 @@ const sampleChildren = [
     },
 ];
 
+const storyDocs = storyParams("navbar");
+
 const meta = {
     title: "3. Components/Mega Main Navigation",
     render,
-    parameters: storyParams("navbar"),
+    decorators: [initComponents([initMegaMenu])],
+    parameters: {
+        ...storyDocs,
+        docs: {
+            ...storyDocs.docs,
+            story: {
+                ...storyDocs.docs.story,
+                // The open mega-menu panel is position:absolute (see
+                // mega_main_navigation/css/component.scss:154) so it doesn't expand its
+                // parent. Give the docs Canvas room for an opened panel.
+                height: "620px",
+            },
+        },
+    },
     argTypes: {
         showMegaMenu: { name: "Mega menu enabled", control: "boolean" },
         showHomeIcon: { name: "Show home icon", control: "boolean" },
@@ -189,16 +205,7 @@ export default meta;
  * The default light-theme nav with the mega menu enabled, home icon, two CTAs,
  * and a single level of inline descriptions inside the open panel.
  */
-export const Default = {
-    // The open mega-menu panel is position:absolute (see
-    // mega_main_navigation/css/component.scss:154) so it doesn't expand its
-    // parent. Give the docs Canvas room for an opened panel.
-    parameters: {
-        docs: {
-            story: { height: "550px" },
-        },
-    },
-};
+export const Default = {};
 
 /**
  * Dark nav style paired with the dark pre-header theme. Use when the rest of

--- a/src/stories/MegaMainNavigation/mega_main_navigation.stories.js
+++ b/src/stories/MegaMainNavigation/mega_main_navigation.stories.js
@@ -3,6 +3,7 @@ import { initMegaMenu } from "../../components/mega_main_navigation/js/global.js
 import { within, userEvent, expect } from "storybook/test";
 import { storyParams } from "../../../.storybook/globals";
 import { initComponents } from "../../../.storybook/decorators";
+import initCtaLinks from "../../components/_global/js/cta_links/global";
 
 function render(args) {
     const { site, children, currentAssetid, showMegaMenu, showHomeIcon, showPageDescLevelOne, showPageDescLevelTwo, showViewAll, preHeaderTheme, navStyle, ctaOneText, ctaOneIcon, ctaTwoText, ctaTwoIcon } = args;
@@ -146,7 +147,7 @@ const storyDocs = storyParams("navbar");
 const meta = {
     title: "3. Components/Mega Main Navigation",
     render,
-    decorators: [initComponents([initMegaMenu])],
+    decorators: [initComponents([initMegaMenu, initCtaLinks])],
     parameters: {
         ...storyDocs,
         docs: {

--- a/vitest.config.js
+++ b/vitest.config.js
@@ -1,0 +1,32 @@
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+import { defineConfig } from "vitest/config";
+import { storybookTest } from "@storybook/addon-vitest/vitest-plugin";
+import { playwright } from "@vitest/browser-playwright";
+
+const dirname =
+    typeof __dirname !== "undefined" ? __dirname : path.dirname(fileURLToPath(import.meta.url));
+
+// https://storybook.js.org/docs/writing-tests/integrations/vitest-addon
+export default defineConfig({
+    test: {
+        projects: [
+            {
+                extends: true,
+                plugins: [
+                    storybookTest({ configDir: path.join(dirname, ".storybook") }),
+                ],
+                test: {
+                    name: "storybook",
+                    browser: {
+                        enabled: true,
+                        headless: true,
+                        provider: playwright({}),
+                        instances: [{ browser: "chromium" }],
+                    },
+                },
+            },
+        ],
+    },
+});


### PR DESCRIPTION
* Installed vitest so we can run storybook tests locally. Uses playwright to test against chrome. This will test stories render correctly and the interaction tests pass. It does not cover visual testing which still requires chromatic.
* Stopped storybook calling initComponents and instead switched to story files calling the initialisation functions that are required to render the stories.
* Updated some components JS files to accept a `root` element so that dom actions can be scoped to a more specific container instead of the whole document. This is important for stories to work when viewing the sotry docs as there are multiple of the same component rendered on the page ande using document would only attach listenere or find elements on the first story rendered. In production `root` defaults to `document`.