### PR TITLE
Restrict chromatic ci workflow to read only access permission.

### DIFF
--- a/.github/workflows/chromatic.yml
+++ b/.github/workflows/chromatic.yml
@@ -11,6 +11,9 @@ on:
       - '**/*.md'
       - 'docs/**'
 
+permissions:
+  contents: read
+
 concurrency:
   group: chromatic-${{ github.ref }}
   cancel-in-progress: true


### PR DESCRIPTION
This pull request adds explicit permissions to the Chromatic GitHub Actions workflow, improving its security posture by restricting access to repository contents.

Workflow permissions update:

* [`.github/workflows/chromatic.yml`](diffhunk://#diff-5db7bb8117a68fd50e5b5e0cbdca28ab4e360e4dd0aeba88911f9404a719700bR14-R16): Added a `permissions` block to set `contents: read`, ensuring the workflow only has read access to repository contents.