### PR TITLE
QHDEV-642 - Apply main nav flex only on large screens

### DIFF
--- a/src/components/main_navigation/css/component.scss
+++ b/src/components/main_navigation/css/component.scss
@@ -556,8 +556,16 @@ $QLD-header-md: 72px;
     }
 
     &--flex {
-      display: flex;
-      flex-wrap: wrap;
+      // Flexbox horizontal layout is a desktop-only concern: it replaces the
+      // float-based top-level nav (QHDEV-642). On mobile the nav is a vertical
+      // sidebar accordion inside a full-height fixed panel, where a flex-wrap
+      // container's lines stretch (align-content: stretch) to fill that height
+      // and pull the items apart. Keep the list in normal block flow below the
+      // desktop breakpoint so the accordion items stay tightly aligned.
+      @include QLD-media(lg) {
+        display: flex;
+        flex-wrap: wrap;
+      }
     }
   }
 

--- a/src/stories/GlobalNavigation/MegaMainNavigation/mega_main_navigation.stories.js
+++ b/src/stories/GlobalNavigation/MegaMainNavigation/mega_main_navigation.stories.js
@@ -375,7 +375,9 @@ export const DescriptionsOnBothLevels = {
  * script, which binds on DOMContentLoaded and isn't wired into Storybook, so
  * the play function applies the drawer's open state directly (the same approach
  * the Internal Navigation MobileToggle story uses) for a deterministic
- * snapshot.
+ * snapshot. It then expands one of the sidebar's nav accordions — which IS
+ * driven by initMegaMenu (wired in via the decorator) — with a real click, so
+ * the snapshot shows an open submenu inside the drawer.
  */
 export const MobileOpenWithHeader = {
   render: (args) => renderHeader({ ...headerArgs, ...args }),
@@ -402,5 +404,24 @@ export const MobileOpenWithHeader = {
     closeBtn?.setAttribute("aria-expanded", "true");
 
     await expect(nav).toHaveClass("qld__main-nav__content--open");
+
+    // With the drawer open, the top-level items render as a stack of accordions
+    // in the sidebar. Expanding one is driven by initMegaMenu — which IS wired
+    // into Storybook (unlike the drawer toggle above) — so a real click works.
+    const canvas = within(canvasElement);
+    const accordionToggle = canvas.getByRole("button", {
+      name: /toggle navigation, services/i,
+    });
+
+    await expect(accordionToggle).toHaveAttribute("aria-expanded", "false");
+
+    await userEvent.click(accordionToggle);
+
+    // The toggle reports expanded and its controlled submenu opens.
+    await expect(accordionToggle).toHaveAttribute("aria-expanded", "true");
+    const submenu = canvasElement.querySelector(
+      `[id="${accordionToggle.getAttribute("aria-controls")}"]`,
+    );
+    await expect(submenu).toHaveClass("qld__accordion--open");
   },
 };


### PR DESCRIPTION
On small screens, the nav items stack as accordions in the sidebar. 'flex wrap' here does not work as it causes the items to stretch and not appear in their expected positions.

<img width="369" height="777" alt="image" src="https://github.com/user-attachments/assets/4812fc3f-08d1-4bc1-82e2-251a5a5925cc" />
