### PR TITLE
Make dummyImageLink a relative url instead of absolute

### DIFF
--- a/.storybook/globals.js
+++ b/.storybook/globals.js
@@ -40,7 +40,7 @@ export const dummyLink = "https://www.google.com";
 // Served locally from .storybook/assets (a staticDir) so Chromatic snapshots
 // are deterministic — an external image URL loads intermittently at capture
 // time, making the image flicker in/out between builds.
-export const dummyImageLink = "/Culex_annulirostris_female2.jpg";
+export const dummyImageLink = "Culex_annulirostris_female2.jpg";
 
 // Path to the icon sprite, relative to the Storybook preview iframe. Used for
 // <use href> references and the coreSiteIcons metadata across stories.

--- a/src/stories/Footer/Footer.stories.js
+++ b/src/stories/Footer/Footer.stories.js
@@ -20,7 +20,7 @@ const footerArgs = {
     // Served locally from .storybook/assets (a staticDir) so Chromatic snapshots
     // are deterministic — an external logo URL loads intermittently at capture
     // time, making the SVG flicker in/out between builds.
-    asset_url: "/coa-delivering-for-qld-mono-blue-mini-lockup.svg",
+    asset_url: "coa-delivering-for-qld-mono-blue-mini-lockup.svg",
   },
 
   footerLinks: [
@@ -187,7 +187,7 @@ export const Dark = {
   args: {
     footerStyle: "qld__footer--dark",
     footerLogo: {
-      asset_url: "/coa-delivering-for-qld-mono-white-mini-lockup.svg",
+      asset_url: "coa-delivering-for-qld-mono-white-mini-lockup.svg",
     },
   },
 };
@@ -195,7 +195,7 @@ export const DarkAlt = {
   args: {
     footerStyle: "qld__footer--dark-alt",
     footerLogo: {
-      asset_url: "/coa-delivering-for-qld-mono-white-mini-lockup.svg",
+      asset_url: "coa-delivering-for-qld-mono-white-mini-lockup.svg",
     },
   },
 };

--- a/src/stories/Header/Header.js
+++ b/src/stories/Header/Header.js
@@ -79,7 +79,7 @@ export const headerArgs = {
   // Served locally from .storybook/assets (a staticDir) so Chromatic snapshots
   // are deterministic — an external logo URL loads intermittently at capture
   // time, making the image flicker in/out between builds.
-  sitePreHeaderLogo: "/CoA-Black-Mobile.svg",
+  sitePreHeaderLogo: "CoA-Black-Mobile.svg",
   siteLogoUrl: "https://www.qld.gov.au/",
   siteLogo: "",
   siteShowLogo: "yes",

--- a/src/stories/PromoPanel/PromoPanel.stories.js
+++ b/src/stories/PromoPanel/PromoPanel.stories.js
@@ -71,7 +71,7 @@ const promoPanelArgs = {
   // Served locally from .storybook/assets (a staticDir) so Chromatic snapshots
   // are deterministic — an external image URL loads intermittently at capture
   // time, making the image flicker in/out between builds.
-  promoImage: "/Woorabinda.jpg",
+  promoImage: "Woorabinda.jpg",
   bodyBackground: "qld__body--light",
   imageAlignment: "qld__promo-panel--image-left",
   promoPanelIcon: "zoom",


### PR DESCRIPTION
This pull request updates several Storybook story files to remove leading slashes from local asset paths. This change standardizes how assets are referenced, which can help prevent issues with asset loading in different environments, such as Chromatic or local development.

**Asset path updates:**

* Updated image and SVG asset paths in `.storybook/globals.js`, `src/stories/Footer/Footer.stories.js`, `src/stories/Header/Header.js`, and `src/stories/PromoPanel/PromoPanel.stories.js` to remove the leading `/`, ensuring assets are referenced relative to the static directory. [[1]](diffhunk://#diff-1c98674e85f69091f48d3a418727475e5c424b152c26c65c1a3bde6befcef523L43-R43) [[2]](diffhunk://#diff-8bf183e870b602dbac400f062ab6fdd3d2f53f87254d01c0603d085135d431e7L23-R23) [[3]](diffhunk://#diff-8bf183e870b602dbac400f062ab6fdd3d2f53f87254d01c0603d085135d431e7L190-R198) [[4]](diffhunk://#diff-1206fe160bddac6ca3a517ee3dc9d104178953f67f9bcb6228ff32b1c68d739bL82-R82) [[5]](diffhunk://#diff-634f6904fe304a1cf99f5f81687653c909fd70552dfe7ac1c7924984bd6584b7L74-R74)