### PR TITLE
QHDEV-678 - Create a Landing Page storybook template

### DIFF
--- a/.storybook/preview.js
+++ b/.storybook/preview.js
@@ -66,7 +66,13 @@ const preview = {
     options: {
       storySort: {
         // Force SB to load Introduction page first
-        order: ["Introduction", "1. Core Styles", "2. Layout", "3. Components"],
+        order: [
+          "Introduction",
+          "1. Core Styles",
+          "2. Layout",
+          "3. Components",
+          "4. Templates",
+        ],
       },
     },
   },

--- a/src/stories/Templates/ContentPage.stories.js
+++ b/src/stories/Templates/ContentPage.stories.js
@@ -1,0 +1,90 @@
+import { initComponents } from "../../../.storybook/decorators";
+import { initMegaMenu } from "../../components/mega_main_navigation/js/global";
+import initCtaLinks from "../../components/_global/js/cta_links/global";
+import { initAccordion } from "../../components/accordion/js/global";
+import initInternalNavigation from "../../components/internal_navigation/js/global";
+import initInPageNavigation from "../../components/in_page_navigation/js/global";
+import {
+  renderSiteHeader,
+  renderSiteFooter,
+  renderPrefooter,
+  renderBanner,
+  renderSideNav,
+  renderInPageNav,
+  contentBody,
+} from "./templateHelpers.js";
+
+/**
+ * A full content page: header + mega main nav, a banner with breadcrumbs, a
+ * side navigation beside the main content, an in-page ("On this page")
+ * navigation, body copy, a pre-footer and the footer.
+ */
+function renderContentPage(args) {
+  const { site } = args;
+
+  return `
+    ${renderSiteHeader(site)}
+    <main class="main" role="main">
+      ${renderBanner({
+        headingPrimary: "Applying for a health card",
+        abstract:
+          "Everything you need to know about eligibility, the application process and what happens next.",
+        backgroundColour: "dark",
+        backgroundType: "texture",
+        showBreadcrumbs: true,
+      })}
+      <div class="qld__body">
+        <div class="container-fluid">
+          <div class="row">
+            <div class="col-xs-12 col-md-4 col-lg-3">
+              ${renderSideNav()}
+            </div>
+            <div class="col-xs-12 col-md-8 col-lg-9" id="content">
+              ${renderInPageNav()}
+              ${contentBody()}
+            </div>
+          </div>
+        </div>
+      </div>
+      ${renderPrefooter(site, { pageType: "content" })}
+    </main>
+    ${renderSiteFooter(site)}
+  `;
+}
+
+export default {
+  title: "4. Templates/Content page",
+  render: renderContentPage,
+  parameters: {
+    layout: "fullscreen",
+    docs: {
+      description: {
+        component:
+          "A representative content page assembled from the design system's " +
+          "layout and component stories: header with the horizontal mega " +
+          "navigation, a banner carrying breadcrumbs, a side navigation, the " +
+          "main content column with an in-page navigation and body copy, then " +
+          "the pre-footer and footer.",
+      },
+    },
+  },
+  // All the interactive chrome a content page needs: the mega menu and its CTA
+  // links, the side nav (an accordion below its breakpoint), and the in-page
+  // navigation that builds its list from the headings inside `#content`.
+  decorators: [
+    initComponents([
+      initMegaMenu,
+      initCtaLinks,
+      initAccordion,
+      initInternalNavigation,
+      initInPageNavigation,
+    ]),
+  ],
+  // The page supplies its own full-width layout, so opt out of controls that
+  // don't apply to a whole-page composition.
+  argTypes: {
+    site: { table: { disable: true } },
+  },
+};
+
+export const Default = {};

--- a/src/stories/Templates/ContentPage.stories.js
+++ b/src/stories/Templates/ContentPage.stories.js
@@ -4,6 +4,7 @@ import initCtaLinks from "../../components/_global/js/cta_links/global";
 import { initAccordion } from "../../components/accordion/js/global";
 import initInternalNavigation from "../../components/internal_navigation/js/global";
 import initInPageNavigation from "../../components/in_page_navigation/js/global";
+import initPromoPanel from "../../components/promo_panel/js/global";
 import {
   renderSiteHeader,
   renderSiteFooter,
@@ -11,6 +12,7 @@ import {
   renderBanner,
   renderSideNav,
   renderInPageNav,
+  renderPromoPanel,
   contentBody,
 } from "./templateHelpers.js";
 
@@ -46,6 +48,14 @@ function renderContentPage(args) {
           </div>
         </div>
       </div>
+      ${renderPromoPanel(site, {
+        title: "Need help with your application?",
+        abstract:
+          "Our team can guide you through eligibility, the application process and what happens next.",
+        imageAlignment: "qld__promo-panel--image-right",
+        bodyBackground: "qld__body--light",
+        promoPanelIcon: undefined,
+      })}
       ${renderPrefooter(site, { pageType: "content" })}
     </main>
     ${renderSiteFooter(site)}
@@ -78,6 +88,7 @@ export default {
       initAccordion,
       initInternalNavigation,
       initInPageNavigation,
+      initPromoPanel,
     ]),
   ],
   // The page supplies its own full-width layout, so opt out of controls that

--- a/src/stories/Templates/LandingPage.stories.js
+++ b/src/stories/Templates/LandingPage.stories.js
@@ -1,0 +1,177 @@
+import { initComponents } from "../../../.storybook/decorators";
+import { initMegaMenu } from "../../components/mega_main_navigation/js/global";
+import initCtaLinks from "../../components/_global/js/cta_links/global";
+import initCards from "../../components/card_no_action/js/global";
+import initBannerAdvanced from "../../components/banner_advanced/js/global";
+import CardSingleActionMeta from "../Cards/CardSingleAction.stories.js";
+import ToowoombaImage from "../Cards/Toowoomba-web.jpeg";
+import {
+  renderSiteHeader,
+  renderSiteFooter,
+  renderPrefooter,
+  renderAdvancedBanner,
+  icon,
+} from "./templateHelpers.js";
+
+// "Our facilities": a feature card (image on the right) beside a link list of
+// related facilities. The card mirrors the card_feature component's markup so it
+// sits cleanly in a grid column, with contact links in its footer.
+const facilitiesSection = () => {
+  const contact = (iconName, text, href) =>
+    `<li><a class="qld__card__footer-link" href="${href}">${icon(iconName, "qld__card__footer-link-icon")}<span>${text}</span></a></li>`;
+
+  const facilityLink = (text) => `<li><a href="#">${text}</a></li>`;
+
+  return `
+    <section class="qld__body">
+      <div class="container-fluid">
+        <h2>Our facilities</h2>
+        <div class="row">
+          <div class="col-xs-12 col-lg-8">
+            <div class="qld__card qld__card__multi-action qld__card--image qld__card__multi-action--feature qld__card__multi-action--image-right">
+              <div class="qld__card__image-wrapper">
+                <div
+                  class="qld__responsive-media-img--bg"
+                  style="background-image: url('${ToowoombaImage}');"
+                  role="img"
+                  aria-label="Toowoomba Hospital"
+                ></div>
+              </div>
+              <div class="qld__card__inner">
+                <div class="qld__card__content">
+                  <div class="qld__card__content-inner">
+                    <h3 class="qld__card__title">
+                      <a class="qld__card--clickable__link" href="#">Toowoomba Hospital</a>
+                    </h3>
+                    <p class="qld__card__description">Address: Pechey St, Toowoomba QLD 4350</p>
+                  </div>
+                </div>
+                <div class="qld__card__footer">
+                  <hr class="qld__horizontal-rule" aria-hidden="true" />
+                  <div class="qld__card__footer-inner">
+                    <ul class="qld__link-list">
+                      ${contact("phone", "Phone 07 4616 6000", "tel:0746166000")}
+                      ${contact("alert-warning", "For emergencies call 000", "tel:000")}
+                      ${contact("phone", "For non-urgent health advice call 13 HEALTH (13 43 25 84)", "tel:134325")}
+                    </ul>
+                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
+          <div class="col-xs-12 col-lg-4">
+            <h3>Hospitals and health centres</h3>
+            <ul aria-label="Hospitals and health centres" class="qld__link-columns">
+              ${facilityLink("Baillie Henderson Hospital")}
+              ${facilityLink("Warwick Hospital")}
+              ${facilityLink("Kingaroy Hospital")}
+              ${facilityLink("Dalby Hospital")}
+              <li class="qld__link-columns__all-link">
+                <a href="#" class="qld__cta-link qld__cta-link--view-all">All hospitals and facilities</a>
+              </li>
+            </ul>
+          </div>
+        </div>
+      </div>
+    </section>
+  `;
+};
+
+// "Our services": a grid of icon cards. Reuses the Card (single action) story so
+// the grid stays in sync with the component; only the section content differs.
+const serviceCard = (id, name, iconName) => ({
+  assetid: String(id),
+  type_code: "page_standard",
+  name,
+  metadata: {
+    shortDescription: { value: "" },
+    cardIcon: { value: iconName },
+    redirect_url: { value: "#" },
+    cardDisplayFooter: { value: "false" },
+    cardFooterContent: { value: "" },
+  },
+});
+
+const servicesSection = () => {
+  const result = CardSingleActionMeta.render({
+    ...CardSingleActionMeta.args,
+    cardType: "icon",
+    iconAlign: "",
+    colWidth: "col-md-6 col-lg-4",
+    showArrow: false,
+    showViewAll: true,
+    introHeading: "Our services",
+    bodyBackground: "qld__body--light",
+    // Card icons render through `iconSwitch` as Material Symbols ligatures
+    // (the font is loaded in .storybook/preview-head.html), so these are
+    // Material Symbols Rounded names.
+    children: [
+      serviceCard(1, "Community health", "groups"),
+      serviceCard(2, "Sexual health", "favorite"),
+      serviceCard(3, "Dental", "dentistry"),
+      serviceCard(4, "Maternity", "pregnant_woman"),
+      serviceCard(5, "Mental health", "psychology"),
+      serviceCard(6, "Emergency", "emergency"),
+    ],
+  });
+  return typeof result === "string" ? result : result.innerHTML;
+};
+
+/**
+ * A full landing page: header + mega main nav, an advanced hero banner (with a
+ * link list and image), an "Our facilities" section (feature card + link list)
+ * and an "Our services" grid of cards, then the pre-footer and footer.
+ */
+function renderLandingPage(args) {
+  const { site } = args;
+
+  return `
+    ${renderSiteHeader(site)}
+    <main class="main landing" role="main">
+      ${renderAdvancedBanner({
+        headingPrimary: "Darling Downs Health",
+        showHeadingBackground: true,
+        abstract:
+          "Hospitals, health services and support for the Darling Downs and South West communities.",
+        backgroundColour: "dark",
+        backgroundType: "colour",
+        showBreadcrumbs: true,
+        heroImage: "https://placehold.co/782x520",
+        heroImageAlt: "Toowoomba Hospital",
+        heroImageTreatment: "crop",
+        heroImageAlignment: "grid",
+        ctaType: "link-list",
+      })}
+      ${facilitiesSection()}
+      ${servicesSection()}
+      ${renderPrefooter(site, { pageType: "landing" })}
+    </main>
+    ${renderSiteFooter(site)}
+  `;
+}
+
+export default {
+  title: "4. Templates/Landing page",
+  render: renderLandingPage,
+  parameters: {
+    layout: "fullscreen",
+    docs: {
+      description: {
+        component:
+          "A representative landing page assembled from the design system's " +
+          "layout and component stories: header with the horizontal mega " +
+          "navigation, an advanced hero banner with a link list, an 'Our " +
+          "facilities' section pairing a feature card with a link list, an " +
+          "'Our services' grid of cards, then the pre-footer and footer.",
+      },
+    },
+  },
+  decorators: [
+    initComponents([initMegaMenu, initCtaLinks, initCards, initBannerAdvanced]),
+  ],
+  argTypes: {
+    site: { table: { disable: true } },
+  },
+};
+
+export const Default = {};

--- a/src/stories/Templates/LandingPage.stories.js
+++ b/src/stories/Templates/LandingPage.stories.js
@@ -3,6 +3,7 @@ import { initMegaMenu } from "../../components/mega_main_navigation/js/global";
 import initCtaLinks from "../../components/_global/js/cta_links/global";
 import initCards from "../../components/card_no_action/js/global";
 import initBannerAdvanced from "../../components/banner_advanced/js/global";
+import initPromoPanel from "../../components/promo_panel/js/global";
 import CardSingleActionMeta from "../Cards/CardSingleAction.stories.js";
 import ToowoombaImage from "../Cards/Toowoomba-web.jpeg";
 import {
@@ -10,6 +11,7 @@ import {
   renderSiteFooter,
   renderPrefooter,
   renderAdvancedBanner,
+  renderPromoPanel,
   icon,
 } from "./templateHelpers.js";
 
@@ -144,6 +146,14 @@ function renderLandingPage(args) {
       })}
       ${facilitiesSection()}
       ${servicesSection()}
+      ${renderPromoPanel(site, {
+        title: "Find a health service near you",
+        abstract:
+          "Search our directory of hospitals, community health centres and support services across the Darling Downs and South West.",
+        imageAlignment: "qld__promo-panel--image-right",
+        bodyBackground: "qld__body--dark",
+        promoPanelIcon: undefined,
+      })}
       ${renderPrefooter(site, { pageType: "landing" })}
     </main>
     ${renderSiteFooter(site)}
@@ -167,7 +177,13 @@ export default {
     },
   },
   decorators: [
-    initComponents([initMegaMenu, initCtaLinks, initCards, initBannerAdvanced]),
+    initComponents([
+      initMegaMenu,
+      initCtaLinks,
+      initCards,
+      initBannerAdvanced,
+      initPromoPanel,
+    ]),
   ],
   argTypes: {
     site: { table: { disable: true } },

--- a/src/stories/Templates/templateHelpers.js
+++ b/src/stories/Templates/templateHelpers.js
@@ -1,0 +1,86 @@
+// Shared building blocks for the page-template demo stories.
+//
+// These templates don't introduce any new markup of their own — they stitch
+// together the existing component stories so the demos stay in sync with the
+// components they showcase. Each helper calls the relevant story's own `render`
+// (exported as `meta.render`) with that story's default args, letting callers
+// override only what a page needs. This is the same approach Header.js uses to
+// embed the mega nav.
+
+import { renderHeader, headerArgs } from "../Header/Header.js";
+import FooterMeta from "../Footer/Footer.stories.js";
+import PrefooterMeta from "../Prefooter/Prefooter.stories.js";
+import BannerBasicMeta from "../Banner/bannerBasic.stories.js";
+import BannerAdvancedMeta from "../Banner/bannerAdvanced.stories.js";
+import SideNavMeta from "../Navigation/InternalNavigation/InternalNavigation.stories.js";
+import InPageNavMeta from "../Navigation/InPageNavigation/InPageNavigation.stories.js";
+import { dummyText, iconSpritePath } from "../../../.storybook/globals";
+
+/** An inline SVG icon referencing the shared sprite (as `iconSwitch` produces). */
+export const icon = (name, extraClass = "") =>
+  `<svg class="qld__icon ${extraClass}" aria-hidden="true" xmlns="http://www.w3.org/2000/svg"><use href="${iconSpritePath}#${name}"></use></svg>`;
+
+/** Header chrome (pre-header, logo, search) plus the horizontal mega nav. */
+export const renderSiteHeader = (site) => renderHeader({ ...headerArgs, site });
+
+/** Footer. `site` carries the shared `coreSiteIcons` metadata the SVGs need. */
+export const renderSiteFooter = (site) =>
+  FooterMeta.render({ ...FooterMeta.args, site });
+
+/** Pre-footer ("Last updated" + "Back to top"). */
+export const renderPrefooter = (site, overrides = {}) =>
+  PrefooterMeta.render({ ...PrefooterMeta.args, site, ...overrides });
+
+/**
+ * Page banner. The basic banner story renders into a detached container (so it
+ * can swap in the bundled texture image), so unwrap it to a markup string.
+ */
+export const renderBanner = (overrides = {}) => {
+  const result = BannerBasicMeta.render({
+    ...BannerBasicMeta.args,
+    ...overrides,
+  });
+  return typeof result === "string" ? result : result.innerHTML;
+};
+
+/**
+ * Advanced banner (hero image + a link-list, icon-tile or button CTA). Like the
+ * basic banner it renders into a detached container so it can swap in a bundled
+ * hero image, so unwrap it to a markup string.
+ */
+export const renderAdvancedBanner = (overrides = {}) => {
+  const result = BannerAdvancedMeta.render({
+    ...BannerAdvancedMeta.args,
+    ...overrides,
+  });
+  return typeof result === "string" ? result : result.innerHTML;
+};
+
+/** Side (internal) navigation for the current section. */
+export const renderSideNav = (overrides = {}) =>
+  SideNavMeta.render({ ...SideNavMeta.args, ...overrides });
+
+/** "On this page" in-page navigation. It scans `#content` for headings at run time. */
+export const renderInPageNav = (overrides = {}) =>
+  InPageNavMeta.render({ ...InPageNavMeta.args, ...overrides });
+
+/**
+ * A block of representative page copy: a handful of `h2` sections (each with a
+ * short `h3` sub-section) so the in-page nav has real anchors to list.
+ */
+export const contentBody = () => {
+  const section = (heading, sub) => `
+    <h2>${heading}</h2>
+    <p>${dummyText}</p>
+    <p>${dummyText}</p>
+    <h3>${sub}</h3>
+    <p>${dummyText}</p>
+  `;
+
+  return [
+    section("Overview", "Who this is for"),
+    section("Eligibility", "What you need"),
+    section("How to apply", "Step by step"),
+    section("After you apply", "What happens next"),
+  ].join("");
+};

--- a/src/stories/Templates/templateHelpers.js
+++ b/src/stories/Templates/templateHelpers.js
@@ -14,6 +14,7 @@ import BannerBasicMeta from "../Banner/bannerBasic.stories.js";
 import BannerAdvancedMeta from "../Banner/bannerAdvanced.stories.js";
 import SideNavMeta from "../Navigation/InternalNavigation/InternalNavigation.stories.js";
 import InPageNavMeta from "../Navigation/InPageNavigation/InPageNavigation.stories.js";
+import PromoPanelMeta from "../PromoPanel/PromoPanel.stories.js";
 import { dummyText, iconSpritePath } from "../../../.storybook/globals";
 
 /** An inline SVG icon referencing the shared sprite (as `iconSwitch` produces). */
@@ -63,6 +64,21 @@ export const renderSideNav = (overrides = {}) =>
 /** "On this page" in-page navigation. It scans `#content` for headings at run time. */
 export const renderInPageNav = (overrides = {}) =>
   InPageNavMeta.render({ ...InPageNavMeta.args, ...overrides });
+
+/**
+ * Promo panel. Like the banners it renders into a detached container (so it can
+ * swap in the bundled promo image), so unwrap it to a markup string. `site`
+ * carries the `coreSiteIcons` metadata the panel's icon SVG references — the
+ * template stories render children directly, bypassing the global `site` arg.
+ */
+export const renderPromoPanel = (site, overrides = {}) => {
+  const result = PromoPanelMeta.render({
+    ...PromoPanelMeta.args,
+    site,
+    ...overrides,
+  });
+  return typeof result === "string" ? result : result.innerHTML;
+};
 
 /**
  * A block of representative page copy: a handful of `h2` sections (each with a


### PR DESCRIPTION
JIRA: QHDEV-678 and QHDEV-677

This pull request adds two new Storybook page template stories—`LandingPage.stories.js` and `ContentPage.stories.js`—which assemble full-page demos from existing design system components. It also introduces a set of shared helpers in `templateHelpers.js` to keep these templates in sync with the component stories, and updates the Storybook sidebar order to include the new "Templates" section.

**New page template stories:**

* Added `LandingPage.stories.js` to showcase a representative landing page composed from the design system's components, including advanced banners, feature cards, service grids, and promo panels.
* Added `ContentPage.stories.js` to demonstrate a typical content page layout, integrating header, banner, side navigation, in-page navigation, content body, promo panel, pre-footer, and footer.

**Shared template helpers:**

* Introduced `templateHelpers.js`, providing reusable functions for rendering common page sections (header, footer, banners, navigation, promo panels, and content body) by delegating to the component stories.

**Storybook configuration:**

* Updated `.storybook/preview.js` to add "4. Templates" to the sidebar navigation, ensuring the new page templates are easily discoverable in Storybook.