### PR TITLE
QHDEV-734 - Replace src/helpers/global-helpers.js with src/utils

### DIFF
--- a/src/components/_global/js/collapsible.js
+++ b/src/components/_global/js/collapsible.js
@@ -13,7 +13,7 @@
  */
 
 import * as animate from "../../../utils/animate.js";
-import { isExpanded, setExpanded } from "../../../helpers/global-helpers.js";
+import * as aria from "../../../utils/aria.js";
 
 /**
  * Shared state-class contract. These class names are also referenced by the CSS
@@ -110,7 +110,7 @@ export function open(elements, speed, root = document, callbacks = {}) {
     target.style.display = "";
     toggleClasses(target, "opening");
     toggleClasses(element, "opening");
-    setExpanded(element, true);
+    aria.setExpanded(element, true);
 
     callbacks.onOpen?.();
     dispatchToggle(element, true);
@@ -147,7 +147,7 @@ export function close(elements, speed, root = document, callbacks = {}) {
     const target = getTarget(element, root);
 
     toggleClasses(element, "closing");
-    setExpanded(element, false);
+    aria.setExpanded(element, false);
 
     callbacks.onClose?.();
     dispatchToggle(element, false);
@@ -194,7 +194,7 @@ export function toggle(elements, speed, root = document, callbacks) {
       );
     }
 
-    if (isExpanded(element)) {
+    if (aria.isExpanded(element)) {
       close(element, speed, root, callbacks);
     } else {
       open(element, speed, root, callbacks);

--- a/src/components/accordion/js/global.js
+++ b/src/components/accordion/js/global.js
@@ -3,7 +3,7 @@
  */
 
 import * as collapsible from "../../_global/js/collapsible.js";
-import { isExpanded, setExpanded } from "../../../helpers/global-helpers.js";
+import * as aria from "../../../utils/aria.js";
 
 export function initAccordion(root = document) {
   const controller = new AbortController();
@@ -81,7 +81,7 @@ function initAccordionGroup(groupEl, signal) {
 function setToggleAllState(toggleAllBtn, isOpen) {
   toggleAllBtn.classList.toggle("qld__accordion__toggle-btn--open", isOpen);
   toggleAllBtn.classList.toggle("qld__accordion__toggle-btn--closed", !isOpen);
-  setExpanded(toggleAllBtn, isOpen);
+  aria.setExpanded(toggleAllBtn, isOpen);
 
   // Only update the label so the inline chevron svg is preserved; fall back
   // to the whole button for legacy markup without the <span> wrapper
@@ -100,7 +100,7 @@ function syncToggleAllButton(groupEl) {
   if (!toggleAllBtn) return;
 
   const titles = groupEl.querySelectorAll(".qld__accordion__title");
-  const allOpen = titles.length > 0 && [...titles].every(isExpanded);
+  const allOpen = titles.length > 0 && [...titles].every(aria.isExpanded);
 
   setToggleAllState(toggleAllBtn, allOpen);
 }

--- a/src/components/banner_advanced/js/global.js
+++ b/src/components/banner_advanced/js/global.js
@@ -1,4 +1,4 @@
-import { loadMaterialIconSheet } from "../../../helpers/global-helpers.js";
+import * as icons from "../../../utils/icons.js";
 
 /**
  * @module bannerAdvanced
@@ -10,6 +10,6 @@ export default function initBannerAdvanced(document = document) {
   );
 
   if (shouldCallMaterialIconLoader.length > 0) {
-    loadMaterialIconSheet();
+    icons.loadMaterialIconSheet();
   }
 }

--- a/src/components/breadcrumbs/js/global.js
+++ b/src/components/breadcrumbs/js/global.js
@@ -1,8 +1,5 @@
-import {
-  validateInternalSvgPath,
-  buildIconPath,
-  setExpanded,
-} from "../../../helpers/global-helpers.js";
+import * as aria from "../../../utils/aria.js";
+import * as icons from "../../../utils/icons.js";
 import { initOverflowMenu } from "../../overflow_menu/js/global.js";
 
 /**
@@ -105,7 +102,7 @@ function createOverFlow(svgPath) {
     "qld__btn qld__btn--toggle qld__overflow_menu__btn qld__accordion--closed";
   button.setAttribute("href", "#");
   button.setAttribute("aria-controls", "overflow-menu--");
-  setExpanded(button, false);
+  aria.setExpanded(button, false);
 
   if (svgPath) {
     // Create <svg>
@@ -117,12 +114,12 @@ function createOverFlow(svgPath) {
     // Create <use>
     const use = document.createElementNS("http://www.w3.org/2000/svg", "use");
     // Validate and normalise the SVG path before using it
-    const safeSvgPath = validateInternalSvgPath(svgPath);
+    const safeSvgPath = icons.validateInternalSvgPath(svgPath);
     if (safeSvgPath) {
       use.setAttributeNS(
         null,
         "href",
-        buildIconPath(safeSvgPath, "more-horizontal"),
+        icons.buildIconPath(safeSvgPath, "more-horizontal"),
       );
     }
 

--- a/src/components/card_no_action/js/global.js
+++ b/src/components/card_no_action/js/global.js
@@ -1,4 +1,4 @@
-import { loadMaterialIconSheet } from "../../../helpers/global-helpers.js";
+import * as icons from "../../../utils/icons.js";
 
 /**
  * @module cards
@@ -10,6 +10,6 @@ export default function initCards(document = document) {
   );
 
   if (shouldCallMaterialIconLoader.length > 0) {
-    loadMaterialIconSheet();
+    icons.loadMaterialIconSheet();
   }
 }

--- a/src/components/code/js/global.js
+++ b/src/components/code/js/global.js
@@ -2,10 +2,7 @@
  * @module code
  */
 
-import {
-  validateInternalSvgPath,
-  buildIconPath,
-} from "../../../helpers/global-helpers.js";
+import * as icons from "../../../utils/icons.js";
 import * as animate from "../../../utils/animate.js";
 
 /**
@@ -109,12 +106,12 @@ export default function initCode(root = document) {
       // Create <use>
       const use = document.createElementNS("http://www.w3.org/2000/svg", "use");
       // Validate and normalise the SVG path before using it
-      const safeSvgPath = validateInternalSvgPath(svgPath);
+      const safeSvgPath = icons.validateInternalSvgPath(svgPath);
       if (safeSvgPath) {
         use.setAttributeNS(
           null,
           "href",
-          buildIconPath(safeSvgPath, "chevron-up"),
+          icons.buildIconPath(safeSvgPath, "chevron-up"),
         );
       }
 

--- a/src/components/header/js/global.js
+++ b/src/components/header/js/global.js
@@ -2,7 +2,7 @@
  * @module header
  */
 
-import { setExpanded } from "../../../helpers/global-helpers.js";
+import * as aria from "../../../utils/aria.js";
 
 // Search toggle button
 const searchToggle = document.querySelector(".qld__main-nav__toggle-search");
@@ -105,7 +105,7 @@ function toggleHeaderSearch() {
 
 function openHeader(requireFocusChange = true) {
   isHeaderOpen = true;
-  setExpanded(searchToggle, true);
+  aria.setExpanded(searchToggle, true);
   searchToggle.classList.remove("qld__main-nav__toggle-search--open");
   searchToggle.classList.add("qld__main-nav__toggle-search--close");
   searchToggleText.textContent = "Close";
@@ -150,7 +150,7 @@ function openHeader(requireFocusChange = true) {
 
 function closeHeader(requireFocusChange = true) {
   isHeaderOpen = false;
-  setExpanded(searchToggle, false);
+  aria.setExpanded(searchToggle, false);
   searchToggle.classList.remove("qld__main-nav__toggle-search--close");
   searchToggle.classList.add("qld__main-nav__toggle-search--open");
   searchToggleText.textContent = "Search";

--- a/src/components/in_page_navigation/js/global.js
+++ b/src/components/in_page_navigation/js/global.js
@@ -1,4 +1,4 @@
-import { normaliseIdentifier } from "../../../helpers/global-helpers.js";
+import * as string from "../../../utils/string.js";
 
 /**
  * @module inPageNavigation
@@ -52,7 +52,8 @@ export default function initInPageNavigation(root = document) {
       const title = heading.innerText;
       // Create sanitized ID from heading text
       const id =
-        existingId || `section__${normaliseIdentifier(title.toLowerCase())}`;
+        existingId ||
+        `section__${string.normaliseIdentifier(title.toLowerCase())}`;
       heading.setAttribute("id", id);
       heading.setAttribute("tabindex", -1);
     });

--- a/src/components/internal_navigation/js/global.js
+++ b/src/components/internal_navigation/js/global.js
@@ -1,7 +1,4 @@
-import {
-  validateInternalSvgPath,
-  buildIconPath,
-} from "../../../helpers/global-helpers.js";
+import * as icons from "../../../utils/icons.js";
 
 /**
  * @module internalNavigation
@@ -32,9 +29,13 @@ export default function initInternalNavigation(root = document) {
           "use",
         );
         // Validate and normalise the SVG path before using it
-        const safeSvgPath = validateInternalSvgPath(svgPath);
+        const safeSvgPath = icons.validateInternalSvgPath(svgPath);
         if (safeSvgPath) {
-          use.setAttributeNS(null, "href", buildIconPath(safeSvgPath, "tick"));
+          use.setAttributeNS(
+            null,
+            "href",
+            icons.buildIconPath(safeSvgPath, "tick"),
+          );
         }
 
         // Append <use> to <svg>

--- a/src/components/main_navigation/js/global.js
+++ b/src/components/main_navigation/js/global.js
@@ -3,7 +3,7 @@
  *
  * @module mobileNav
  */
-import { setExpanded } from "../../../helpers/global-helpers.js";
+import * as aria from "../../../utils/aria.js";
 import * as animate from "../../../utils/animate.js";
 import utils from "../../_global/js/global.js";
 
@@ -250,8 +250,8 @@ mobileNav.Toggle = function (element, speed, callbacks) {
           if (menuHeading) {
             menuHeading.focus();
           }
-          if (openButton) setExpanded(openButton, true);
-          if (closeButton) setExpanded(closeButton, true);
+          if (openButton) aria.setExpanded(openButton, true);
+          if (closeButton) aria.setExpanded(closeButton, true);
 
           if (focustrapTop) focustrapTop.setAttribute("tabindex", 0);
           if (focustrapBottom) focustrapBottom.setAttribute("tabindex", 0);
@@ -314,8 +314,8 @@ mobileNav.Toggle = function (element, speed, callbacks) {
         } else {
           // Move the focus back to the menu button
           if (closeButton) closeButton.focus();
-          if (openButton) setExpanded(openButton, false);
-          if (closeButton) setExpanded(closeButton, false);
+          if (openButton) aria.setExpanded(openButton, false);
+          if (closeButton) aria.setExpanded(closeButton, false);
 
           if (focustrapTop) focustrapTop.removeAttribute("tabindex");
           if (focustrapBottom) focustrapBottom.removeAttribute("tabindex");

--- a/src/components/mega_main_navigation/js/global.js
+++ b/src/components/mega_main_navigation/js/global.js
@@ -10,7 +10,7 @@
  */
 
 import * as collapsible from "../../_global/js/collapsible.js";
-import { isExpanded } from "../../../helpers/global-helpers.js";
+import * as aria from "../../../utils/aria.js";
 
 /** Selector matching all interactive elements that can receive focus. */
 const FOCUSABLE_SELECTOR =
@@ -171,7 +171,7 @@ function handleFocusOut(item) {
 }
 
 function isSubMenuOpen(toggleBtnEl) {
-  return isExpanded(toggleBtnEl);
+  return aria.isExpanded(toggleBtnEl);
 }
 
 function syncNavItemLinkClass(linkEl, isOpen) {

--- a/src/components/overflow_menu/js/global.js
+++ b/src/components/overflow_menu/js/global.js
@@ -9,7 +9,7 @@
  */
 
 import * as collapsible from "../../_global/js/collapsible.js";
-import { isExpanded } from "../../../helpers/global-helpers.js";
+import * as aria from "../../../utils/aria.js";
 
 /**
  * Wire up every overflow menu toggle button found under `root`.
@@ -40,7 +40,7 @@ function toggleOverflowMenu(button, root = document) {
   );
   if (!panel) return;
 
-  if (isExpanded(button)) {
+  if (aria.isExpanded(button)) {
     collapsible.close(button, undefined, root);
     teardownOutsideClick(panel);
   } else {
@@ -70,7 +70,7 @@ function setupOutsideClick(button, panel, root = document) {
       if (button.contains(event.target) || panel.contains(event.target)) return;
       controller.abort();
       panel.__qldOutsideClickController = null;
-      if (isExpanded(button)) {
+      if (aria.isExpanded(button)) {
         collapsible.close(button, undefined, root);
       }
     },

--- a/src/index.js
+++ b/src/index.js
@@ -1,7 +1,6 @@
 // JS
 import utils from "./components/_global/js/global.js";
 import initComponents from "./component-loader.js";
-import "../src/helpers/global-helpers.js";
 import "prismjs";
 
 // Swap the `no-js` html class for `js` as early as possible.

--- a/src/utils/aria.js
+++ b/src/utils/aria.js
@@ -1,0 +1,24 @@
+/**
+ * @module utils/aria
+ *
+ * Small readers/writers for ARIA state, so components express intent
+ * ("is this expanded?") rather than repeating attribute string comparisons.
+ */
+
+/**
+ * Whether an element's `aria-expanded` attribute is currently "true".
+ *
+ * @param  {HTMLElement} element
+ * @return {boolean}
+ */
+export const isExpanded = (element) =>
+  element.getAttribute("aria-expanded") === "true";
+
+/**
+ * Set an element's `aria-expanded` attribute from a boolean.
+ *
+ * @param {HTMLElement} element
+ * @param {boolean}     expanded
+ */
+export const setExpanded = (element, expanded) =>
+  element.setAttribute("aria-expanded", expanded ? "true" : "false");

--- a/src/utils/icons.js
+++ b/src/utils/icons.js
@@ -1,11 +1,22 @@
-// Validate that an SVG path has the correct extension and is same-origin, and
-// return a normalised, safe absolute URL for use as a <use href> value (or
-// null if the path is invalid). Returning the URL built by the browser's own
-// URL parser — rather than the raw DOM-derived string — ensures the value
-// reaching the sink has passed through a recognised sanitisation barrier.
-//
-// Accepts either a Squiz Matrix asset URL (?a=12345:path/to/icons.svg) or a
-// plain path to an .svg file (e.g. "QLD-icons.svg" in Storybook builds).
+/**
+ * @module utils/icons
+ *
+ * Helpers for resolving and rendering SVG sprite icons.
+ */
+
+/**
+ * Validate that an SVG path has the correct extension and is same-origin, and
+ * return a normalised, safe absolute URL for use as a `<use href>` value (or
+ * null if the path is invalid). Returning the URL built by the browser's own
+ * URL parser — rather than the raw DOM-derived string — ensures the value
+ * reaching the sink has passed through a recognised sanitisation barrier.
+ *
+ * Accepts either a Squiz Matrix asset URL (?a=12345:path/to/icons.svg) or a
+ * plain path to an .svg file (e.g. "QLD-icons.svg" in Storybook builds).
+ *
+ * @param  {string} path
+ * @return {string | null}
+ */
 export const validateInternalSvgPath = (path) => {
   // Check given path is a string
   if (typeof path !== "string") {
@@ -56,17 +67,23 @@ export const validateInternalSvgPath = (path) => {
   return url.href;
 };
 
-// Build a sprite reference like "QLD-icons.svg#tick". Relative paths are left
-// relative so the browser resolves them against the current document, which
-// keeps icons working when the site is deployed under a sub-path.
+/**
+ * Build a sprite reference like "QLD-icons.svg#tick". Relative paths are left
+ * relative so the browser resolves them against the current document, which
+ * keeps icons working when the site is deployed under a sub-path.
+ *
+ * @param  {string} path - Path to the sprite sheet
+ * @param  {string} icon - Name of the icon within the sprite sheet
+ * @return {string}
+ */
 export const buildIconPath = (path, icon) => (icon ? `${path}#${icon}` : path);
 
-// Remove all special characters
-export const normaliseIdentifier = (string) => {
-  return string.replace(/[^a-z0-9]+/g, "");
-};
-
-// Used to create link to material symbols stylesheet. Only use on components that require full access to material icons, not just from our sprite sheets
+/**
+ * Link the Material Symbols stylesheet into the document head, once.
+ *
+ * Only use on components that require full access to material icons, not just
+ * the icons in our own sprite sheets.
+ */
 export const loadMaterialIconSheet = () => {
   const materialStylesheetId = "material-stylesheet";
   if (document.getElementById(materialStylesheetId)) return;
@@ -78,11 +95,3 @@ export const loadMaterialIconSheet = () => {
     "https://fonts.googleapis.com/css2?family=Material+Symbols+Rounded:opsz,wght,FILL,GRAD@40,300,0..1,0";
   document.head.appendChild(link);
 };
-
-// Whether an element's aria-expanded attribute is currently "true"
-export const isExpanded = (element) =>
-  element.getAttribute("aria-expanded") === "true";
-
-// Set an element's aria-expanded attribute from a boolean
-export const setExpanded = (element, expanded) =>
-  element.setAttribute("aria-expanded", expanded ? "true" : "false");

--- a/src/utils/icons.test.js
+++ b/src/utils/icons.test.js
@@ -8,7 +8,7 @@ import {
   vi,
 } from "vitest";
 
-import { validateInternalSvgPath, buildIconPath } from "./global-helpers.js";
+import { validateInternalSvgPath, buildIconPath } from "./icons.js";
 
 const ORIGIN = "https://www.health.qld.gov.au";
 const HREF = `${ORIGIN}/some/page`;

--- a/src/utils/string.js
+++ b/src/utils/string.js
@@ -1,0 +1,13 @@
+/**
+ * @module utils/string
+ */
+
+/**
+ * Strip everything that is not a lowercase letter or digit, producing a value
+ * safe to use as part of a DOM id.
+ *
+ * @param  {string} string
+ * @return {string}
+ */
+export const normaliseIdentifier = (string) =>
+  string.replace(/[^a-z0-9]+/g, "");

--- a/vitest.config.js
+++ b/vitest.config.js
@@ -15,10 +15,19 @@ export default defineConfig({
   test: {
     projects: [
       {
+        // Pure-logic tests, anywhere under src/ — helpers, utils, and a
+        // component's non-DOM logic. Matched by filename, so a new test file
+        // needs no change here.
+        //
+        // This project runs in Node: there is no `window` or `document`. Tests
+        // that need a real DOM belong in the `storybook` project below, as a
+        // story `play` function — that runs in a real browser, with the
+        // component's CSS applied, which is what its behaviour actually depends
+        // on.
         test: {
           name: "unit",
           environment: "node",
-          include: ["src/helpers/**/*.test.js"],
+          include: ["src/**/*.test.js"],
         },
       },
       {


### PR DESCRIPTION
`global-helpers.js` had become a catch-all: SVG sprite resolution, an ARIA state reader/writer pair, and a string sanitiser, related only by having nowhere else to live. Each now has a module named for what it does:

- `src/utils/icons.js`   — validateInternalSvgPath, buildIconPath,
                           loadMaterialIconSheet
- `src/utils/aria.js`    — isExpanded, setExpanded
- `src/utils/string.js`  — normaliseIdentifier

Consumers import the namespace (`import * as icons`) rather than named members, so a call site says which module a helper came from.

The behaviour is unchanged; the function bodies are moved verbatim and the existing test moves with them to `src/utils/icons.test.js`. The vitest `unit` project now matches `src/**/*.test.js` instead of an allowlist under `src/helpers`, so a new pure-logic test needs no config change.

`src/index.js` no longer imports `global-helpers.js` for side effects — it never had any; every consumer imports what it needs.