### PR TITLE
QHDEV-734 - Move the animation engine to src/utils/animate.js

### DIFF
--- a/src/components/_global/js/collapsible.js
+++ b/src/components/_global/js/collapsible.js
@@ -12,7 +12,7 @@
  * arrow keys, etc.) belong to the consuming component, not here.
  */
 
-import * as animate from "./animate/global.js";
+import * as animate from "../../../utils/animate.js";
 import { isExpanded, setExpanded } from "../../../helpers/global-helpers.js";
 
 /**

--- a/src/components/_global/js/legacyGlobal.js
+++ b/src/components/_global/js/legacyGlobal.js
@@ -18,7 +18,7 @@
 // exports; the object is then spelled out member-by-member below so the legacy
 // contract stays explicit and a removed source export surfaces here.
 import utils from "./global.js";
-import * as animate from "./animate/global.js";
+import * as animate from "../../../utils/animate.js";
 import { tabs } from "./tabs/global.js";
 import { Modal } from "./modal/global.js";
 import { toggleToolTips } from "./popover/controller.js";

--- a/src/components/code/js/global.js
+++ b/src/components/code/js/global.js
@@ -6,7 +6,7 @@ import {
   validateInternalSvgPath,
   buildIconPath,
 } from "../../../helpers/global-helpers.js";
-import * as animate from "../../_global/js/animate/global.js";
+import * as animate from "../../../utils/animate.js";
 
 /**
  * Initialise the code component: syntax-highlight snippets, wire the copy

--- a/src/components/main_navigation/js/global.js
+++ b/src/components/main_navigation/js/global.js
@@ -4,7 +4,7 @@
  * @module mobileNav
  */
 import { setExpanded } from "../../../helpers/global-helpers.js";
-import * as animate from "../../_global/js/animate/global.js";
+import * as animate from "../../../utils/animate.js";
 import utils from "../../_global/js/global.js";
 
 var mobileNav = {};

--- a/src/utils/animate.js
+++ b/src/utils/animate.js
@@ -1,5 +1,13 @@
 /**
- * @module animate
+ * @module utils/animate
+ *
+ * A JS animation engine: steps a single CSS property on one or more elements
+ * from its current value to a target value (including resolving `auto`), and
+ * tracks the in-flight animation on the element itself via `QLDanimation`.
+ *
+ * The PascalCase export names are the legacy `QLD.animate.*` contract for
+ * external (non-bundled) callers — see `legacyGlobal.js` — so they are kept as
+ * they are rather than renamed to match the rest of `src/utils`.
  */
 
 /**


### PR DESCRIPTION
`animate` is a generic engine — it steps a CSS property from its current value to a target on any element and knows nothing about our markup, our class names or any component. Living under `src/components/_global/js/` implied it was a component, and gave it a two-segment path (`animate/global.js`) for a single module.

It is now `src/utils/animate.js`, alongside the other helpers with no component knowledge.

The module body is unchanged, including the PascalCase export names: those are the `QLD.animate.*` legacy contract for external callers, so the docblock now records why they do not match the rest of `src/utils`.