### PR TITLE
QHDEV-734 - Move the window.QLD.* namespace to src/legacy/qld-namespa…

### DIFF
--- a/src/behaviours/popover/controller.js
+++ b/src/behaviours/popover/controller.js
@@ -154,8 +154,7 @@ export function createPopoverController({ componentName, marginFromTrigger }) {
 
 // Back-compat surface: the old shared helper was exposed as
 // window.QLD.toggleToolTips. Exported here and registered in
-// src/components/_global/js/legacyGlobal.js for any external (non-bundled)
-// callers.
+// src/legacy/qld-namespace.js for any external (non-bundled) callers.
 export const toggleToolTips = {
   openToggleToolTip: show,
   closeToggleToolTip: hide,

--- a/src/component-loader.js
+++ b/src/component-loader.js
@@ -1,6 +1,6 @@
 // Legacy global namespace (registers all window.QLD.* and self-inits standalone
 // components) — must load before any init runs
-import "./components/_global/js/legacyGlobal.js";
+import "./legacy/qld-namespace.js";
 
 // Standard components
 import initAZListing from "./components/a-z_listing/js/global.js";

--- a/src/legacy/qld-namespace.js
+++ b/src/legacy/qld-namespace.js
@@ -1,5 +1,5 @@
 /**
- * @module _global/legacyGlobal
+ * @module legacy/qld-namespace
  *
  * Single home for the legacy `window.QLD.*` global namespace.
  *
@@ -13,8 +13,9 @@
  * side-effect-free and independently testable.
  *
  * Nothing inside `src/` should import from this file. New code imports the
- * underlying modules (`src/utils/*`, the component modules) directly. This file
- * exists solely to keep external callers working, and shrinks as they migrate.
+ * underlying modules (`src/utils/*`, `src/behaviours/*`, the component modules)
+ * directly. This file exists solely to keep external callers working, and
+ * shrinks as they migrate.
  *
  * This module must be imported early (see `component-loader.js`) so the globals
  * exist before any component init runs. Component initialisation itself lives in
@@ -24,29 +25,29 @@
 // `import * as` for the modules whose legacy aggregate is a slice of their named
 // exports; the object is then spelled out member-by-member below so the legacy
 // contract stays explicit and a removed source export surfaces here.
-import * as animate from "../../../utils/animate.js";
-import { tabs } from "./tabs/global.js";
-import { Modal } from "../../modal/js/global.js";
-import { toggleToolTips } from "../../../behaviours/popover/controller.js";
+import * as animate from "../utils/animate.js";
+import { tabs } from "../components/_global/js/tabs/global.js";
+import { Modal } from "../components/modal/js/global.js";
+import { toggleToolTips } from "../behaviours/popover/controller.js";
 
 // Utils
-import * as cookies from "../../../utils/cookies.js";
-import * as dom from "../../../utils/dom.js";
-import * as geolocation from "../../../utils/geolocation.js";
-import * as icons from "../../../utils/icons.js";
-import * as loading from "../../../utils/loading.js";
-import * as storage from "../../../utils/storage.js";
-import * as timing from "../../../utils/timing.js";
-import * as url from "../../../utils/url.js";
+import * as cookies from "../utils/cookies.js";
+import * as dom from "../utils/dom.js";
+import * as geolocation from "../utils/geolocation.js";
+import * as icons from "../utils/icons.js";
+import * as loading from "../utils/loading.js";
+import * as storage from "../utils/storage.js";
+import * as timing from "../utils/timing.js";
+import * as url from "../utils/url.js";
 
 // Feature components
-import * as accordion from "../../accordion/js/global.js";
-import { fileUploads } from "../../file_upload/js/global.js";
-import initCode from "../../code/js/global.js";
-import initBasicSearch from "../../basic_search/js/global.js";
-import initTab from "../../tab/js/global.js";
-import initToolTip from "../../tool_tip/js/global.js";
-import initToggleTip from "../../toggle_tip/js/global.js";
+import * as accordion from "../components/accordion/js/global.js";
+import { fileUploads } from "../components/file_upload/js/global.js";
+import initCode from "../components/code/js/global.js";
+import initBasicSearch from "../components/basic_search/js/global.js";
+import initTab from "../components/tab/js/global.js";
+import initToolTip from "../components/tool_tip/js/global.js";
+import initToggleTip from "../components/toggle_tip/js/global.js";
 
 /**
  * `QLD.utils` — the legacy grab-bag of helpers. Its members now live in

--- a/src/utils/animate.js
+++ b/src/utils/animate.js
@@ -6,8 +6,8 @@
  * tracks the in-flight animation on the element itself via `QLDanimation`.
  *
  * The PascalCase export names are the legacy `QLD.animate.*` contract for
- * external (non-bundled) callers — see `legacyGlobal.js` — so they are kept as
- * they are rather than renamed to match the rest of `src/utils`.
+ * external (non-bundled) callers — see `src/legacy/qld-namespace.js` — so they
+ * are kept as they are rather than renamed to match the rest of `src/utils`.
  */
 
 /**


### PR DESCRIPTION
…ce.js

The legacy global namespace is not part of any component, but it lived
at `src/components/_global/js/legacyGlobal.js` — under the very
directory the earlier commits have been emptying out. It is now
`src/legacy/qld-namespace.js`, a directory whose name states what the
file is for and which is expected to shrink to nothing.

The file is already an adapter rather than a source of truth: every
object it registers is assembled from modules that know nothing about
`window.QLD`. The docblock now says so, and states the rule that keeps
it that way — nothing inside `src/` imports from this file; new code
imports the underlying `src/utils/*`, `src/behaviours/*` or component
module directly.

Import paths only; no change to what the namespace exposes.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>