### PR TITLE
QHDEV-779 | Buttons, Single action card | Update trailing icon hover colour, set single action card max-width

### DIFF
--- a/src/components/_global/css/btn/component.scss
+++ b/src/components/_global/css/btn/component.scss
@@ -54,6 +54,11 @@
       text-decoration-color: var(--QLD-color-light__link--on-action);
       text-underline-offset: var(--QLD-underline__offset);
       text-decoration-thickness: var(--QLD-underline__thickness-thick);
+
+      .qld__icon {
+        color: var(--QLD-color-light__link--on-action);
+        fill: var(--QLD-color-light__link--on-action);
+      }
     }
 
     &:focus:active {
@@ -128,6 +133,8 @@
 
         .qld__icon {
           text-decoration: none !important;
+          color: var(--QLD-color-dark__link--on-action);
+          fill: var(--QLD-color-dark__link--on-action);
         }
       }
 

--- a/src/components/_global/css/btn/component.scss
+++ b/src/components/_global/css/btn/component.scss
@@ -42,6 +42,7 @@
 
     .qld__icon {
       color: var(--QLD-color-light__link--on-action);
+      fill: var(--QLD-color-light__link--on-action);
     }
 
     &:hover {
@@ -64,6 +65,7 @@
 
       .qld__icon {
         color: var(--QLD-color-light__heading);
+        fill: var(--QLD-color-light__heading);
       }
     }
 
@@ -86,6 +88,7 @@
 
       .qld__icon {
         color: var(--QLD-color-light__text--lighter);
+        fill: var(--QLD-color-light__text--lighter);
       }
     }
   }
@@ -111,6 +114,7 @@
 
       .qld__icon {
         color: var(--QLD-color-dark__link--on-action);
+        fill: var(--QLD-color-dark__link--on-action);
       }
 
       &:hover {
@@ -133,6 +137,7 @@
         @include QLD-focus(dark);
         .qld__icon {
           color: var(--QLD-color-dark__link--on-action);
+          fill: var(--QLD-color-dark__link--on-action);
         }
       }
 
@@ -144,6 +149,7 @@
 
         .qld__icon {
           color: var(--QLD-color-light__heading);
+          fill: var(--QLD-color-light__heading);
         }
       }
 
@@ -163,6 +169,7 @@
 
         .qld__icon {
           color: var(--QLD-color-dark__text--lighter);
+          fill: var(--QLD-color-dark__text--lighter);
         }
       }
     }

--- a/src/components/card_single_action/css/component.scss
+++ b/src/components/card_single_action/css/component.scss
@@ -3,6 +3,7 @@
 //--------------------------------------------------------------------------------------------------------------------------------------------------------------
 
 .qld__card.qld__card__action {
+  max-width: 47rem;
   @include QLD-box-shadow(2);
 
   // If any element inside the card receives focus, add a focus ring around the wrapper card div

--- a/src/stories/Iconography/Iconography.stories.js
+++ b/src/stories/Iconography/Iconography.stories.js
@@ -5,7 +5,7 @@ import iconsSvg from "../../assets/img/QLD-icons.svg?raw";
 
 const componentIntroduction = `<p>All icons are implemented as SVGs and provided through a sprite sheet. Icons used to build components are also available in the Figma UI Kit. We use SVG icons instead of an icon font to improve performance, scalability, maintainability and accessibility.</p>
 <p>You can view all icons included in our icon library below.</p>
-<p>If you require additional icons, you can find them at https://fonts.google.com/icons. The following URL defines the specifications for our Material Symbols: https://fonts.googleapis.com/css2?family=Material+Symbols+Rounded:opsz,wght,FILL,GRAD@40,300,0..1,0.
+<p>If you require additional icons, you can find them at <a href="https://fonts.google.com/icons" target="_blank">Material Symbols</a>. The following URL defines the specifications for our Material Symbols: https://fonts.googleapis.com/css2?family=Material+Symbols+Rounded:opsz,wght,FILL,GRAD@40,300,0..1,0.
 You can add Material Symbols manually by including the following &lt;link&gt; tag in the &lt;head&gt; of your page:</p>
 <strong>&lt;link id="material-stylesheet" rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Material+Symbols+Rounded:opsz,wght,FILL,GRAD@40,300,0..1,0" &gt;</strong> 
 <p>Then add the icon to your template using:</p><strong>&lt;span class="material-symbols-rounded" aria-hidden="true"&gt;ICON_NAME&lt;/span&gt;</strong>`;

--- a/src/stories/Iconography/Iconography.stories.js
+++ b/src/stories/Iconography/Iconography.stories.js
@@ -3,7 +3,7 @@ import { Iconography } from "./Iconography";
 import { themeWrapper } from "../../../.storybook/helper-functions.js";
 import iconsSvg from "../../assets/img/QLD-icons.svg?raw";
 
-const componentIntroduction = `<p>All icons are implemented as SVGs and provided through a sprite sheet. Icons used to build components are also available in the Figma UI Kit. We use SVG icons instead of an icon font to improve performance, scalability, maintainability and accessibility.</p>
+const componentIntroduction = `<p>All icons are implemented as SVGs and provided through a sprite sheet. Icons used to build components are also available in the <a href="https://www.figma.com/design/qKsxl3ogIlBp7dafgxXuCA/QGDS-UI-Kit?node-id=6902-69802&p=f&t=4sdNArLVXAEw3eI4-0" target="_blank">Figma UI Kit</a>. We use SVG icons instead of an icon font to improve performance, scalability, maintainability and accessibility.</p>
 <p>You can view all icons included in our icon library below.</p>
 <p>If you require additional icons, you can find them at <a href="https://fonts.google.com/icons" target="_blank">Material Symbols</a>. The following URL defines the specifications for our Material Symbols: https://fonts.googleapis.com/css2?family=Material+Symbols+Rounded:opsz,wght,FILL,GRAD@40,300,0..1,0.
 You can add Material Symbols manually by including the following &lt;link&gt; tag in the &lt;head&gt; of your page:</p>

--- a/src/stories/Iconography/Iconography.stories.js
+++ b/src/stories/Iconography/Iconography.stories.js
@@ -7,8 +7,8 @@ const componentIntroduction = `<p>All icons are implemented as SVGs and provided
 <p>You can view all icons included in our icon library below.</p>
 <p>If you require additional icons, you can find them at <a href="https://fonts.google.com/icons" target="_blank">Material Symbols</a>. The following URL defines the specifications for our Material Symbols: https://fonts.googleapis.com/css2?family=Material+Symbols+Rounded:opsz,wght,FILL,GRAD@40,300,0..1,0.
 You can add Material Symbols manually by including the following &lt;link&gt; tag in the &lt;head&gt; of your page:</p>
-<strong>&lt;link id="material-stylesheet" rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Material+Symbols+Rounded:opsz,wght,FILL,GRAD@40,300,0..1,0" &gt;</strong> 
-<p>Then add the icon to your template using:</p><strong>&lt;span class="material-symbols-rounded" aria-hidden="true"&gt;ICON_NAME&lt;/span&gt;</strong>`;
+&lt;link id="material-stylesheet" rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Material+Symbols+Rounded:opsz,wght,FILL,GRAD@40,300,0..1,0" &gt;
+<p>Then add the icon to your template using:</p>&lt;span class="material-symbols-rounded" aria-hidden="true"&gt;ICON_NAME&lt;/span&gt;`;
 
 // The sprite is inlined at build time (?raw); we parse it with DOMParser to list
 // every <symbol> id for the allIcons gallery. Lives here as it's the only consumer.

--- a/src/stories/Iconography/Iconography.stories.js
+++ b/src/stories/Iconography/Iconography.stories.js
@@ -3,7 +3,9 @@ import { Iconography } from "./Iconography";
 import { themeWrapper } from "../../../.storybook/helper-functions.js";
 import iconsSvg from "../../assets/img/QLD-icons.svg?raw";
 
-const componentIntroduction = `<p>We use Material Symbols for iconography. The following URL defines the specifications for our Material Symbols: https://fonts.googleapis.com/css2?family=Material+Symbols+Rounded:opsz,wght,FILL,GRAD@40,300,0..1,0.
+const componentIntroduction = `<p>All icons are implemented as SVGs and provided through a sprite sheet. Icons used to build components are also available in the Figma UI Kit. We use SVG icons instead of an icon font to improve performance, scalability, maintainability and accessibility.</p>
+<p>You can view all icons included in our icon library below.</p>
+<p>If you require additional icons, you can find them at https://fonts.google.com/icons. The following URL defines the specifications for our Material Symbols: https://fonts.googleapis.com/css2?family=Material+Symbols+Rounded:opsz,wght,FILL,GRAD@40,300,0..1,0.
 You can add Material Symbols manually by including the following &lt;link&gt; tag in the &lt;head&gt; of your page:</p>
 <strong>&lt;link id="material-stylesheet" rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Material+Symbols+Rounded:opsz,wght,FILL,GRAD@40,300,0..1,0" &gt;</strong> 
 <p>Then add the icon to your template using:</p><strong>&lt;span class="material-symbols-rounded" aria-hidden="true"&gt;ICON_NAME&lt;/span&gt;</strong>`;

--- a/src/stories/Iconography/Iconography.stories.js
+++ b/src/stories/Iconography/Iconography.stories.js
@@ -3,11 +3,10 @@ import { Iconography } from "./Iconography";
 import { themeWrapper } from "../../../.storybook/helper-functions.js";
 import iconsSvg from "../../assets/img/QLD-icons.svg?raw";
 
-const componentIntroduction = `Iconography is in the process of being transitioned from using Font Awesome icons, to using Material Symbols.
-Currently, the following URL is being utilised to define the specifications of these new icons: https://fonts.googleapis.com/css2?family=Material+Symbols+Rounded:opsz,wght,FILL,GRAD@40,300,0..1,0.
-This can be done manually replicated by adding a link tag within &lt;head&gt;,
-<strong>&lt;link id="material-stylesheet" rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Material+Symbols+Rounded:opsz,wght,FILL,GRAD@40,300,0..1,0" &gt;</strong> and 
-then adding the component to your template via <strong>&lt;span class="material-symbols-rounded" aria-hidden="true"&gt;ICON_NAME&lt;/span&gt;</strong>`;
+const componentIntroduction = `<p>We use Material Symbols for iconography. The following URL defines the specifications for our Material Symbols: https://fonts.googleapis.com/css2?family=Material+Symbols+Rounded:opsz,wght,FILL,GRAD@40,300,0..1,0.
+You can add Material Symbols manually by including the following &lt;link&gt; tag in the &lt;head&gt; of your page:</p>
+<strong>&lt;link id="material-stylesheet" rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Material+Symbols+Rounded:opsz,wght,FILL,GRAD@40,300,0..1,0" &gt;</strong> 
+<p>Then add the icon to your template using:</p><strong>&lt;span class="material-symbols-rounded" aria-hidden="true"&gt;ICON_NAME&lt;/span&gt;</strong>`;
 
 // The sprite is inlined at build time (?raw); we parse it with DOMParser to list
 // every <symbol> id for the allIcons gallery. Lives here as it's the only consumer.


### PR DESCRIPTION
This pull request makes several improvements to icon styling and documentation. The main focus is on ensuring consistent coloring and fill for SVG icons used in buttons, as well as updating documentation to clarify how icons are implemented and can be used. There is also a minor layout adjustment to the single action card component.

**Icon Styling Consistency:**

* Updated `.qld__icon` styles in `component.scss` for buttons to set the `fill` property alongside `color`, ensuring SVG icons display with the correct color across all button states (default, hover, focus, active, light, and dark themes). 

**Documentation and Usage Instructions:**

* Revised the introduction in `Iconography.stories.js` to clarify that all icons are provided as SVGs via a sprite sheet, with links to the Figma UI Kit and instructions for using Material Symbols. This improves clarity for developers and designers on how to use and extend the icon library.

**Component Layout:**

* Added a `max-width` property to `.qld__card.qld__card__action` in the single action card component for better layout control.